### PR TITLE
perf(home): load the OnlyOffice DocsAPI script on demand instead of render-blocking the homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ notes. Entries describe what users experience, not internal refactors.
 
 ### Fixed
 
+- The homepage no longer blocks its first paint on the editor's API loader
+  script (about half a second of LCP); the loader is fetched when you open or
+  create a document.
 - The Chinese landing pages' "open your XLSX / PPTX / CSV" buttons no longer
   drop you into a blank new Word document; they go to the Chinese homepage
   where you can pick the file.

--- a/docs/explorations/2026-08-16-perf-baseline-and-api-loader.md
+++ b/docs/explorations/2026-08-16-perf-baseline-and-api-loader.md
@@ -1,0 +1,42 @@
+# 性能基线 + 首页去掉渲染阻塞的 api.js（2026-08-16）
+
+路线图第 9 项（方向四 2 前半）。方法：chrome-devtools MCP 直接打线上
+edit.chaxus.com，冷 profile、无节流，performance trace + 逐帧
+`performance.getEntriesByType('resource')`。数字与结论已写进路线图方向四 2
+"基线"小节，这里只记过程与首刀。
+
+## 首页
+
+LCP 774 ms（TTFB 205 / render delay 569）。渲染阻塞请求 5 个：home.css、
+index-_.css、fonts.css、ran-tokens._.css，以及 **`web-apps/apps/api/documents/
+api.js`——一个同步 `<script>`，479 ms**。它是 OnlyOffice DocsAPI 加载器，
+只有真的打开/新建文档才需要；`lib/onlyoffice-editor.ts` 早有幂等的
+`loadEditorApi()`，但只有 `onCreateNew` 与 embed 路径调用它，
+`openLocalFile` / `openDocumentFromUrl` / 桌面事件路径都在吃 head 里那个
+同步标签。
+
+首刀：删同步标签，`lib/converter.ts` 的 `handleDocumentOperation`（所有
+打开路径的汇合点）开头 `await loadEditorApi()`；index.html 留一条
+`<link rel="prefetch" as="script">`（低优先级、不阻塞）。验证：单测 461
+绿；E2E app-smoke / main-site / entry-paths / embed-api / embed-save-default
+16 passed（覆盖 hero 打开、New Excel、`?file=`、`?open=local`、embed 三种打开）。
+
+## 编辑器冷打开（`?new=docx`）
+
+就绪（`isDocumentLoadComplete && isLoadFullApi`）≈ 16 s。瀑布：
+app.js 0.35–0.9 s → sdk-all-min.js 1.2–1.9 s → **sdk-all.js 2.95 MB br，
+2.0–8.6 s** → 14 个字体文件 8.9–15.0 s。sdk-all.js 边缘已命中
+（REVALIDATED、br），是纯带宽；字体仍 DYNAMIC（`_headers` immutable 已上，
+但无扩展名路径要 CF 面板 Cache Rule，待用户）。空白文档拉 14 个字体文件
+偏多，留给字体专项查 `fonts_loading`。
+
+## 预取决策
+
+不做无差别 idle 预取（3 MB 对落地页访客是浪费）；改"意图触发"——hover /
+focus 打开与新建按钮、文件选择框弹出时 prefetch sdk-all-min.js /
+sdk-all.js / app.js。留在路线图第 11 项，与路由拆分一起做。
+
+## 顺手
+
+第 8 项"PPT E2E"实际早已被战役里的 format-parity / embed-save-default /
+resave-idempotence / visual-roundtrip / corpus 覆盖，路线图打 ✅ 并注明。

--- a/docs/superpowers/plans/2026-08-15-next-phase-roadmap.md
+++ b/docs/superpowers/plans/2026-08-15-next-phase-roadmap.md
@@ -210,6 +210,25 @@ WebMCP 接入本质是把同一批能力换个注册方式暴露出来。
    预取（落地页 idle 时 prefetch sdk-all 等核心资产）与 SW 预缓存
    （离线秒开，与隐私定位天然契合）的投入。先测量后优化。
 
