### PR TITLE
docs(seo): explain CSV mojibake and the automatic GB18030/UTF-8 detection on the csv-to-xlsx pages

### DIFF
--- a/docs/superpowers/plans/2026-08-15-next-phase-roadmap.md
+++ b/docs/superpowers/plans/2026-08-15-next-phase-roadmap.md
@@ -79,10 +79,11 @@ Breadcrumb）、页脚互链全齐；robots.txt / sitemap.xml / llms.txt 三件�
    /open/docx；同时新增 `test/unit/landing-pages.test.ts` 钉住全部落地页的
    canonical/hreflang/JSON-LD/sitemap/双语互指契约，见
    docs/explorations/2026-08-16-pdf-landing-and-landing-contract.md。
-2. **CSV 中文乱码长尾强化**：zh-CN 侧价值最高的词是"CSV 乱码/GBK 乱码
-   修复"。在 convert/csv-to-xlsx 中文页增补一节"为什么别的工具打开中文
-   CSV 会乱码、本工具如何检测编码"，FAQ 加对应问答；评估独立页
-   `/fix/csv-garbled`（zh 优先，en 后补）。
+2. ✅ 2026-08-16（前半）**CSV 中文乱码长尾强化**：convert/csv-to-xlsx 中文页
+   加"为什么别的工具打开中文 CSV 会乱码"一节 + 两条 FAQ（含 JSON-LD）+
+   description 带词；英文页同步，并修正了两页里"导入步骤可选编码"的过期
+   说法（v9 走 SheetJS 自动嗅探，没有导入对话框）。独立页 `/fix/csv-garbled`
+   待 GSC 数据再定。
 3. ✅ 2026-08-16 **只读/预览模式说明**：embed 落地页（en + zh）增补
    "Read-only and preview mode" 一节 + FAQ + FAQPage JSON-LD；docs/embed-api.md
    本就有该节；页面里的 API 参考链接改指站内 /help/embed-api。

--- a/public/convert/csv-to-xlsx.html
+++ b/public/convert/csv-to-xlsx.html
@@ -105,7 +105,15 @@
                 "name": "What delimiter and encoding does it expect?",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "It defaults to standard comma-separated values, and the OnlyOffice import lets you choose a different delimiter or text encoding if your file needs it."
