### PR TITLE
feat(ui): light/dark/system switch in the FAB menu so the theme can change while editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ notes. Entries describe what users experience, not internal refactors.
 
 ### Added
 
+- The bottom-right Menu now has a light / dark / system switch, so the theme
+  can be changed while a document is open (the editor follows it).
 - A help center (`/help`, `/zh-CN/help`) answering the practical questions:
   formats, saving and converting, CSV encodings, what the PDF viewer can do,
   read-only and embedding, offline use, privacy boundaries, error codes,

--- a/docs/explorations/2026-08-16-fab-menu-theme-switch.md
+++ b/docs/explorations/2026-08-16-fab-menu-theme-switch.md
@@ -1,0 +1,16 @@
+# FAB 菜单加主题切换（2026-08-16）
+
+编辑器跟随站点主题（`lib/editor-theme.ts`）落地后留下的缺口：文档一打开
+首页 hero（连同页脚的 `<r-theme-switch>`）就隐藏，用户没有任何地方切换主题。
+
+改动：`lib/ui.ts` 的 FAB 菜单末尾追加一行 `Div.fab-menu-item.fab-menu-theme`
+包一个 `View('r-theme-switch')`（ranui builder 直接建自定义元素），
+label / label-system / label-light / label-dark 走 i18n 新词条
+`themeLabel/themeSystem/themeLight/themeDark`（zh：主题/跟随系统/浅色/深色）；
+`styles/base.css` 给该行居中 + 顶部 hairline、去 hover 填充（它是控件不是
+命令）。`index.ts` 早已 `import 'ranui/theme-switch'`。
+
+验证：真浏览器 `?new=docx` → hover Menu → 点"Dark"：`<html data-ran-theme>`
+= dark、`ran-theme` 存 dark、菜单面板底色随 token 变深、编辑器
+`currentThemeId()` = theme-dark。注意 r-theme-switch 是 closed shadow，
+脚本里拿不到内部按钮，用 a11y 树（button "Dark"）点。

--- a/docs/superpowers/plans/2026-08-15-next-phase-roadmap.md
+++ b/docs/superpowers/plans/2026-08-15-next-phase-roadmap.md
@@ -369,9 +369,8 @@ llms.txt 形成互补）。结构化数据用 FAQPage / HowTo，并入 sitemap�
   主题优先（用 `ui-theme-site-driven` 标记区分"我们驱动的"与"用户选的"）。
   单测 `test/unit/editor-theme.test.ts`；真浏览器验证 dark 挂载 +
   双向实时切换。
-- **仍缺**：编辑器打开后站点顶栏隐藏，页面上没有主题切换入口（只能靠
-  编辑器自己的 File → Advanced settings → Theme）；建议把
-  `<r-theme-switch>` 放进右下角 FAB Menu（方向六 2 路由拆分时一并做）。
+- ✅ 2026-08-16 补齐：右下角 FAB Menu 末行加了 `<r-theme-switch>`
+  （i18n 四个词条），文档打开期间可切换，编辑器实时跟随。
   文档正文的"深色画布"（OnlyOffice `asc_setContentDarkMode`）刻意不
   跟随——那是编辑器内的用户偏好，且会改变文档观感。
 

--- a/lib/ui.ts
+++ b/lib/ui.ts
@@ -184,6 +184,20 @@ function buildFab(): { container: HTMLElement; button: HTMLElement } {
         },
         false,
       ),