+   **基线（2026-08-16，chrome-devtools 打线上，无节流，冷 profile）**：
+   - 首页 `/`：LCP 774 ms（TTFB 205 + render delay 569），CLS 0。渲染阻塞
+     5 个请求里 4 个是 CSS，1 个是 `web-apps/apps/api/documents/api.js`
+     （同步 `<script>`，479 ms）——首页读者根本用不到它。**首刀**：删掉
+     该同步标签，`handleDocumentOperation` 入口统一 `await loadEditorApi()`
+     （幂等），首页只留 `<link rel="prefetch">`。
+   - `?new=docx` 冷打开到 `isDocumentLoadComplete && isLoadFullApi`：
+     **≈16 s**。瀑布：app 壳 0.5–0.9 s → `sdk-all-min.js` 424 KB 1.2–1.9 s
+     → **`sdk-all.js` 2.95 MB（br）2.0–8.6 s** → 字体 14 个文件 8.9–15.0 s
+     → 就绪。总计 61 请求 / 4.2 MB。两个瓶颈：sdk-all.js 纯带宽（边缘已
+     REVALIDATED/br，无法再压）；字体仍 `cf-cache-status: DYNAMIC`（CF
+     Cache Rule 待用户在面板加）+ 空白 docx 竟拉 14 个字体文件（值得查
+     fonts_loading 为何这么多——字体线归战役字体专项）。
+   - **预取决策（第 11 项）**：不做无差别 idle 预取——sdk-all.js 3 MB 对
+     只读落地页的访客是纯浪费；改为"意图触发"：hover/focus 到 Open/New
+     按钮、文件选择框弹出时 `<link rel=prefetch>` sdk-all-min.js + sdk-all.js
+     - app.js（同源、SWR 缓存会接住），零成本覆盖 80% 的真实打开。SW
+       离线预缓存等路由拆分后按新首页再测。
+
    **2026-08-16 已落地的第一批（由用户"线上 PPT 永久 Loading、本地正常"
    报障驱动，全部有线上冷/热 profile 实测数字）**：
    - `_headers`：`/fonts/*` 与 `x2t.wasm.gz` immutable（`a2a4010`）；
@@ -392,10 +411,10 @@ llms.txt 形成互补）。结构化数据用 FAQPage / HowTo，并入 sitemap�
 | 5   | embed-demo 对齐 ran 设计体系（方向六 1）         | 半天      | ✅ 2026-08-16 r-button/r-input/r-checkbox/r-card/r-theme-switch + token；E2E 契约不变，见 explorations/2026-08-16-embed-demo-ranui-restyle.md |
 | 6   | markdown→HTML 生成器（方向七 1，后两项的前置）   | 半天~1 天 | ✅ 2026-08-16 `bin/build-pages.mjs`（locale × page，marked，FAQ/TOC 自动，输出入库 + `--check` 单测）                                         |
 | 7   | /help 帮助中心 + /changelog 页（方向七 2/3）     | 1~2 天    | ✅ 2026-08-16 /help、/help/embed-api、/changelog（en + zh-CN）；CHANGELOG 中文版待补                                                          |
-| 8   | PPT E2E（方向四 1）                              | 小时级    |                                                                                                                                               |
-| 9   | 性能基线审计（方向四 2 前半）                    | 半天      |                                                                                                                                               |
+| 8   | PPT E2E（方向四 1）                              | 小时级    | ✅ 已由战役覆盖：format-parity / embed-save-default / resave-idempotence / visual-roundtrip / corpus 均含 pptx 打开-编辑-保存-导 PDF          |
+| 9   | 性能基线审计（方向四 2 前半）                    | 半天      | ✅ 2026-08-16 线上基线已测（见方向四 2 的"基线"小节）+ 首刀：api.js 改按需加载（PR）                                                          |
 | 10  | 首页/编辑器路由拆分（方向六 2，基线之后做）      | 1~2 天    |                                                                                                                                               |
