### PR TITLE
perf(open): intent-triggered prefetch of the editor engine (hover/focus on Open/New)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ notes. Entries describe what users experience, not internal refactors.
 
 ### Changed
 
+- Hovering (or focusing) an Open / New button starts downloading the editor
+  engine in the background, so the document opens noticeably faster after the
+  click; skipped on Save-Data and 2G connections.
 - The homepage is now a plain landing page and the editor lives at `/editor`
   (`/editor?new=docx`, `/editor?file=<url>`, `/editor?embed=1`). The homepage
   no longer downloads the editor at all, so it loads faster; old links to

--- a/docs/explorations/2026-08-16-intent-prefetch.md
+++ b/docs/explorations/2026-08-16-intent-prefetch.md
@@ -1,0 +1,33 @@
+# 意图触发的编辑器资产预取（2026-08-16）
+
+路线图第 11 项前半（方向四 2 后半）。基线（explorations/2026-08-16-perf-
+baseline-and-api-loader.md）显示冷打开 ≈16 s 里有 ≈9 s 是纯下载：api.js →
+app.js（≈2 MB 原始）→ sdk-all-min.js → sdk-all.js（≈14 MB 原始 / ≈3 MB br）。
+决策是不做无差别 idle 预取（对只读落地页的访客是 3 MB 浪费），改"意图触发"。
+
+## 实现 `lib/prefetch.ts`
+
+- `editorAssetUrls(kind?)`：loader + 该 app 的 app.js + sdk-all-min.js +
+  sdk-all.js（docx→word/documenteditor，xlsx→cell/spreadsheeteditor，
+  pptx→slide/presentationeditor）。
+- `prefetchEditorAssets(kind?)`：往 `<head>` 插 `<link rel="prefetch" as="script">`，
+  按 URL 去重；`navigator.connection.saveData` 或 2G 直接跳过。prefetch 走
+  fetch 事件，SW 的 stale-while-revalidate 会顺手把它们放进 RUNTIME_CACHE，
+  所以随后真正的加载是缓存命中。
+- `prefetchOnIntent(el, kind)`：pointerenter / focus / touchstart 首次触发。
+- 接线：FAB 菜单的 View/Edit（loader）与三个 New（全套）。首页 hero 的
+  同款接线在路由拆分（同日）后改由静态 `public/landing-prefetch.js` 承担
+  （`/` 不再有 bundle），规则与 URL 表与本文件一致。
+
+## 验证
+
+- 单测 `test/unit/prefetch.test.ts` 5 条（URL 映射、文件名→app、去重、
+  Save-Data/2G 否决、intent 只触发一次）。jsdom 的 `<link>` 没有 `.as`
+  属性，要用 `setAttribute('as', 'script')`。
+- 真浏览器：hover "New Word" 后 `<head>` 出现 4 条 prefetch link，
+  Resource Timing 中 4 个请求 initiatorType=link 已发出。
+
+## 度量待办
+
+上线后用 chrome-devtools 复测"hover 1 s 后点 New Word"的就绪时间；预期
+把 sdk-all.js 的 6.6 s 从关键路径挪到 hover 与点击之间。

--- a/docs/superpowers/plans/2026-08-15-next-phase-roadmap.md
+++ b/docs/superpowers/plans/2026-08-15-next-phase-roadmap.md
@@ -441,7 +441,7 @@ ranui 复制并**入库**。用户指出仍在用"历史有问题的版本"。
 | 8   | PPT E2E（方向四 1）                              | 小时级    | ✅ 已由战役覆盖：format-parity / embed-save-default / resave-idempotence / visual-roundtrip / corpus 均含 pptx 打开-编辑-保存-导 PDF                    |
 | 9   | 性能基线审计（方向四 2 前半）                    | 半天      | ✅ 2026-08-16 线上基线已测（见方向四 2 的"基线"小节）+ 首刀：api.js 改按需加载（PR）                                                                    |
 | 10  | 首页/编辑器路由拆分（方向六 2，基线之后做）      | 1~2 天    | ✅ 2026-08-16 `/` 静态落地（无编辑器 bundle）+ `/editor` 编辑器入口（editor.html），旧深链/iframe 内联重定向，见 explorations/2026-08-16-route-split.md |
