### PR TITLE
feat(seo): P0 关键词落地页 + 开源卖点/GitHub 指向

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,8 +55,21 @@
           "No account or sign-up required",
           "Open documents from a URL via ?src= or ?file=",
           "Installable PWA with offline support",
-          "Embeddable via postMessage API"
+          "Embeddable via postMessage API",
+          "Free and open source (AGPL-3.0)"
         ]
+      }
+    </script>
+
+    <!-- Open source: signals a trustworthy, self-hostable tool to search engines and AI assistants. -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareSourceCode",
+        "name": "Online Document Editor",
+        "codeRepository": "https://github.com/ranuts/document",
+        "programmingLanguage": "TypeScript",
+        "license": "https://www.gnu.org/licenses/agpl-3.0.html"
       }
     </script>
 
@@ -85,7 +98,16 @@
           <li>Open documents from a URL with the <code>?src=</code> or <code>?file=</code> parameter</li>
           <li>Installable as a PWA and usable offline</li>
           <li>Embeddable in other sites through a postMessage API</li>
+          <li>
+            Free and open source (AGPL-3.0) —
+            <a href="https://github.com/ranuts/document" rel="noopener">view the source on GitHub</a>
+          </li>
         </ul>
+        <p>
+          See also:
+          <a href="/no-signup-document-editor">document editor with no sign up</a> and a
+          <a href="/vs/google-docs">private, open-source Google Docs alternative</a>.
+        </p>
         <p>This editor requires JavaScript. Please enable JavaScript to start editing.</p>
       </main>
     </noscript>

