### PR TITLE
docs: PR-only workflow in CLAUDE.md; roadmap direction 9 (ranui/ranuts alignment + IIFE drift); test: ranui vendoring sentinel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,10 @@ gh pr merge --auto --rebase      # 检查全绿后自动 rebase 合并（约 15 
 
 若不小心提交到了本地 main：`git branch <topic> && git reset --hard origin/main` 再照上走。
 
+**多会话并行**：不要共用同一个 checkout（HEAD/index/dist/test-results 都会互相干扰）。
+第二个及以后的会话用独立 worktree：`git worktree add .claude/worktrees/<name> -b <topic>`
+（`.claude/` 已在 .gitignore），各自 `pnpm install`、各占一个 `E2E_PORT`；PR 流程不变。
+
 ## 开发命令
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,23 @@
 
 ---
 
+## 提交流程（2026-08-16 起：PR 制，main 受保护）
+
+`main` 分支保护已开（含管理员）：**不能直推**，必须 PR，且必须通过 6 个必需检查——
+`Lint and Validate` / `E2E` / `E2E (Cloudflare Pages semantics)` / `E2E (Docker image)` /
+`Preview smoke against Cloudflare Pages`（`.github/workflows/preview-smoke.yml`：等 CF Pages
+为该 PR 提交构建好 preview，再对 preview URL 跑冒烟集）/ `Cloudflare Pages`；线性历史，
+自动合并与合并后删分支已开。常规操作：
+
+```bash
+git switch -c <topic>            # 多会话共用工作树时一律在分支上提交
+git push -u origin <topic>
+gh pr create --fill
+gh pr merge --auto --rebase      # 检查全绿后自动 rebase 合并（约 15 分钟）
+```
+
+若不小心提交到了本地 main：`git branch <topic> && git reset --hard origin/main` 再照上走。
+
 ## 开发命令
 
 ```bash

--- a/docs/changelogs/2026-08-15-v9-regression-campaign.md
+++ b/docs/changelogs/2026-08-15-v9-regression-campaign.md
@@ -254,3 +254,9 @@ gh workflow run nightly-corpus.yml -f limit=300     # 手动触发夜间
   67 通过 / 10 跳过（opt-in 夜间档）/ 0 失败。台账 A 表基本填满，剩 doc/xls/ppt 合成
   用例（靠夜间 POI）与图表/修订生成器。**待用户决定**：是否改为 PR → CF preview →
   冒烟门禁 → 合并的工作流（现在是 push main 即上线 + 上线后冒烟）。
+- **流程切换为 PR 制**（用户决定）：main 分支保护（含管理员、线性历史、6 个必需检查）、
+  `preview-smoke.yml`（等 CF Pages preview → 冒烟）、auto-merge + 删分支。两个会话共用
+  工作树，之后一律在 topic 分支提交。
+- **ranui IIFE 对齐**列入 roadmap 方向九：审计结论=入库 IIFE 与 npm latest 一致，落后的是
+  源仓库未发版；L1 防漂移哨兵 `test/unit/ranui-vendor-sync.test.ts` 已落，L2 发版对齐等
+  用户在 ran 仓库发 0.5.0-alpha.3。

--- a/docs/superpowers/plans/2026-08-15-next-phase-roadmap.md
+++ b/docs/superpowers/plans/2026-08-15-next-phase-roadmap.md
@@ -375,6 +375,31 @@ llms.txt 形成互补）。结构化数据用 FAQPage / HowTo，并入 sitemap�
   文档正文的"深色画布"（OnlyOffice `asc_setContentDarkMode`）刻意不
   跟随——那是编辑器内的用户偏好，且会改变文档观感。
 
+## 方向九：ranui / ranuts 版本对齐与 IIFE 防漂移（2026-08-16 追加，用户要求）
+
+**背景**：静态页（落地页、demo、404、changelog/help 生成页）没有 bundler，通过
+`public/ranui-iife/<comp>.iife.js` 使用 ranui；这些文件由 `bin/build.sh` 从已安装的
+ranui 复制并**入库**。用户指出仍在用"历史有问题的版本"。
+
+**审计（2026-08-16）**：`public/ranui-iife/*` 与安装的 ranui 0.5.0-alpha.2 逐字节一致，
+且 0.5.0-alpha.2 = npm `latest`；但源仓库 `chaxus/ran` 的 ranui 有 8-13 之后**未发布**
+的修复（colorpicker、player、math 字体等），dist 也是 8-13 构建。结论：落后的是
+**npm 上的发布**，不是本仓的复制。
+
+**分级实施**：
+
+1. **L1 防漂移哨兵（已做）**：`test/unit/ranui-vendor-sync.test.ts`——每个入库 IIFE 与
+   `node_modules/ranui/dist/iife` 逐字节一致、页面引用的每个 IIFE 都已 vendored、
+   workspace 各包 ranui/ranuts 版本与根一致（双份 ranui 会让自定义元素先到先得、图标静默丢）。
+2. **L2 发版对齐（需用户在 ran 仓库操作）**：从 `chaxus/ran` 发布 ranui `0.5.0-alpha.3`
+   （含 8-13 后的修复），本仓 `package.json` + 三个 workspace 包同步 bump，
+   `pnpm install` 后 `bin/build.sh` 自动重拷 IIFE；提交前用 L1 哨兵与 E2E
+   （embed-demo、主站落地页）验证。发版是外部动作，由用户执行或授权。
+3. **L3 上游可用性提醒（自动化）**：夜间任务加一步 `npm view ranui version` 与
+   `package.json` 比对，落后即在 step summary 提示（不失败）。
+4. **L4 反向修复**：ranui IIFE 若发现缺陷，按"ran 生态优先"改 `chaxus/ran` 再发版，
+   不在本仓打补丁。
+
 ## 建议执行顺序（2026-08-15 三修：方向零插入为最高优先级）
 
 **方向零（全面回归战役）压倒下表所有事项**；表内条目在战役期间仅在

--- a/test/unit/ranui-vendor-sync.test.ts
+++ b/test/unit/ranui-vendor-sync.test.ts
@@ -1,0 +1,71 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * ranui vendoring sentinel. Static pages under public/ cannot import from
+ * node_modules, so bin/build.sh copies the per-component IIFE bundles the
+ * pages reference into public/ranui-iife/ from the INSTALLED ranui. The
+ * copies are committed; if someone edits or forgets to rebuild them, pages
+ * silently run an older component build than the app (the "IIFE still on a
+ * historical version" class). Pin: every referenced bundle exists, every
+ * vendored bundle is byte-identical to the installed package's, and every
+ * workspace package pins the same ranui/ranuts versions as the root.
+ */
+const ROOT = resolve(__dirname, '../..');
+const read = (rel: string) => readFileSync(resolve(ROOT, rel));
+
+describe('ranui vendored IIFE bundles', () => {
+  const vendoredDir = resolve(ROOT, 'public/ranui-iife');
+  const installedDir = resolve(ROOT, 'node_modules/ranui/dist/iife');
+  const vendored = readdirSync(vendoredDir).filter((f) => f.endsWith('.iife.js'));
+
+  it('are byte-identical to the installed ranui dist', () => {
+    expect(vendored.length).toBeGreaterThan(0);
+    for (const f of vendored) {
+      const installed = resolve(installedDir, f);
+      expect(existsSync(installed), `${f} is not shipped by the installed ranui`).toBe(true);
+      expect(
+        read(`public/ranui-iife/${f}`).equals(readFileSync(installed)),
+        `${f} drifted from node_modules/ranui/dist/iife`,
+      ).toBe(true);
+    }
+  });
+
+  it('cover every bundle a static page references', () => {
+    const walk = (dir: string): string[] =>
+      readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+        if (e.name === 'sdkjs' || e.name === 'web-apps' || e.name === 'fonts') return [];
+        const p = resolve(dir, e.name);
+        return e.isDirectory() ? walk(p) : e.name.endsWith('.html') ? [p] : [];
+      });
+    const refs = new Set<string>();
+    for (const html of walk(resolve(ROOT, 'public'))) {
+      for (const m of readFileSync(html, 'utf8').matchAll(/ranui-iife\/([a-z-]+\.iife\.js)/g)) refs.add(m[1]);
+    }
+    expect(refs.size).toBeGreaterThan(0);
+    for (const r of refs) expect(vendored, `page references ${r} but it is not vendored`).toContain(r);
+  });
+});
+
+describe('ranui / ranuts versions', () => {
+  const root = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8'));
+  const installed = JSON.parse(readFileSync(resolve(ROOT, 'node_modules/ranui/package.json'), 'utf8')).version;
+
+  it('the installed ranui is the version the root pins', () => {
+    expect(installed).toBe(root.dependencies.ranui);
+  });
+
+  it('every workspace package pins the same ranui / ranuts as the root (a second copy = first-registered custom elements win, icons vanish)', () => {
+    for (const pkg of readdirSync(resolve(ROOT, 'packages'))) {
+      const file = resolve(ROOT, 'packages', pkg, 'package.json');
+      if (!existsSync(file)) continue;
+      const deps = {
+        ...JSON.parse(readFileSync(file, 'utf8')).dependencies,
+        ...JSON.parse(readFileSync(file, 'utf8')).peerDependencies,
+      };
+      if (deps.ranui) expect(deps.ranui, `packages/${pkg} ranui`).toBe(root.dependencies.ranui);
+      if (deps.ranuts) expect(deps.ranuts, `packages/${pkg} ranuts`).toBe(root.dependencies.ranuts);
+    }
+  });
+});


### PR DESCRIPTION
Docs for the PR-only flow, roadmap direction 9 (ranui/ranuts alignment; audit: vendored IIFEs == installed == npm latest 0.5.0-alpha.2, source repo has unreleased fixes), and the vendoring sentinel unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)