-| 11  | 预取/SW 预缓存决策（方向四 2 后半，拆分后再测）  | 1 天      | ↻ 决策已给：不做无差别 idle 预取，改"意图触发预取"（见方向四 2）；SW 预缓存待路由拆分后测                                                               |
+| 11  | 预取/SW 预缓存决策（方向四 2 后半，拆分后再测）  | 1 天      | ✅ 2026-08-16 前半：意图触发预取已落地（`lib/prefetch.ts`，hero + FAB 的 Open/New 按钮 hover 即预取 loader/app.js/sdk-all）；SW 预缓存待路由拆分后测    |
 | 12  | WebMCP 薄适配 + origin trial（专节）             | 1 天      |                                                                                                                                                         |
 | 13  | 外链发布稿（方向二 3，指向 /changelog 与新功能） | 用户主导  |                                                                                                                                                         |
 | 14  | agent-collab（方向五）                           | 大周期    |                                                                                                                                                         |

--- a/lib/prefetch.ts
+++ b/lib/prefetch.ts
@@ -1,0 +1,101 @@
+/**
+ * Intent-triggered prefetch of the editor's heavy assets.
+ *
+ * Opening a document cold downloads ~3 MB (brotli) of engine before anything
+ * renders: the DocsAPI loader, the app shell (app.js ~2 MB raw) and the SDK
+ * (sdk-all-min.js + sdk-all.js, ~16 MB raw / ~3 MB compressed) of the app
+ * matching the file type. On the production baseline that is ~9 s of a ~16 s
+ * cold open. Prefetching it unconditionally on the landing page would waste
+ * that on visitors who only read, so it is triggered by intent instead: the
+ * moment a pointer hovers (or focus lands on) an Open / New button, the files
+ * are requested with `<link rel="prefetch">` -- lowest priority, cached by
+ * the browser (and by the service worker's stale-while-revalidate cache), so
+ * the real load a moment later is a cache hit. Idempotent per URL.
+ *
+ * Skipped when the visitor asked for data saving or is on a 2G-class link.
+ */
+
+export type EditorKind = 'docx' | 'xlsx' | 'pptx';
+
+const APP_DIR: Record<EditorKind, string> = {
+  docx: 'documenteditor',
+  xlsx: 'spreadsheeteditor',
+  pptx: 'presentationeditor',
+};
+const SDK_DIR: Record<EditorKind, string> = { docx: 'word', xlsx: 'cell', pptx: 'slide' };
+
+const API_LOADER = 'web-apps/apps/api/documents/api.js';
+
+const requested = new Set<string>();
+
+function connectionAllowsPrefetch(): boolean {
+  const conn = (navigator as Navigator & { connection?: { saveData?: boolean; effectiveType?: string } }).connection;
+  if (!conn) return true;
+  if (conn.saveData) return false;
+  return !(conn.effectiveType === 'slow-2g' || conn.effectiveType === '2g');
+}
+
+/** URLs (relative to the app root) that a given kind of open will need first. */
+export function editorAssetUrls(kind?: EditorKind): string[] {
+  const urls = [API_LOADER];
+  if (kind) {
+    urls.push(
+      `web-apps/apps/${APP_DIR[kind]}/main/app.js`,
+      `sdkjs/${SDK_DIR[kind]}/sdk-all-min.js`,
+      `sdkjs/${SDK_DIR[kind]}/sdk-all.js`,
+    );
+  }
+  return urls;
+}
+
+/** Kind for a file name / extension, or undefined when the editor cannot be predicted (csv, pdf, unknown). */
+export function editorKindForFile(nameOrExt: string): EditorKind | undefined {
+  const ext = nameOrExt.toLowerCase().split('.').pop() || '';
+  if (ext === 'docx' || ext === 'doc') return 'docx';
+  if (ext === 'xlsx' || ext === 'xls' || ext === 'csv') return 'xlsx';
+  if (ext === 'pptx' || ext === 'ppt') return 'pptx';
+  return undefined;
+}
+
+/**
+ * Prefetch the loader and, when the kind is known, that app's shell + SDK.
+ * Returns the URLs newly requested (empty when everything was already
+ * requested or the connection vetoed it).
+ */
+export function prefetchEditorAssets(kind?: EditorKind): string[] {
+  if (typeof document === 'undefined' || !connectionAllowsPrefetch()) return [];
+  const added: string[] = [];
+  for (const url of editorAssetUrls(kind)) {
+    if (requested.has(url)) continue;
+    requested.add(url);
+    const link = document.createElement('link');
+    link.rel = 'prefetch';
+    link.setAttribute('as', 'script');
+    link.href = url;
+    document.head.appendChild(link);
+    added.push(url);
+  }
+  return added;
+}
+
+/**
+ * Attach the intent triggers to an element: first hover / focus / touch fires
+ * the prefetch once. `kind` may be a function when it depends on state.
+ */
+export function prefetchOnIntent(el: Element | null, kind?: EditorKind | (() => EditorKind | undefined)): void {
+  if (!el) return;
+  let fired = false;
+  const fire = () => {
+    if (fired) return;
+    fired = true;
+    prefetchEditorAssets(typeof kind === 'function' ? kind() : kind);
+  };
+  for (const evt of ['pointerenter', 'focus', 'touchstart']) {
+    el.addEventListener(evt, fire, { passive: true, once: true });
+  }
+}
+
+/** Test hook. */
+export function resetPrefetchState(): void {
+  requested.clear();
+}

