### PR TITLE
chore: 线上地址引用改到 edit.chaxus.com

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 基于 OnlyOffice 的本地 Web 文档编辑器，所有处理在浏览器端完成，无需服务器，保护用户隐私。支持 docx、xlsx、pptx、csv 等格式。
 
-- **线上地址**：https://ranuts.github.io/document/
+- **线上地址**：https://edit.chaxus.com/ （旧址 https://ranuts.github.io/document/ 已跳转至此）
 - **GitHub**：https://github.com/ranuts/document
 - **技术栈**：TypeScript + Vite + Tailwind CSS + OnlyOffice Web Apps
 

--- a/docs/explorations/2026-07-05-migration-finishing-touches.md
+++ b/docs/explorations/2026-07-05-migration-finishing-touches.md
@@ -6,12 +6,12 @@
 
 ## 改动
 
-| 文件 | 改动 |
-|---|---|
+| 文件           | 改动                                                                   |
+| -------------- | ---------------------------------------------------------------------- |
 | `package.json` | `homepage` → `https://edit.chaxus.com/`(npm 页 / 工具链读取的规范主页) |
-| `readme.md` | Live Demo badge 链接 + "Try it online" → edit.chaxus.com |
-| `readme.zh.md` | 在线体验 badge + 链接 → edit.chaxus.com |
-| `CLAUDE.md` | 线上地址 → edit.chaxus.com(注明旧址已跳转至此) |
+| `readme.md`    | Live Demo badge 链接 + "Try it online" → edit.chaxus.com               |
+| `readme.zh.md` | 在线体验 badge + 链接 → edit.chaxus.com                                |
+| `CLAUDE.md`    | 线上地址 → edit.chaxus.com(注明旧址已跳转至此)                         |
 
 **故意保留旧 URL 的地方**:`redirect/{index,404}.html` 的注释——它们描述的正是"从 `ranuts.github.io/document` 搬走",改了反而语义错。
 

--- a/docs/explorations/2026-07-05-migration-finishing-touches.md
+++ b/docs/explorations/2026-07-05-migration-finishing-touches.md
@@ -1,0 +1,25 @@
+# edit.chaxus.com 迁移收尾:线上地址引用更新
+
+> 2026-07-05
+
+迁移主体(CF Pages 新站 + 旧站跳转器)上线后,把仓库里指向旧地址 `ranuts.github.io/document` 的对外引用统一改到 `edit.chaxus.com`。
+
+## 改动
+
+| 文件 | 改动 |
+|---|---|
+| `package.json` | `homepage` → `https://edit.chaxus.com/`(npm 页 / 工具链读取的规范主页) |
+| `readme.md` | Live Demo badge 链接 + "Try it online" → edit.chaxus.com |
+| `readme.zh.md` | 在线体验 badge + 链接 → edit.chaxus.com |
+| `CLAUDE.md` | 线上地址 → edit.chaxus.com(注明旧址已跳转至此) |
+
+**故意保留旧 URL 的地方**:`redirect/{index,404}.html` 的注释——它们描述的正是"从 `ranuts.github.io/document` 搬走",改了反而语义错。
+
+## 仓库设置(代码外)
+
+- GitHub repo **Website 字段** → `https://edit.chaxus.com/`(`gh repo edit`)
+- 删除远端分支 `release/v0.0.4`:v7 线已在 `main` 维护,该分支不再需要(CI 触发已全部统一到 main)
+
+## 仍待用户在外部后台做
+
+- **GSC 地址变更**:旧 property → edit.chaxus.com,加速 SEO 权重转移 + sitemap 提交

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "type": "git",
     "url": "https://github.com/ranuts/document.git"
   },
-  "homepage": "https://ranuts.github.io/document/",
+  "homepage": "https://edit.chaxus.com/",
   "bugs": {
     "url": "https://github.com/ranuts/document/issues"
   },

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/ranuts/document/releases">
     <img src="https://img.shields.io/github/v/release/ranuts/document" alt="Version">
   </a>
-  <a href="https://ranuts.github.io/document/">
+  <a href="https://edit.chaxus.com/">
     <img src="https://img.shields.io/badge/Live-Demo-brightgreen" alt="Live Demo">
   </a>
 </p>
@@ -37,7 +37,7 @@ A privacy-first, browser-based document editor powered by OnlyOffice. Edit DOCX,
 
 ## 🚀 Quick Start
 
-**Try it online:** [ranuts.github.io/document](https://ranuts.github.io/document/)
+**Try it online:** [edit.chaxus.com](https://edit.chaxus.com/)
 
 **Run with Docker:**
 

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/ranuts/document/releases">
     <img src="https://img.shields.io/github/v/release/ranuts/document" alt="版本">
   </a>
-  <a href="https://ranuts.github.io/document/">
+  <a href="https://edit.chaxus.com/">
     <img src="https://img.shields.io/badge/在线-体验-brightgreen" alt="在线体验">
   </a>
 </p>
@@ -37,7 +37,7 @@
 
 ## 🚀 快速开始
 
-**在线体验：** [ranuts.github.io/document](https://ranuts.github.io/document/)
+**在线体验：** [edit.chaxus.com](https://edit.chaxus.com/)
 
 **Docker 运行：**
 


### PR DESCRIPTION
迁移主体已上线(CF Pages 新站 + 旧站带参跳转),把对外引用统一到 `edit.chaxus.com`。

- `package.json` homepage
- `readme.md` / `readme.zh.md` Live Demo 链接 + 在线体验
- `CLAUDE.md` 线上地址(注明旧址已跳转)

`redirect/*.html` 注释里的旧 URL **故意保留**(描述"从旧址搬走")。仓库 Website 字段另用 gh 改;GSC 地址变更待外部后台操作。详见 `docs/explorations/2026-07-05-migration-finishing-touches.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)