### PR TITLE
更换基础镜像，支持高阶配置 Switched to a new base image with support for advanced configuration.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,8 @@ RUN npm install
 COPY . .
 RUN npm run build
 
-FROM nginxinc/nginx-unprivileged:stable-alpine
-COPY --from=builder /app/dist /usr/share/nginx/html
+#FROM nginxinc/nginx-unprivileged:stable-alpine
+#COPY --from=builder /app/dist /usr/share/nginx/html
+
+FROM joseluisq/static-web-server:latest
+COPY --from=builder /app/dist /public

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,20 @@
+nanme: document
 services:
   document:
     image: ghcr.io/ranui/document:latest
     container_name: document
     ports:
-      - 8080:8080
+      - 8080:80
+    # 进阶配置
+    # volumes:
+    #   # 证书
+    #   - 证书路径:/ssl
+    # environment:
+    #   # 账号
+    #   # 格式用户名:密码，必须使用BCrypt密码哈希函数对密码进行编码。
+    #   # 获取BCrypt加密的结果，把加密结果中的$替换成$$转义。
+    #   SERVER_BASIC_AUTH: "用户名:BCrypt加密密码"
+    #   # 证书
+    #   SERVER_HTTP2_TLS: true
+    #   SERVER_HTTP2_TLS_CERT: 证书路径
+    #   SERVER_HTTP2_TLS_KEY: 私钥路径

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ This project provides foundational services for document preview components in t
 
 ```bash
 # docker run
-docker run -d --name document -p 8080:8080 ghcr.io/ranui/document:latest
+docker run -d --name document -p 8080:80 ghcr.io/ranui/document:latest
 
 # docker compose
 services:
@@ -74,7 +74,32 @@ services:
     image: ghcr.io/ranui/document:latest
     container_name: document
     ports:
-      - 8080:8080
+      - 8080:80
+```
+
+#### Advanced Configuration
+
+```yaml
+nanme: document
+services:
+  document:
+    image: ghcr.io/ranui/document:latest
+    container_name: document
+    ports:
+      - 8080:80
+    # Advanced Configuration
+    volumes:
+      # Add certificates
+      - certificate_path:/ssl
+    environment:
+      # Set account
+      # Format username:password, password must be encoded using BCrypt hash function.
+      # To get BCrypt encryption result, replace $ in the encrypted result with $$ for escaping.
+      SERVER_BASIC_AUTH: "username:BCrypt_encrypted_password"
+      # Use certificate
+      SERVER_HTTP2_TLS: true
+      SERVER_HTTP2_TLS_CERT: certificate_path
+      SERVER_HTTP2_TLS_KEY: private_key_path
 ```
 
 ### Important Notes

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -66,7 +66,7 @@
 
 ```bash
 # docker run
-docker run -d --name document -p 8080:8080 ghcr.io/ranui/document:latest
+docker run -d --name document -p 8080:80 ghcr.io/ranui/document:latest
 
 # docker compose
 services:
@@ -74,7 +74,32 @@ services:
     image: ghcr.io/ranui/document:latest
     container_name: document
     ports:
-      - 8080:8080
+      - 8080:80
+```
+
+#### 进阶配置
+
+```yaml
+nanme: document
+services:
+  document:
+    image: ghcr.io/ranui/document:latest
+    container_name: document
+    ports:
+      - 8080:80
+    # 进阶配置
+    volumes:
+      # 添加证书
+      - 证书路径:/ssl
+    environment:
+      # 设置账号
+      # 格式用户名:密码，必须使用BCrypt密码哈希函数对密码进行编码。
+      # 获取BCrypt加密的结果，把加密结果中的$替换成$$转义。
+      SERVER_BASIC_AUTH: "用户名:BCrypt加密密码"
+      # 使用证书
+      SERVER_HTTP2_TLS: true
+      SERVER_HTTP2_TLS_CERT: 证书路径
+      SERVER_HTTP2_TLS_KEY: 私钥路径
 ```
 
 ### 重要提示


### PR DESCRIPTION
容器基础镜像更换为 static-web-server
支持通过环境变量为应用设置账号密码和配置ssl证书
方便使用。
The container's base image has been changed to static-web-server.

Supports setting application username/password and SSL certificate via environment variables,

making it easy to use.

```yaml
nanme: document
services:
  document:
    image: ghcr.io/ranui/document:latest
    container_name: document
    ports:
      - 8080:80
    # 进阶配置
    volumes:
      # 添加证书
      - 证书路径:/ssl
    environment:
      # 设置账号
      # 格式用户名:密码，必须使用BCrypt密码哈希函数对密码进行编码。
      # 获取BCrypt加密的结果，把加密结果中的$替换成$$转义。
      SERVER_BASIC_AUTH: "用户名:BCrypt加密密码"
      # 使用证书
      SERVER_HTTP2_TLS: true
      SERVER_HTTP2_TLS_CERT: 证书路径
      SERVER_HTTP2_TLS_KEY: 私钥路径
```

```yaml
nanme: document
services:
  document:
    image: ghcr.io/ranui/document:latest
    container_name: document
    ports:
      - 8080:80
    # Advanced Configuration
    volumes:
      # Add certificates
      - certificate_path:/ssl
    environment:
      # Set account
      # Format username:password, password must be encoded using BCrypt hash function.
      # To get BCrypt encryption result, replace $ in the encrypted result with $$ for escaping.
      SERVER_BASIC_AUTH: "username:BCrypt_encrypted_password"
      # Use certificate
      SERVER_HTTP2_TLS: true
      SERVER_HTTP2_TLS_CERT: certificate_path
      SERVER_HTTP2_TLS_KEY: private_key_path
```

#51