--- a/lib/ui.ts
+++ b/lib/ui.ts
@@ -1,5 +1,6 @@
 import { localStorageGetItem, localStorageSetItem } from 'ranuts/utils';
 import { ButtonBuilder, Div, View } from 'ranui/builder';
+import { prefetchEditorAssets, type EditorKind } from './prefetch';
 import { t } from '@ranuts/shared/i18n';
 import { showLoading } from './loading';
 import { onCreateNew, onOpenDocument } from './document';
@@ -115,6 +116,7 @@ function buildFab(): { container: HTMLElement; button: HTMLElement } {
     text: string,
     onClick: () => void | Promise<void>,
     showLoadingImmediately = true,
+    prefetchKind?: EditorKind | 'loader',
   ): HTMLDivElement =>
     Div()
       .class('fab-menu-item')
@@ -122,6 +124,10 @@ function buildFab(): { container: HTMLElement; button: HTMLElement } {
         ButtonBuilder()
           .class('fab-menu-button')
           .text(text)
+          // Hovering a New/Open entry is intent: start pulling the engine now.
+          .on('pointerenter', () => {
+            if (prefetchKind) prefetchEditorAssets(prefetchKind === 'loader' ? undefined : prefetchKind);
+          })
           .on('click', async () => {
             hideMenu();
             // Only show loading immediately if specified (for operations that don't require user interaction)
@@ -162,16 +168,32 @@ function buildFab(): { container: HTMLElement; button: HTMLElement } {
           // If user selected file, document will be opened in handleChange
         },
         false, // Don't show loading immediately - wait for file selection
+        'loader',
       ),
-      createMenuButton(t('newWord'), async () => {
-        await onCreateNew('.docx');
-      }),
-      createMenuButton(t('newExcel'), async () => {
-        await onCreateNew('.xlsx');
-      }),
-      createMenuButton(t('newPowerPoint'), async () => {
-        await onCreateNew('.pptx');
-      }),
+      createMenuButton(
+        t('newWord'),
+        async () => {
+          await onCreateNew('.docx');
+        },
+        true,
+        'docx',
+      ),
+      createMenuButton(
+        t('newExcel'),
+        async () => {
+          await onCreateNew('.xlsx');
+        },
+        true,
+        'xlsx',
+      ),
+      createMenuButton(
+        t('newPowerPoint'),
+        async () => {
+          await onCreateNew('.pptx');
+        },
+        true,
+        'pptx',
+      ),
       // AI assistant entry — lazy-loads the agent panel on first click (no bundle
       // cost until used). Idempotent: if a panel already exists (e.g. opened via
       // ?agent=1 or a prior click), do nothing and let its own launcher reopen it.

--- a/test/e2e/app-smoke.spec.ts
+++ b/test/e2e/app-smoke.spec.ts
@@ -22,7 +22,9 @@ test('/editor?new=docx mounts the editor shell; legacy /?new=docx redirects ther
   await page.goto('/?new=docx');
   await page.waitForURL(/\/editor\?new=docx/);
   await expect(page.locator('#app')).toBeVisible();
-  await expect(page.locator('#iframe')).toBeAttached();
+  // The #iframe placeholder is replaced by the DocsAPI iframe (name=frameEditor,
+  // no id) as soon as the editor mounts, so accept either state.
+  await expect(page.locator('#iframe, iframe[name="frameEditor"]').first()).toBeAttached();
   await expect(page.locator('#fab-container')).toBeAttached();
   await expect(page.locator('#control-panel-container')).toBeAttached();
   expect(pageErrors).toEqual([]);

--- a/test/unit/prefetch.test.ts
+++ b/test/unit/prefetch.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  editorAssetUrls,
+  editorKindForFile,
+  prefetchEditorAssets,
+  prefetchOnIntent,
+  resetPrefetchState,
+} from '../../lib/prefetch';
+
+const links = () => [...document.head.querySelectorAll('link[rel="prefetch"]')].map((l) => l.getAttribute('href'));
+
+afterEach(() => {
+  resetPrefetchState();
+  document.head.querySelectorAll('link[rel="prefetch"]').forEach((l) => l.remove());
+  Object.defineProperty(navigator, 'connection', { configurable: true, value: undefined });
+  vi.restoreAllMocks();
+});
+
+describe('editor asset prefetch', () => {
+  it('maps a kind to its loader + app shell + SDK bundles', () => {
+    expect(editorAssetUrls()).toEqual(['web-apps/apps/api/documents/api.js']);
+    expect(editorAssetUrls('xlsx')).toEqual([
+      'web-apps/apps/api/documents/api.js',
+      'web-apps/apps/spreadsheeteditor/main/app.js',
+      'sdkjs/cell/sdk-all-min.js',
+      'sdkjs/cell/sdk-all.js',
+    ]);
+  });
+
+  it('predicts the editor from a file name (csv -> spreadsheet, pdf -> unknown)', () => {
+    expect(editorKindForFile('a.DOC')).toBe('docx');
+    expect(editorKindForFile('report.csv')).toBe('xlsx');
+    expect(editorKindForFile('deck.ppt')).toBe('pptx');
+    expect(editorKindForFile('scan.pdf')).toBeUndefined();
+  });
+
+  it('adds one <link rel=prefetch as=script> per URL and never repeats a URL', () => {
+    expect(prefetchEditorAssets('docx')).toHaveLength(4);
+    expect(links()).toEqual(editorAssetUrls('docx'));
+    expect(prefetchEditorAssets('docx')).toEqual([]);
+    // Another kind only adds what is new (the loader is shared).
+    expect(prefetchEditorAssets('pptx')).toHaveLength(3);
+    expect(document.head.querySelector('link[rel="prefetch"]')?.getAttribute('as')).toBe('script');
+  });
+
+  it('respects Save-Data and 2G-class connections', () => {
+    Object.defineProperty(navigator, 'connection', { configurable: true, value: { saveData: true } });
+    expect(prefetchEditorAssets('docx')).toEqual([]);
+    Object.defineProperty(navigator, 'connection', { configurable: true, value: { effectiveType: '2g' } });
+    expect(prefetchEditorAssets('docx')).toEqual([]);
+    Object.defineProperty(navigator, 'connection', { configurable: true, value: { effectiveType: '4g' } });
+    expect(prefetchEditorAssets('docx')).toHaveLength(4);
+  });
+
+  it('prefetchOnIntent fires once on the first hover/focus/touch', () => {
+    const btn = document.createElement('button');
+    prefetchOnIntent(btn, 'xlsx');
+    btn.dispatchEvent(new Event('focus'));
+    btn.dispatchEvent(new Event('pointerenter'));
+    expect(links()).toEqual(editorAssetUrls('xlsx'));
+    expect(links()).toHaveLength(4);
+    prefetchOnIntent(null); // tolerated
+  });
+});


### PR DESCRIPTION
## Summary
Roadmap item 11 (first half): intent-triggered prefetch instead of blanket idle prefetch.
- `lib/prefetch.ts`: `<link rel=prefetch as=script>` for `api.js` + the matching app's `app.js` / `sdk-all-min.js` / `sdk-all.js`; deduped; skipped on Save-Data / 2G
- Wired to the hero Open/New buttons (`index.ts`) and the FAB menu entries (`lib/ui.ts`); Open prefetches only the loader (type unknown), New * prefetch the full set
- 5 unit tests; real-browser check: hover "New Word" → 4 prefetch links, 4 requests with initiatorType=link
- Docs: `docs/explorations/2026-08-16-intent-prefetch.md`; roadmap 11 first half ✅; CHANGELOG (+ regenerated /changelog pages)

## Test plan
- [x] unit + lint:ts
- [x] manual (chrome-devtools)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)