+                  "text": "Comma, semicolon or tab are detected automatically, and so is the encoding: UTF-8 (with or without BOM), GB18030 / GBK for Chinese ANSI exports, and Latin-1 as the last resort."
+                }
+              },
+              {
+                "@type": "Question",
+                "name": "My CSV shows garbled characters (mojibake) in other tools — will it here?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "Usually not. Mojibake means the file was saved in a legacy code page (GBK / GB18030, Latin-1) and opened as UTF-8. This converter sniffs the bytes first, so Chinese exports from Excel open correctly, and saving writes UTF-8 with a byte-order mark that Excel reads without a wizard."
                 }
               },
               {
@@ -244,9 +252,10 @@
       <p>
         The conversion is handled by OnlyOffice's x2t engine compiled to WebAssembly, which targets the common office
         and text formats — Word, Excel and PowerPoint plus PDF, TXT, HTML and CSV. Because it runs in the browser tab
-        there is no upload queue and no server-imposed size cap, and your data never touches the network. It defaults to
-        comma-separated values, and the import step lets you pick a different delimiter or text encoding — and mark
-        number, date or text columns — before you save the result as XLSX.
+        there is no upload queue and no server-imposed size cap, and your data never touches the network. The delimiter
+        (comma, semicolon or tab) and the text encoding are detected automatically — strict UTF-8 first, then GB18030
+        (the "ANSI" encoding Excel uses for Chinese exports), then Latin-1 — so files that show mojibake elsewhere open
+        with the right characters here. Mark number, date or text columns in the sheet, then save the result as XLSX.
       </p>
 
       <p>
@@ -279,7 +288,14 @@
         </p>
         <h3>What delimiter and encoding does it expect?</h3>
         <p>
-          Standard comma-separated values by default; the import lets you pick a different delimiter or text encoding.
+          Comma, semicolon or tab are detected automatically, and so is the encoding: UTF-8 (with or without BOM),
+          GB18030 / GBK for Chinese "ANSI" exports, and Latin-1 as the last resort.
+        </p>
+        <h3>My CSV shows garbled characters (mojibake) in other tools — will it here?</h3>
+        <p>
+          Usually not. Mojibake means the file was saved in a legacy code page (GBK / GB18030 for Chinese, Latin-1 for
+          Western European) and opened as UTF-8. This converter sniffs the bytes first, so Chinese exports from Excel
+          open correctly, and saving writes UTF-8 with a byte-order mark that Excel reads without a wizard.
         </p>
         <h3>Does the converter work offline?</h3>
         <p>Yes. Once loaded it is an installable PWA, so it keeps working with no internet connection.</p>

--- a/public/zh-CN/convert/csv-to-xlsx.html
+++ b/public/zh-CN/convert/csv-to-xlsx.html
@@ -12,7 +12,7 @@
     <title>在浏览器中把 CSV 转成 XLSX——免费、不传服务器</title>
     <meta
       name="description"
-      content="完全在浏览器中把 CSV 文件转成 XLSX（Excel）——打开后导出为 XLSX。免费、开源、文件留在本地、支持离线。无需 Excel，也无需账号。"
+      content="完全在浏览器中把 CSV 文件转成 XLSX（Excel）——自动识别 GBK/GB18030 编码，中文 CSV 不再乱码。免费、开源、文件留在本地、支持离线。无需 Excel，也无需账号。"
     />
     <link rel="canonical" href="https://edit.chaxus.com/zh-CN/convert/csv-to-xlsx" />
     <link rel="alternate" hreflang="en" href="https://edit.chaxus.com/convert/csv-to-xlsx" />
@@ -99,7 +99,15 @@
                 "name": "它期望什么分隔符和编码？",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "它默认使用标准的逗号分隔值；如果你的文件需要，OnlyOffice 的导入步骤允许你选择不同的分隔符或文本编码。"
+                  "text": "逗号、分号、制表符自动识别；编码同样自动嗅探：UTF-8（有无 BOM 皆可）、GB18030 / GBK、最后 Latin-1。"
+                }
+              },
+              {
+                "@type": "Question",
+                "name": "中文 CSV 在别的工具里乱码，这里会吗？",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "通常不会。乱码是文件用 GBK / GB18030 保存却被当作 UTF-8 读的结果；这里先嗅探字节再解码，Excel 导出的中文 CSV 能正常打开，保存时写入带 BOM 的 UTF-8，Excel 直接打开不乱码。"
                 }
               },
               {
@@ -245,6 +253,15 @@
         XLSX 之前写入公式——而且全程不会把数据上传到任何地方。这是让机器生成的导出变得美观易读的快捷方式。
       </p>
 
+      <h2>为什么别的工具打开中文 CSV 会乱码</h2>
+      <p>
+        乱码几乎总是编码问题：Excel"另存为 CSV"默认用系统代码页（简体中文系统是 GBK / GB18030，也就是 Excel
+        里写的"ANSI"），而多数网页工具、macOS 数据编辑器和程序库一律按 UTF-8 读，于是"客户名称"变成一串"锟斤拷"。
+        反过来，带 UTF-8 BOM 的文件在旧版 Excel 里又会把 BOM 当成内容。这个转换器在打开前先嗅探字节：先按严格 UTF-8
+        解码，失败再按 GB18030，最后 Latin-1 兜底；分隔符（逗号、分号、制表符）同样自动识别。保存回 CSV 时写入带 BOM 的
+        UTF-8，Excel 双击打开不再乱码。整个过程在你的浏览器里完成，文件不上传。
+      </p>
+
       <r-card class="oss"
         ><div class="card-body">
           <strong>开源且可自托管。</strong> 基于 AGPL-3.0 协议——你可以核实文件确实没有被上传，或者运行你自己的副本：
@@ -265,7 +282,12 @@
         <h3>数字和日期列会被识别吗？</h3>
         <p>CSV 会变成一个真正的表格，因此你可以在保存为 XLSX 之前设置数字、日期和文本单元格格式。</p>
         <h3>它期望什么分隔符和编码？</h3>
-        <p>默认使用标准的逗号分隔值；导入步骤允许你选择不同的分隔符或文本编码。</p>
+        <p>逗号、分号、制表符自动识别；编码同样自动嗅探：UTF-8（有无 BOM 皆可）、GB18030 / GBK、最后 Latin-1。</p>
+        <h3>中文 CSV 在别的工具里乱码，这里会吗？</h3>
+        <p>
+          通常不会。乱码是文件用 GBK / GB18030 保存却被当作 UTF-8 读的结果；这里先嗅探字节再解码，Excel 导出的中文 CSV
+          能正常打开，保存时写入带 BOM 的 UTF-8，Excel 直接打开不乱码。
+        </p>
         <h3>这个转换器能离线使用吗？</h3>
         <p>可以。加载后它就是一个可安装的 PWA，因此在没有网络时依然可用。</p>
       </div>


### PR DESCRIPTION
Roadmap direction one, item 2: the zh-CN csv-to-xlsx page gains a section on why Chinese CSVs show mojibake elsewhere and how the converter sniffs UTF-8 → GB18030 → Latin-1; en + zh get a matching FAQ (with FAQPage JSON-LD) and the stale "import step lets you pick delimiter/encoding" claim (v7 behaviour) is corrected. landing-pages.test.ts green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)