### PR TITLE
fix(copy): drop 'no telemetry' over-claim (RUM stays on)

### DIFF
--- a/public/no-signup-document-editor.html
+++ b/public/no-signup-document-editor.html
@@ -140,8 +140,9 @@
       </ul>
 
       <div class="oss">
-        <strong>Open source &amp; self-hostable.</strong> This editor is fully open source under the AGPL-3.0 license —
-        there is no hidden telemetry and nothing to trust us on. Read the code, file issues, or run your own copy:
+        <strong>Open source &amp; self-hostable.</strong> This editor is fully open source under the AGPL-3.0 license,
+        so you don't have to take our word for it — read the code to confirm your files are never uploaded, file issues,
+        or run your own copy:
         <a href="https://github.com/ranuts/document" rel="noopener">github.com/ranuts/document</a>.
       </div>
 


### PR DESCRIPTION
## Why

We decided to **keep** Cloudflare RUM (cookieless, no cross-site) because it is the signal that distinguishes real human traffic from bots. With RUM on, the landing page's blanket **"no hidden telemetry"** claim is no longer accurate.

This wording fix was part of PR #106 but got **separated when #106 was squash-merged without it**, so the over-claim is currently live on `/no-signup-document-editor`.

## Change

Reword the open-source callout to the still-true point: the code is open, so you can confirm your files are never uploaded. All file-privacy claims (no upload, 100% client-side, no account) remain intact — RUM never touches document contents.

## Verification

- `prettier --check` passes.
- `grep "no hidden telemetry"` now returns 0 matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)