### PR TITLE
test(v9): docx tracked changes and header/footer round trips; buildDocx grows header/footer parts

### DIFF
--- a/docs/changelogs/2026-08-15-v9-regression-campaign.md
+++ b/docs/changelogs/2026-08-15-v9-regression-campaign.md
@@ -260,3 +260,7 @@ gh workflow run nightly-corpus.yml -f limit=300     # 手动触发夜间
 - **ranui IIFE 对齐**列入 roadmap 方向九：审计结论=入库 IIFE 与 npm latest 一致，落后的是
   源仓库未发版；L1 防漂移哨兵 `test/unit/ranui-vendor-sync.test.ts` 已落，L2 发版对齐等
   用户在 ran 仓库发 0.5.0-alpha.3。
+- PR 制上线后的合并列车：`e2e-pages` 因 wrangler workerd 并行下载中止崩溃连红 12 次堵住
+  所有 PR → PR #121（串行 + 重试 + 监督重启）；`required_status_checks.strict` 改 false
+  避免 PR 互相打成 BEHIND。对方会话迁到独立 worktree（CLAUDE.md 已记）。
+- docx-features.spec：修订（w:ins/w:del）与页眉页脚往返；`buildDocx` 支持 header/footer 部件。

--- a/test/e2e/docx-features.spec.ts
+++ b/test/e2e/docx-features.spec.ts
@@ -1,0 +1,73 @@
+import { buildDocx, ooxmlText, toBase64, zipEntryNames, zipEntryText } from './lib/ooxml';
+import { expect, test } from './lib/l0';
+
+declare function post(type: string, payload?: Record<string, unknown>): Promise<any>;
+
+/**
+ * Word features a real document carries and the minimal fixture never did
+ * (matrix section B "修订 / 页眉页脚"): tracked changes and header/footer
+ * parts must survive open + save.
+ */
+test.describe('docx feature round trips (real editor)', () => {
+  test.describe.configure({ timeout: 120_000 });
+
+  const roundTrip = (page: import('@playwright/test').Page, name: string, b64: string) =>
+    page.evaluate(
+      async ({ name, b64 }) => {
+        const bin = atob(b64);
+        const bytes = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+        await post('document:open-buffer', { fileName: name, buffer: bytes.buffer, readonly: false });
+        const saved = await post('document:save', {});
+        const out = new Uint8Array(await saved.file.arrayBuffer());
+        let s = '';
+        for (let i = 0; i < out.length; i += 0x8000)
+          s += String.fromCharCode.apply(null, Array.from(out.subarray(i, i + 0x8000)));
+        return btoa(s);
+      },
+      { name, b64 },
+    );
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/embed-demo.html');
+    await expect(page.locator('#status')).toHaveText('ready', { timeout: 60_000 });
+  });
+
+  test('tracked changes (insertion + deletion) survive a save', async ({ page }) => {
+    const body =
+      '<w:p><w:r><w:t xml:space="preserve">Kept text </w:t></w:r>' +
+      '<w:ins w:id="1" w:author="Reviewer" w:date="2026-08-16T00:00:00Z"><w:r><w:t>inserted 插入</w:t></w:r></w:ins>' +
+      '<w:del w:id="2" w:author="Reviewer" w:date="2026-08-16T00:00:00Z"><w:r><w:delText>deleted 删除</w:delText></w:r></w:del>' +
+      '</w:p>';
+    const out = new Uint8Array(
+      Buffer.from(await roundTrip(page, 'revisions.docx', toBase64(buildDocx('', body))), 'base64'),
+    );
+    const xml = zipEntryText(out, 'word/document.xml') || '';
+    expect(xml).toMatch(/<w:ins\b[^>]*w:author="Reviewer"/);
+    expect(xml).toMatch(/<w:del\b[^>]*w:author="Reviewer"/);
+    expect(xml).toContain('<w:delText');
+    expect(ooxmlText(xml)).toContain('inserted 插入');
+    expect(xml).toContain('deleted 删除');
+  });
+
+  test('header and footer parts survive a save', async ({ page }) => {
+    const out = new Uint8Array(
+      Buffer.from(
+        await roundTrip(
+          page,
+          'hf.docx',
+          toBase64(buildDocx('body text', undefined, { headerText: 'Header 页眉', footerText: 'Footer 页脚' })),
+        ),
+        'base64',
+      ),
+    );
+    const names = zipEntryNames(out);
+    const header = names.find((n) => /^word\/header\d+\.xml$/.test(n));
+    const footer = names.find((n) => /^word\/footer\d+\.xml$/.test(n));
+    expect(header, `no header part in ${names.join(',')}`).toBeTruthy();
+    expect(footer, `no footer part in ${names.join(',')}`).toBeTruthy();
+    expect(ooxmlText(zipEntryText(out, header!) || '')).toContain('Header 页眉');
+    expect(ooxmlText(zipEntryText(out, footer!) || '')).toContain('Footer 页脚');
+    expect(ooxmlText(zipEntryText(out, 'word/document.xml') || '')).toContain('body text');
+  });
+});