--- a/public/no-signup-document-editor.html
+++ b/public/no-signup-document-editor.html
@@ -1,0 +1,287 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="/img/64.png" rel="shortcut icon" />
+    <link rel="icon" type="image/png" href="/img/64.png" />
+    <meta name="robots" content="index, follow" />
+    <meta name="theme-color" content="#0052cc" />
+
+    <title>Document Editor — No Sign Up, No Upload · Free &amp; Open Source</title>
+    <meta
+      name="description"
+      content="Edit Word (DOCX), Excel (XLSX), PowerPoint (PPTX) and CSV in your browser with no sign up, no login and no upload. Free, open source (AGPL-3.0) and works offline — your files never leave your device."
+    />
+    <link rel="canonical" href="https://edit.chaxus.com/no-signup-document-editor" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Online Document Editor" />
+    <meta property="og:title" content="Document Editor — No Sign Up, No Upload · Free &amp; Open Source" />
+    <meta
+      property="og:description"
+      content="Edit DOCX, XLSX, PPTX and CSV in your browser — no sign up, no upload, works offline. Free and open source."
+    />
+    <meta property="og:url" content="https://edit.chaxus.com/no-signup-document-editor" />
+    <meta property="og:image" content="https://edit.chaxus.com/img/pwa-512.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Document Editor — No Sign Up, No Upload · Free &amp; Open Source" />
+    <meta
+      name="twitter:description"
+      content="Edit DOCX, XLSX, PPTX and CSV in your browser — no sign up, no upload, works offline. Free and open source."
+    />
+    <meta name="twitter:image" content="https://edit.chaxus.com/img/pwa-512.png" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "WebApplication",
+            "name": "Online Document Editor",
+            "url": "https://edit.chaxus.com/no-signup-document-editor",
+            "applicationCategory": "BusinessApplication",
+            "operatingSystem": "Any (web browser)",
+            "isAccessibleForFree": true,
+            "description": "A free, open-source document editor that runs entirely in the browser with no sign up and no upload. Edit DOCX, XLSX, PPTX and CSV offline.",
+            "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+          },
+          {
+            "@type": "SoftwareSourceCode",
+            "name": "Online Document Editor",
+            "codeRepository": "https://github.com/ranuts/document",
+            "programmingLanguage": "TypeScript",
+            "license": "https://www.gnu.org/licenses/agpl-3.0.html"
+          },
+          {
+            "@type": "FAQPage",
+            "mainEntity": [
+              {
+                "@type": "Question",
+                "name": "Do I need to sign up or create an account?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "No. There is no sign up, no login and no account of any kind. Open the editor and start editing immediately."
+                }
+              },
+              {
+                "@type": "Question",
+                "name": "Are my files uploaded to a server?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "No. All editing happens locally in your browser using WebAssembly. Your documents never leave your device."
+                }
+              },
+              {
+                "@type": "Question",
+                "name": "Is it really free?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "Yes. It is free and open source under the AGPL-3.0 license. You can also self-host it from the source code on GitHub."
+                }
+              },
+              {
+                "@type": "Question",
+                "name": "Can I use it offline?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "Yes. It is an installable PWA and works fully offline once loaded."
+                }
+              }
+            ]
+          },
+          {
+            "@type": "BreadcrumbList",
+            "itemListElement": [
+              { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://edit.chaxus.com/" },
+              {
+                "@type": "ListItem",
+                "position": 2,
+                "name": "No sign up document editor",
+                "item": "https://edit.chaxus.com/no-signup-document-editor"
+              }
+            ]
+          }
+        ]
+      }
+    </script>
+
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      :root {
+        --bg: #ffffff;
+        --fg: #1f2937;
+        --muted: #6b7280;
+        --accent: #0052cc;
+        --border: #e5e7eb;
+        --card: #f9fafb;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0f1116;
+          --fg: #e6e8eb;
+          --muted: #9aa2ad;
+          --accent: #5b9bff;
+          --border: #262b33;
+          --card: #171a21;
+        }
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+        line-height: 1.65;
+      }
+      .wrap {
+        max-width: 760px;
+        margin: 0 auto;
+        padding: 24px;
+      }
+      header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 16px 24px;
+        border-bottom: 1px solid var(--border);
+      }
+      header a {
+        color: var(--fg);
+        text-decoration: none;
+        font-weight: 600;
+      }
+      .gh {
+        font-size: 14px;
+        color: var(--muted);
+      }
+      h1 {
+        font-size: clamp(26px, 5vw, 38px);
+        line-height: 1.2;
+        margin: 32px 0 12px;
+      }
+      h2 {
+        font-size: 22px;
+        margin: 36px 0 12px;
+      }
+      p {
+        margin: 12px 0;
+      }
+      .lead {
+        font-size: 18px;
+        color: var(--muted);
+      }
+      .cta {
+        display: inline-block;
+        margin: 20px 0;
+        padding: 14px 28px;
+        background: var(--accent);
+        color: #fff;
+        border-radius: 8px;
+        text-decoration: none;
+        font-weight: 600;
+        font-size: 17px;
+      }
+      ul {
+        padding-left: 20px;
+      }
+      li {
+        margin: 8px 0;
+      }
+      .oss {
+        margin: 28px 0;
+        padding: 18px 20px;
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+      }
+      .oss a {
+        color: var(--accent);
+        font-weight: 600;
+      }
+      a {
+        color: var(--accent);
+      }
+      .faq h3 {
+        font-size: 17px;
+        margin: 20px 0 4px;
+      }
+      footer {
+        margin-top: 48px;
+        padding-top: 20px;
+        border-top: 1px solid var(--border);
+        color: var(--muted);
+        font-size: 14px;
+      }
+      footer a {
+        color: var(--muted);
+        margin-right: 16px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <header>
+      <a href="/">📝 Online Document Editor</a>
+      <a class="gh" href="https://github.com/ranuts/document" rel="noopener">★ Open source on GitHub</a>
+    </header>
+
+    <main class="wrap">
+      <h1>Free Online Document Editor — No Sign Up, No Upload</h1>
+      <p class="lead">
+        Edit Word (DOCX), Excel (XLSX), PowerPoint (PPTX) and CSV files right in your browser. No account, no login, no
+        subscription — and your files are never uploaded anywhere.
+      </p>
+
+      <a class="cta" href="/">Open the editor →</a>
+
+      <p>
+        Most "free" online editors ask you to create an account, then quietly upload your document to their servers.
+        This one does neither. Everything runs locally in your browser with WebAssembly, so your files stay on your
+        device. Close the tab and nothing is left behind.
+      </p>
+
+      <h2>Why people use it</h2>
+      <ul>
+        <li><strong>No sign up, no login, no subscription</strong> — open the page and start editing.</li>
+        <li><strong>No upload</strong> — 100% client-side; your documents never leave your device.</li>
+        <li><strong>All the common formats</strong> — DOCX, XLSX, PPTX and CSV, powered by OnlyOffice.</li>
+        <li><strong>Works offline</strong> — installable as a PWA and usable with no connection.</li>
+        <li><strong>Open source</strong> — audit it or self-host it yourself.</li>
+      </ul>
+
+      <div class="oss">
+        <strong>Open source &amp; self-hostable.</strong> This editor is fully open source under the AGPL-3.0 license —
+        there is no hidden telemetry and nothing to trust us on. Read the code, file issues, or run your own copy:
+        <a href="https://github.com/ranuts/document" rel="noopener">github.com/ranuts/document</a>.
+      </div>
+
+      <h2 class="faq">Frequently asked questions</h2>
+      <div class="faq">
+        <h3>Do I need to sign up or create an account?</h3>
+        <p>
+          No. There is no sign up, no login and no account of any kind. Open the editor and start editing immediately.
+        </p>
+        <h3>Are my files uploaded to a server?</h3>
+        <p>
+          No. All editing happens locally in your browser using WebAssembly. Your documents never leave your device.
+        </p>
+        <h3>Is it really free?</h3>
+        <p>
+          Yes. It is free and open source under the AGPL-3.0 license. You can also self-host it from the
+          <a href="https://github.com/ranuts/document" rel="noopener">source code on GitHub</a>.
+        </p>
+        <h3>Can I use it offline?</h3>
+        <p>Yes. It is an installable PWA and works fully offline once loaded.</p>
+      </div>
+
+      <footer>
+        <a href="/">Open editor</a>
+        <a href="/vs/google-docs">vs Google Docs</a>
+        <a href="https://github.com/ranuts/document" rel="noopener">GitHub</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,4 +5,14 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://edit.chaxus.com/no-signup-document-editor</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://edit.chaxus.com/vs/google-docs</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/public/vs/google-docs.html
+++ b/public/vs/google-docs.html
@@ -1,0 +1,340 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="/img/64.png" rel="shortcut icon" />
+    <link rel="icon" type="image/png" href="/img/64.png" />
+    <meta name="robots" content="index, follow" />
+    <meta name="theme-color" content="#0052cc" />
+
+    <title>Private, Open-Source Google Docs Alternative — No AI, No Account</title>
+    <meta
+      name="description"
+      content="A private Google Docs alternative that runs entirely in your browser: no account, no cloud upload, no AI trained on your documents. Free, open source (AGPL-3.0), works offline. Edit DOCX, XLSX, PPTX and CSV."
+    />
+    <link rel="canonical" href="https://edit.chaxus.com/vs/google-docs" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Online Document Editor" />
+    <meta property="og:title" content="Private, Open-Source Google Docs Alternative — No AI, No Account" />
+    <meta
+      property="og:description"
+      content="A private Google Docs alternative: no account, no cloud upload, no AI on your files. Free and open source."
+    />
+    <meta property="og:url" content="https://edit.chaxus.com/vs/google-docs" />
+    <meta property="og:image" content="https://edit.chaxus.com/img/pwa-512.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Private, Open-Source Google Docs Alternative — No AI, No Account" />
+    <meta
+      name="twitter:description"
+      content="A private Google Docs alternative: no account, no cloud upload, no AI on your files. Free and open source."
+    />
+    <meta name="twitter:image" content="https://edit.chaxus.com/img/pwa-512.png" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "WebApplication",
+            "name": "Online Document Editor",
+            "url": "https://edit.chaxus.com/vs/google-docs",
+            "applicationCategory": "BusinessApplication",
+            "operatingSystem": "Any (web browser)",
+            "isAccessibleForFree": true,
+            "description": "A private, open-source Google Docs alternative that runs entirely in the browser with no account, no cloud upload and no AI trained on your documents.",
+            "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+          },
+          {
+            "@type": "SoftwareSourceCode",
+            "name": "Online Document Editor",
+            "codeRepository": "https://github.com/ranuts/document",
+            "programmingLanguage": "TypeScript",
+            "license": "https://www.gnu.org/licenses/agpl-3.0.html"
+          },
+          {
+            "@type": "FAQPage",
+            "mainEntity": [
+              {
+                "@type": "Question",
+                "name": "Is this a Google Docs alternative without AI?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "Yes. There are no AI features and nothing is trained on your documents. It is a plain, private document editor that runs locally in your browser."
+                }
+              },
+              {
+                "@type": "Question",
+                "name": "Do I need a Google account or any account?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "No account is required. There is no sign up and no login of any kind."
+                }
+              },
+              {
+                "@type": "Question",
+                "name": "Are my documents stored in the cloud?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "No. Everything runs client-side in your browser. Your files are never uploaded and stay on your device."
+                }
+              },
+              {
+                "@type": "Question",
+                "name": "Is it open source?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "Yes, it is open source under the AGPL-3.0 license and can be self-hosted from the source code on GitHub."
+                }
+              }
+            ]
+          },
+          {
+            "@type": "BreadcrumbList",
+            "itemListElement": [
+              { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://edit.chaxus.com/" },
+              {
+                "@type": "ListItem",
+                "position": 2,
+                "name": "vs Google Docs",
+                "item": "https://edit.chaxus.com/vs/google-docs"
+              }
+            ]
+          }
+        ]
+      }
+    </script>
+
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      :root {
+        --bg: #ffffff;
+        --fg: #1f2937;
+        --muted: #6b7280;
+        --accent: #0052cc;
+        --border: #e5e7eb;
+        --card: #f9fafb;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0f1116;
+          --fg: #e6e8eb;
+          --muted: #9aa2ad;
+          --accent: #5b9bff;
+          --border: #262b33;
+          --card: #171a21;
+        }
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+        line-height: 1.65;
+      }
+      .wrap {
+        max-width: 760px;
+        margin: 0 auto;
+        padding: 24px;
+      }
+      header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 16px 24px;
+        border-bottom: 1px solid var(--border);
+      }
+      header a {
+        color: var(--fg);
+        text-decoration: none;
+        font-weight: 600;
+      }
+      .gh {
+        font-size: 14px;
+        color: var(--muted);
+      }
+      h1 {
+        font-size: clamp(26px, 5vw, 38px);
+        line-height: 1.2;
+        margin: 32px 0 12px;
+      }
+      h2 {
+        font-size: 22px;
+        margin: 36px 0 12px;
+      }
+      p {
+        margin: 12px 0;
+      }
+      .lead {
+        font-size: 18px;
+        color: var(--muted);
+      }
+      .cta {
+        display: inline-block;
+        margin: 20px 0;
+        padding: 14px 28px;
+        background: var(--accent);
+        color: #fff;
+        border-radius: 8px;
+        text-decoration: none;
+        font-weight: 600;
+        font-size: 17px;
+      }
+      a {
+        color: var(--accent);
+      }
+      .cmp {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 16px 0;
+        font-size: 15px;
+      }
+      .cmp th,
+      .cmp td {
+        border: 1px solid var(--border);
+        padding: 10px 12px;
+        text-align: left;
+        vertical-align: top;
+      }
+      .cmp th {
+        background: var(--card);
+      }
+      .scroll {
+        overflow-x: auto;
+      }
+      .oss {
+        margin: 28px 0;
+        padding: 18px 20px;
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+      }
+      .oss a {
+        color: var(--accent);
+        font-weight: 600;
+      }
+      .faq h3 {
+        font-size: 17px;
+        margin: 20px 0 4px;
+      }
+      footer {
+        margin-top: 48px;
+        padding-top: 20px;
+        border-top: 1px solid var(--border);
+        color: var(--muted);
+        font-size: 14px;
+      }
+      footer a {
+        color: var(--muted);
+        margin-right: 16px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <header>
+      <a href="/">📝 Online Document Editor</a>
+      <a class="gh" href="https://github.com/ranuts/document" rel="noopener">★ Open source on GitHub</a>
+    </header>
+
+    <main class="wrap">
+      <h1>A Private, Open-Source Google Docs Alternative</h1>
+      <p class="lead">
+        No account. No cloud upload. No AI trained on your documents. Edit DOCX, XLSX, PPTX and CSV entirely in your
+        browser — your files never leave your device.
+      </p>
+
+      <a class="cta" href="/">Open the editor →</a>
+
+      <p>
+        Google Docs is convenient, but every document lives on Google's servers and is tied to your account. If you just
+        want to open and edit a file without handing it to the cloud — or without AI features you never asked for — this
+        is a lightweight, private alternative that runs 100% client-side.
+      </p>
+
+      <h2>How it compares</h2>
+      <div class="scroll">
+        <table class="cmp">
+          <thead>
+            <tr>
+              <th></th>
+              <th>This editor</th>
+              <th>Google Docs</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Account required</td>
+              <td>No</td>
+              <td>Yes (Google account)</td>
+            </tr>
+            <tr>
+              <td>Files uploaded to cloud</td>
+              <td>No — stays on your device</td>
+              <td>Yes — stored on Google servers</td>
+            </tr>
+            <tr>
+              <td>AI on your documents</td>
+              <td>None</td>
+              <td>Gemini features integrated</td>
+            </tr>
+            <tr>
+              <td>Works offline</td>
+              <td>Yes (PWA)</td>
+              <td>Limited</td>
+            </tr>
+            <tr>
+              <td>Open source</td>
+              <td>Yes (AGPL-3.0)</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>Self-hostable</td>
+              <td>Yes</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>Native formats</td>
+              <td>DOCX, XLSX, PPTX, CSV</td>
+              <td>Google formats (convert on import)</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="oss">
+        <strong>Don't take our word for it — read the code.</strong> Because it is open source under AGPL-3.0, you can
+        verify that nothing is uploaded and run your own copy:
+        <a href="https://github.com/ranuts/document" rel="noopener">github.com/ranuts/document</a>.
+      </div>
+
+      <h2 class="faq">Frequently asked questions</h2>
+      <div class="faq">
+        <h3>Is this a Google Docs alternative without AI?</h3>
+        <p>
+          Yes. There are no AI features and nothing is trained on your documents. It is a plain, private document editor
+          that runs locally in your browser.
+        </p>
+        <h3>Do I need a Google account or any account?</h3>
+        <p>No account is required. There is no sign up and no login of any kind.</p>
+        <h3>Are my documents stored in the cloud?</h3>
+        <p>No. Everything runs client-side in your browser. Your files are never uploaded and stay on your device.</p>
+        <h3>Is it open source?</h3>
+        <p>
+          Yes, it is open source under the AGPL-3.0 license and can be self-hosted from the
+          <a href="https://github.com/ranuts/document" rel="noopener">source code on GitHub</a>.
+        </p>
+      </div>
+
+      <footer>
+        <a href="/">Open editor</a>
+        <a href="/no-signup-document-editor">No sign up editor</a>
+        <a href="https://github.com/ranuts/document" rel="noopener">GitHub</a>
+      </footer>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## 背景

edit.chaxus.com 技术 SEO 已齐全，但**只有 1 个页面**（sitemap 1 条 URL）——单页工具没做关键词内页。本 PR 按「横向拓展关键词内页」的思路，落地第一批 P0 页面，并把**开源**做成卖点、指向 GitHub。

关键词经 `google suggest` + `google search` SERP 实测选出（见对应知识库记录）。

## 改动

**两个新落地页**（public/ 下自包含静态 HTML，走已有 embed-demo.html 先例；SW 为 network-first，不会劫持路由）：

- **`/no-signup-document-editor`** — 主打 `document editor no sign up / no login / no upload`。该词 SERP 是**空档**：首页几乎全是 PDF 工具，无人占「office 文档」这个词。
- **`/vs/google-docs`** — 私密、无 AI、开源的 Google Docs 替代品对比页（含对比表），同时服务 GEO / AI 助手推荐（"private online document editor" 类问题）。

**每页 on-page 优化**：关键词化 title/description/H1、canonical、OG/Twitter、JSON-LD（`WebApplication` + `SoftwareSourceCode` + `FAQPage` + `BreadcrumbList`）、响应式、明暗主题、内链互通。

**开源卖点 + GitHub 指向**：
- 首页 `index.html`：新增 `SoftwareSourceCode` JSON-LD；`<noscript>` 里加开源特性行 + GitHub 链接；并内链到两个新页（从首页传权重、帮爬虫发现内页）。
- 落地页：显著的「open source (AGPL-3.0)、可自托管」区块，链到 `github.com/ranuts/document`——同时增强 EEAT 信任与 AI 可引用性。

**sitemap.xml**：1 → 3 条 URL。

## 验证

- `prettier --check` 全部通过（CI format gate）。
- 未改动 SPA/编辑器/构建逻辑：新页面是纯静态文件，`vite build` 仅复制 public/。
- 无新增依赖。

## 部署后待办

- GSC 重新提交 sitemap；对两个新 URL 请求编入索引。
- 确认 CF Pages 对 `/no-signup-document-editor`、`/vs/google-docs` 返回静态页（clean URL）。
- 下一批 P0：`/open/docx`、`/open/xlsx·pptx`、`/offline-document-editor`、`/convert/xlsx-to-json·csv` 等。

🤖 Generated with [Claude Code](https://claude.com/claude-code)