-| 11  | 预取/SW 预缓存决策（方向四 2 后半，拆分后再测）  | 1 天      |                                                                                                                                               |
+| 11  | 预取/SW 预缓存决策（方向四 2 后半，拆分后再测）  | 1 天      | ↻ 决策已给：不做无差别 idle 预取，改"意图触发预取"（见方向四 2）；SW 预缓存待路由拆分后测                                                     |
 | 12  | WebMCP 薄适配 + origin trial（专节）             | 1 天      |                                                                                                                                               |
 | 13  | 外链发布稿（方向二 3，指向 /changelog 与新功能） | 用户主导  |                                                                                                                                               |
 | 14  | agent-collab（方向五）                           | 大周期    |                                                                                                                                               |

--- a/index.html
+++ b/index.html
@@ -148,7 +148,10 @@
       }
     </script>
 
-    <script src="web-apps/apps/api/documents/api.js"></script>
+    <!-- The OnlyOffice DocsAPI loader is fetched on demand (lib/onlyoffice-editor.ts
+         loadEditorApi) when a document is opened or created; a synchronous tag here
+         was render-blocking (~0.5 s of LCP) for visitors who only read the landing. -->
+    <link rel="prefetch" href="/web-apps/apps/api/documents/api.js" as="script" />
   </head>
 
   <body>

--- a/lib/converter.ts
+++ b/lib/converter.ts
@@ -34,6 +34,11 @@ export async function handleDocumentOperation(options: {
   readonly?: boolean;
 }): Promise<void> {
   try {
+    // The DocsAPI loader is no longer a render-blocking <script> in
+    // index.html (it cost ~0.5 s of homepage LCP for visitors who never open
+    // a document); every open path funnels through here, so load it on
+    // demand. Idempotent once window.DocsAPI exists.
+    await loadEditorApi();
     const { isNew, fileName, file, readonly = false } = options;
     const fileType = fileName.split('.').pop() || getExtensions(file?.type || '')[0] || '';
     const _docType = getDocumentType(fileType);

--- a/public/changelog.html
+++ b/public/changelog.html
@@ -179,6 +179,10 @@ from Excel) are detected and decoded correctly instead of showing mojibake.</li>
 </ul>
 <h3 id="fixed">Fixed</h3>
 <ul>
+<li><p>The homepage no longer blocks its first paint on the editor&#39;s API loader
+script (about half a second of LCP); the loader is fetched when you open or
+create a document.</p>
+</li>
 <li><p>The Chinese landing pages&#39; &quot;open your XLSX / PPTX / CSV&quot; buttons no longer
 drop you into a blank new Word document; they go to the Chinese homepage
 where you can pick the file.</p>

--- a/public/zh-CN/changelog.html
+++ b/public/zh-CN/changelog.html
@@ -180,6 +180,10 @@ from Excel) are detected and decoded correctly instead of showing mojibake.</li>
 </ul>
 <h3 id="fixed">Fixed</h3>
 <ul>
+<li><p>The homepage no longer blocks its first paint on the editor&#39;s API loader
+script (about half a second of LCP); the loader is fetched when you open or
+create a document.</p>
+</li>
 <li><p>The Chinese landing pages&#39; &quot;open your XLSX / PPTX / CSV&quot; buttons no longer
 drop you into a blank new Word document; they go to the Chinese homepage
 where you can pick the file.</p>


### PR DESCRIPTION
## Summary
- `index.html`: drop the synchronous `web-apps/apps/api/documents/api.js` tag (479 ms of a 774 ms homepage LCP on production, render-blocking) → `<link rel="prefetch">`
- `lib/converter.ts` `handleDocumentOperation`: `await loadEditorApi()` first (idempotent); this is the funnel for every open path (hero open, New, `?file=`, `?open=local`, embed, desktop events), several of which relied on the sync tag
- Roadmap: performance baseline recorded (homepage LCP; cold `?new=docx` ≈16 s: sdk-all.js 3 MB br 6.6 s + 14 font files 6 s; fonts still `cf-cache-status: DYNAMIC` pending the CF Cache Rule), item 8 (PPT E2E) marked covered by campaign specs, item 11 prefetch decision (intent-triggered, not idle)
- Exploration: `docs/explorations/2026-08-16-perf-baseline-and-api-loader.md`

## Test plan
- [x] `pnpm run lint:ts`, unit 461 passed
- [x] E2E (E2E_PORT=4176): app-smoke, main-site, entry-paths, embed-api, embed-save-default → 16 passed
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)