--- a/test/e2e/lib/ooxml.ts
+++ b/test/e2e/lib/ooxml.ts
@@ -80,8 +80,50 @@ export function makeStoredZip(entries: Array<{ name: string; data: Uint8Array | 
 
 const XML_HEAD = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 
-/** A one-paragraph .docx (or, with `bodyXml`, an arbitrary <w:body> content). */
-export function buildDocx(text: string, bodyXml?: string): Uint8Array {
+/**
+ * A one-paragraph .docx (or, with `bodyXml`, an arbitrary <w:body> content).
+ * `opts.headerText` / `opts.footerText` add a default header/footer part
+ * wired through sectPr.
+ */
+export function buildDocx(
+  text: string,
+  bodyXml?: string,
+  opts: { headerText?: string; footerText?: string } = {},
+): Uint8Array {
+  const REL = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+  const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+  const hf = (tag: 'hdr' | 'ftr', t: string) =>
+    XML_HEAD + `<w:${tag} xmlns:w="${W}"><w:p><w:r><w:t>${t}</w:t></w:r></w:p></w:${tag}>`;
+  const extraOverrides =
+    (opts.headerText
+      ? '<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>'
+      : '') +
+    (opts.footerText
+      ? '<Override PartName="/word/footer1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>'
+      : '');
+  const docRels =
+    (opts.headerText ? `<Relationship Id="rIdH1" Type="${REL}/header" Target="header1.xml"/>` : '') +
+    (opts.footerText ? `<Relationship Id="rIdF1" Type="${REL}/footer" Target="footer1.xml"/>` : '');
+  const sectPr =
+    opts.headerText || opts.footerText
+      ? '<w:sectPr>' +
+        (opts.headerText ? '<w:headerReference w:type="default" r:id="rIdH1"/>' : '') +
+        (opts.footerText ? '<w:footerReference w:type="default" r:id="rIdF1"/>' : '') +
+        '<w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/></w:sectPr>'
+      : '';
+  const extraParts: Array<{ name: string; data: string }> = [];
+  if (opts.headerText) extraParts.push({ name: 'word/header1.xml', data: hf('hdr', opts.headerText) });
+  if (opts.footerText) extraParts.push({ name: 'word/footer1.xml', data: hf('ftr', opts.footerText) });
+  if (docRels) {
+    extraParts.push({
+      name: 'word/_rels/document.xml.rels',
+      data:
+        XML_HEAD +
+        '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+        docRels +
+        '</Relationships>',
+    });
+  }
   return makeStoredZip([
     {
       name: '[Content_Types].xml',
@@ -91,6 +133,7 @@ export function buildDocx(text: string, bodyXml?: string): Uint8Array {
         '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
         '<Default Extension="xml" ContentType="application/xml"/>' +
         '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+        extraOverrides +
         '</Types>',
     },
     {
@@ -105,9 +148,10 @@ export function buildDocx(text: string, bodyXml?: string): Uint8Array {
       name: 'word/document.xml',
       data:
         XML_HEAD +
-        '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
-        `<w:body>${bodyXml ?? `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`}</w:body></w:document>`,
+        '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' +
+        `<w:body>${bodyXml ?? `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`}${sectPr}</w:body></w:document>`,
     },
+    ...extraParts,
   ]);
 }
 


### PR DESCRIPTION
Matrix section B: tracked changes (w:ins/w:del) and header/footer parts survive open + save; buildDocx gains header/footer support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)