+      // Light / dark / system. The landing hero has the same <r-theme-switch>
+      // in its footer, but the hero is hidden once a document is open and the
+      // editor follows the site theme (lib/editor-theme.ts) -- without this
+      // row there is no way to flip it while editing.
+      Div()
+        .class('fab-menu-item fab-menu-theme')
+        .children(
+          View('r-theme-switch')
+            .class('theme-switch')
+            .attr('label', t('themeLabel'))
+            .attr('label-system', t('themeSystem'))
+            .attr('label-light', t('themeLight'))
+            .attr('label-dark', t('themeDark')),
+        ),
     )
     // Keep menu visible when hovering over it
     .on('mouseenter', () => {

--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -37,6 +37,10 @@ export interface I18nMessages {
   newPowerPoint: string;
   menu: string;
   menuGuide: string;
+  themeLabel: string;
+  themeSystem: string;
+  themeLight: string;
+  themeDark: string;
 
   // Messages
   fileSavedSuccess: string;
@@ -99,6 +103,10 @@ const messages: Record<Language, I18nMessages> = {
     newPowerPoint: '新建 PowerPoint',
     menu: '菜单',
     menuGuide: '菜单在右下角，悬停即可查看（点击关闭后不再提示）',
+    themeLabel: '主题',
+    themeSystem: '跟随系统',
+    themeLight: '浅色',
+    themeDark: '深色',
     fileSavedSuccess: '文件保存成功：',
     documentLoaded: '文档加载完成：',
     failedToLoadEditor: '无法加载编辑器组件。请确保已正确安装 OnlyOffice API。',
@@ -152,6 +160,10 @@ const messages: Record<Language, I18nMessages> = {
     newPowerPoint: 'New PowerPoint',
     menu: 'Menu',
     menuGuide: "Menu is in the bottom right corner, hover to view (click to close, won't show again)",
+    themeLabel: 'Theme',
+    themeSystem: 'System',
+    themeLight: 'Light',
+    themeDark: 'Dark',
     fileSavedSuccess: 'File saved successfully: ',
     documentLoaded: 'Document loaded: ',
     failedToLoadEditor: 'Failed to load editor component. Please ensure OnlyOffice API is properly installed.',

--- a/public/changelog.html
+++ b/public/changelog.html
@@ -155,6 +155,8 @@ fonts loaded on demand instead of up front.</li>
 </ul>
 <h3 id="added">Added</h3>
 <ul>
+<li>The bottom-right Menu now has a light / dark / system switch, so the theme
+can be changed while a document is open (the editor follows it).</li>
 <li>A help center (<code>/help</code>, <code>/zh-CN/help</code>) answering the practical questions:
 formats, saving and converting, CSV encodings, what the PDF viewer can do,
 read-only and embedding, offline use, privacy boundaries, error codes,

--- a/public/zh-CN/changelog.html
+++ b/public/zh-CN/changelog.html
@@ -156,6 +156,8 @@ fonts loaded on demand instead of up front.</li>
 </ul>
 <h3 id="added">Added</h3>
 <ul>
+<li>The bottom-right Menu now has a light / dark / system switch, so the theme
+can be changed while a document is open (the editor follows it).</li>
 <li>A help center (<code>/help</code>, <code>/zh-CN/help</code>) answering the practical questions:
 formats, saving and converting, CSV encodings, what the PDF viewer can do,
 read-only and embedding, offline use, privacy boundaries, error codes,

--- a/styles/base.css
+++ b/styles/base.css
@@ -171,6 +171,17 @@ r-button[type='text']::part(content) {
   width: 100%;
   border-radius: var(--ran-radius-sm);
 }
+/* Theme row: a control, not a command -- no hover fill, hairline above. */
+.fab-menu-theme {
+  display: flex;
+  justify-content: center;
+  padding: var(--ran-space-2) var(--ran-space-3);
+  margin-top: var(--ran-space-1);
+  border-top: 1px solid var(--ran-color-border);
+}
+.fab-menu-theme:hover {
+  background-color: transparent;
+}
 
 /* Menu Guide */
 .menu-guide {


### PR DESCRIPTION
## Summary
- FAB menu (bottom-right "Menu") gets a light / dark / system `<r-theme-switch>` row — the landing hero's switch is hidden once a document is open and the editor follows the site theme (51f85e7), so this is the only in-editor entry point
- i18n keys `themeLabel / themeSystem / themeLight / themeDark` (en + zh-CN); `.fab-menu-theme` styles on tokens
- Verified in a real browser: click "Dark" in the menu → `data-ran-theme=dark`, menu re-tints, editor `theme-dark`

## Test plan
- [x] unit + lint:ts
- [x] manual (chrome-devtools)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)