### PR TITLE
feat(routes): static landing at / and the editor at /editor, with legacy deep-link redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ notes. Entries describe what users experience, not internal refactors.
 
 ### Changed
 
+- The homepage is now a plain landing page and the editor lives at `/editor`
+  (`/editor?new=docx`, `/editor?file=<url>`, `/editor?embed=1`). The homepage
+  no longer downloads the editor at all, so it loads faster; old links to
+  `/?src=`, `/?file=`, `/?new=` and `/?embed=1` keep working (they redirect).
 - The iframe embedding demo (`/embed-demo.html`) now uses the same design
   system as the rest of the site (ranui components and tokens, dark mode,
   shared top bar) instead of its own ad-hoc styling; the demo's postMessage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,9 @@ public/               # v9 vendor（sdkjs / web-apps / x2t.wasm.gz / XOR 字体�
 bin/                  # build.sh、test-e2e-docker.sh、font-catalog.mjs、bundle_single_html.js、build-pages.mjs（markdown→/help /changelog；由 vite 插件 `generated-pages` 在 build/dev 时渲染进 public/，产物不入库）
 content/              # 生成页面的 markdown 源（content/<locale>/*.md，frontmatter title/description）
 docs/                 # embed-api / fonts 文档、explorations/（每次改动的记录）、superpowers/plans/
-index.ts              # 应用入口（初始化事件、UI、PWA）
-index.html            # HTML 入口
+index.ts              # 编辑器入口（初始化事件、UI、PWA），挂在 editor.html
+index.html            # `/`：静态落地页（无编辑器 bundle；CTA 跳 /editor，旧深链内联脚本重定向）
+editor.html           # `/editor`：编辑器页面（?new= ?file= ?src= ?embed=1 ?open=local）
 ```
 
 ---
@@ -91,7 +92,7 @@ index.html            # HTML 入口
 
 允许父页面通过 `postMessage` 控制编辑器。触发条件：
 
-- URL 含 `?embed=`、`?embed=1`、`?embed=true`、`?embedded=1` 等参数
+- URL 含 `?embed=`、`?embed=1`、`?embed=true`、`?embedded=1` 等参数（编辑器路由是 `/editor`；`/` 是静态落地页，遇到这些参数或被 iframe 嵌入时带参跳到 `/editor`）
 - 或页面被嵌入 iframe（`window.parent !== window`）
 
 支持的消息类型：

--- a/content/en/help.md
+++ b/content/en/help.md
@@ -11,11 +11,11 @@ lead: Practical answers for using the editor. Everything runs inside your browse
 
 ### Which file formats can I open?
 
-Word (`.docx`, legacy `.doc`), Excel (`.xlsx`, legacy `.xls`), PowerPoint (`.pptx`, legacy `.ppt`), comma-separated values (`.csv`) and PDF (`.pdf`). Pick a file with **Open**, drag and drop it onto the page, or pass a URL with `?file=https://…` / `?src=https://…` (the server hosting the file must allow cross-origin requests).
+Word (`.docx`, legacy `.doc`), Excel (`.xlsx`, legacy `.xls`), PowerPoint (`.pptx`, legacy `.ppt`), comma-separated values (`.csv`) and PDF (`.pdf`). Pick a file with **Open**, drag and drop it onto the page, or pass a URL with `/editor?file=https://…` / `/editor?src=https://…` (the server hosting the file must allow cross-origin requests).
 
 ### How do I create a new document?
 
-Use **New Word / New Excel / New PowerPoint** on the homepage, or open `/?new=docx`, `/?new=xlsx`, `/?new=pptx` directly. Nothing is created on any server: the blank document exists only in your tab until you download it.
+Use **New Word / New Excel / New PowerPoint** on the homepage, or open `/editor?new=docx`, `/editor?new=xlsx`, `/editor?new=pptx` directly. Nothing is created on any server: the blank document exists only in your tab until you download it.
 
 ### Is there a file size limit?
 
@@ -53,7 +53,7 @@ Not as free-flowing text — PDF is a fixed-layout format. To change wording, op
 
 ### Can I open a document read-only?
 
-Yes. Add `&readonly=1` to a `?file=` link, or send `document:set-readonly` through the embed API. Read-only can be switched on and off at runtime without reloading the document.
+Yes. Add `&readonly=1` to a `/editor?file=` link, or send `document:set-readonly` through the embed API. Read-only can be switched on and off at runtime without reloading the document.
 
 ### Can I put the editor inside my own web app?
 

--- a/content/zh-CN/help.md
+++ b/content/zh-CN/help.md
@@ -11,11 +11,11 @@ lead: 使用编辑器的实用解答。一切都在你的浏览器标签页内�
 
 ### 支持打开哪些格式？
 
-Word（`.docx`，以及旧版 `.doc`）、Excel（`.xlsx`，以及旧版 `.xls`）、PowerPoint（`.pptx`，以及旧版 `.ppt`）、CSV（`.csv`）和 PDF（`.pdf`）。点击**打开**选择文件、把文件拖到页面上，或用 `?file=https://…` / `?src=https://…` 传入网址（文件所在服务器需允许跨域请求）。
+Word（`.docx`，以及旧版 `.doc`）、Excel（`.xlsx`，以及旧版 `.xls`）、PowerPoint（`.pptx`，以及旧版 `.ppt`）、CSV（`.csv`）和 PDF（`.pdf`）。点击**打开**选择文件、把文件拖到页面上，或用 `/editor?file=https://…` / `/editor?src=https://…` 传入网址（文件所在服务器需允许跨域请求）。
 
 ### 怎么新建文档？
 
-首页的**新建 Word / 新建 Excel / 新建 PowerPoint**，或直接访问 `/?new=docx`、`/?new=xlsx`、`/?new=pptx`。服务器上不会创建任何东西：空白文档只存在于你的标签页里，直到你下载它。
+首页的**新建 Word / 新建 Excel / 新建 PowerPoint**，或直接访问 `/editor?new=docx`、`/editor?new=xlsx`、`/editor?new=pptx`。服务器上不会创建任何东西：空白文档只存在于你的标签页里，直到你下载它。
 
 ### 有文件大小限制吗？
 
@@ -53,7 +53,7 @@ Word（`.docx`，以及旧版 `.doc`）、Excel（`.xlsx`，以及旧版 `.xls`�
 
 ### 能以只读方式打开吗？
 
-能。在 `?file=` 链接后加 `&readonly=1`，或通过嵌入 API 发送 `document:set-readonly`。只读可以在运行时随时开关，不需要重新加载文档。
+能。在 `/editor?file=` 链接后加 `&readonly=1`，或通过嵌入 API 发送 `document:set-readonly`。只读可以在运行时随时开关，不需要重新加载文档。
 
 ### 能把编辑器放进我自己的网站吗？
 

--- a/docs/embed-api.md
+++ b/docs/embed-api.md
@@ -11,15 +11,20 @@ A working demo is available at `/embed-demo.html` (includes sha256 logging for d
 ```html
 <iframe
   id="documentEditor"
-  src="https://your-deployment/?embed=1"
+  src="https://your-deployment/editor?embed=1"
   style="width: 100%; height: 720px; border: 0"
 ></iframe>
 ```
 
+> The editor lives at `/editor`; the homepage `/` is a static landing page. Older links to `/?embed=1`, `/?src=`, `/?file=` and `/?new=` still work -- `/` redirects them to `/editor` with the same query.
+
 To restrict messages to a specific origin, add `embedOrigin`:
 
 ```html
-<iframe id="documentEditor" src="https://your-deployment/?embed=1&embedOrigin=https://your-system.example.com"></iframe>
+<iframe
+  id="documentEditor"
+  src="https://your-deployment/editor?embed=1&embedOrigin=https://your-system.example.com"
+></iframe>
 ```
 
 ---

--- a/docs/embed-api.zh.md
+++ b/docs/embed-api.zh.md
@@ -11,15 +11,20 @@
 ```html
 <iframe
   id="documentEditor"
-  src="https://your-deployment/?embed=1"
+  src="https://your-deployment/editor?embed=1"
   style="width: 100%; height: 720px; border: 0"
 ></iframe>
 ```
 
+> 编辑器位于 `/editor`，首页 `/` 是纯静态落地页。旧链接 `/?embed=1`、`/?src=`、`/?file=`、`/?new=` 仍然有效——`/` 会带同样的参数跳转到 `/editor`。
+
 如需限制只接受指定来源的消息，增加 `embedOrigin`：
 
 ```html
-<iframe id="documentEditor" src="https://your-deployment/?embed=1&embedOrigin=https://your-system.example.com"></iframe>
+<iframe
+  id="documentEditor"
+  src="https://your-deployment/editor?embed=1&embedOrigin=https://your-system.example.com"
+></iframe>
 ```
 
 ---

--- a/docs/explorations/2026-08-16-route-split.md
+++ b/docs/explorations/2026-08-16-route-split.md
@@ -1,0 +1,49 @@
+# 首页 / 编辑器路由拆分（2026-08-16）
+
+路线图第 10 项（方向六 2）。此前 `/` 一页三用：SEO 落地页 + 新建 + 编辑，
+首屏被编辑器 bundle 拖累、URL 不可分享、刷新/后退语义混乱。
+
+## 目标形态（已落地）
+
+| 路由      | 文件          | 内容                                                                                                                                                                                |
+| --------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/`       | `index.html`  | 纯静态落地页：原 hero + SEO/JSON-LD 原样保留；**不再挂 `index.ts`**，与 `/zh-CN/` 同构（ranui IIFE + `lang-switch.js` + `open-local.js` + 新的 `landing-prefetch.js`），内联注册 SW |
+| `/editor` | `editor.html` | 编辑器：`?new=docx\|xlsx\|pptx`、`?file=` / `?src=`（+ `readonly`）、`?embed=1`、`?open=local`、`?agent`；`noindex`；挂 `index.ts`                                                  |
+
+- Vite 改双入口 MPA（`rollupOptions.input = { main, editor }`）；`cleanUrls`
+  中间件在 dev 下把 `/editor` 解析到根目录 `editor.html`（preview / CF Pages
+  本就按 `.html` 自动解析）。
+- **向后兼容**：`index.html` `<head>` 顶部一段内联脚本——URL 带
+  `file|src|new|open|embed|embedded|readonly|agent` 任一参数，或页面处于
+  iframe 中（旧的裸 `/` 嵌入），立刻 `location.replace('/editor' + search)`
+  （iframe 无参数时补 `?embed=1`）。E2E 里所有 `page.goto('/?...')` 因此
+  不改也能过。
+- hero CTA：Open → `data-open-local="/editor?open=local"`（IndexedDB 交接，
+  与 zh 首页同一份 `open-local.js`，accept 加了 `.pdf`）；New * →
+  `<a href="/editor?new=…">`。语言切换器改 `data-href` 走 `lang-switch.js`。
+- `index.ts`：删掉 hero 接线；裸 `/editor`（无参数、非嵌入）与失效的
+  `?open=local` 都 `location.replace('/')`；其余不变。
+- `public/sw.js` 预缓存加 `./editor`、`./editor.html`。
+- `embed-demo.html` iframe → `./editor?embed=1`；docs/embed-api(.zh).md、
+  readme(.zh).md、help 内容、embed 落地页示例统一改 `/editor?...` 并注明旧
+  链接仍可用；zh 首页与 zh 落地页的 `?locale=zh-CN&new=docx` 改到 `/editor`。
+- 意图预取：`/` 上没有 bundle，用 `public/landing-prefetch.js`（与
+  `lib/prefetch.ts` 同一套 URL 与规则）挂到 `#hero-open` 与 `[data-prefetch]`。
+
+## 验证
+
+- 单测 499 绿（landing-pages 契约把 zh CTA 允许集改为 `/editor?locale=…`）。
+- E2E：`app-smoke.spec` 改写为三条——`/` 是静态落地（有 hero、无
+  `#iframe`/`#fab-container`、URL 不含 /editor）、`/?new=docx` 重定向到
+  `/editor?new=docx` 且编辑器壳就位、裸 `/editor` 回到 `/`；main-site /
+  entry-paths / embed-api / embed-save-default 沿旧 URL 全绿（靠重定向）；
+  全套 E2E 结果见 PR。
+
+## 收益与后续
+
+- 首页彻底不下载编辑器 JS（此前即便去掉 api.js 同步标签，`index.ts` 及其
+  依赖仍随首页加载）；LCP 复测待部署后用同一方法量。
+- 主题切换/`?locale` 等首页交互全部由静态脚本承担，`/` 与 `/zh-CN/` 现在是
+  同一形态，多语言落地页（方向八 3）可以直接复制。
+- SW 更新策略仍只在编辑器页处理（那里才有"文档打开中"的状态）；首页只做
+  裸注册。

--- a/docs/superpowers/plans/2026-08-15-next-phase-roadmap.md
+++ b/docs/superpowers/plans/2026-08-15-next-phase-roadmap.md
@@ -428,22 +428,22 @@ ranui 复制并**入库**。用户指出仍在用"历史有问题的版本"。
 
 ## 原执行顺序（2026-08-15 更新：加入方向六、七，第 1 项已完成）
 
-| 序  | 事项                                             | 体量      | 状态                                                                                                                                          |
-| --- | ------------------------------------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | 部署后 issue 验证清单（方向四 3）                | 半天      | ✅ 已完成，关 6 个                                                                                                                            |
-| 2   | CHANGELOG.md + 发布 v9 release（方向七 3 前半）  | 1 小时    |                                                                                                                                               |
-| 3   | /open/pdf 落地页 + 内容收尾同步（方向一）        | 半天~1 天 | ✅ 2026-08-16 落地页 + sitemap/llms/首页卡片/页脚互链 + `landing-pages.test.ts` 契约；方向一 2/3（CSV 乱码长文、只读说明）待做                |
-| 4   | vendor noindex + GSC 提交（方向二 1/2）          | 1 小时    | ✅ 2026-08-16 noindex 已上（`_headers` + hosting-contract 钉住）；GSC/Bing 提交需站长权限，待用户                                             |
-| 5   | embed-demo 对齐 ran 设计体系（方向六 1）         | 半天      | ✅ 2026-08-16 r-button/r-input/r-checkbox/r-card/r-theme-switch + token；E2E 契约不变，见 explorations/2026-08-16-embed-demo-ranui-restyle.md |
-| 6   | markdown→HTML 生成器（方向七 1，后两项的前置）   | 半天~1 天 | ✅ 2026-08-16 `bin/build-pages.mjs`（locale × page，marked，FAQ/TOC 自动；vite 插件构建期渲染、产物不入库）                                   |
-| 7   | /help 帮助中心 + /changelog 页（方向七 2/3）     | 1~2 天    | ✅ 2026-08-16 /help、/help/embed-api、/changelog（en + zh-CN）；CHANGELOG 中文版待补                                                          |
-| 8   | PPT E2E（方向四 1）                              | 小时级    | ✅ 已由战役覆盖：format-parity / embed-save-default / resave-idempotence / visual-roundtrip / corpus 均含 pptx 打开-编辑-保存-导 PDF          |
-| 9   | 性能基线审计（方向四 2 前半）                    | 半天      | ✅ 2026-08-16 线上基线已测（见方向四 2 的"基线"小节）+ 首刀：api.js 改按需加载（PR）                                                          |
-| 10  | 首页/编辑器路由拆分（方向六 2，基线之后做）      | 1~2 天    |                                                                                                                                               |
-| 11  | 预取/SW 预缓存决策（方向四 2 后半，拆分后再测）  | 1 天      | ↻ 决策已给：不做无差别 idle 预取，改"意图触发预取"（见方向四 2）；SW 预缓存待路由拆分后测                                                     |
-| 12  | WebMCP 薄适配 + origin trial（专节）             | 1 天      |                                                                                                                                               |
-| 13  | 外链发布稿（方向二 3，指向 /changelog 与新功能） | 用户主导  |                                                                                                                                               |
-| 14  | agent-collab（方向五）                           | 大周期    |                                                                                                                                               |
+| 序  | 事项                                             | 体量      | 状态                                                                                                                                                    |
+| --- | ------------------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | 部署后 issue 验证清单（方向四 3）                | 半天      | ✅ 已完成，关 6 个                                                                                                                                      |
+| 2   | CHANGELOG.md + 发布 v9 release（方向七 3 前半）  | 1 小时    |                                                                                                                                                         |
+| 3   | /open/pdf 落地页 + 内容收尾同步（方向一）        | 半天~1 天 | ✅ 2026-08-16 落地页 + sitemap/llms/首页卡片/页脚互链 + `landing-pages.test.ts` 契约；方向一 2/3（CSV 乱码长文、只读说明）待做                          |
+| 4   | vendor noindex + GSC 提交（方向二 1/2）          | 1 小时    | ✅ 2026-08-16 noindex 已上（`_headers` + hosting-contract 钉住）；GSC/Bing 提交需站长权限，待用户                                                       |
+| 5   | embed-demo 对齐 ran 设计体系（方向六 1）         | 半天      | ✅ 2026-08-16 r-button/r-input/r-checkbox/r-card/r-theme-switch + token；E2E 契约不变，见 explorations/2026-08-16-embed-demo-ranui-restyle.md           |
+| 6   | markdown→HTML 生成器（方向七 1，后两项的前置）   | 半天~1 天 | ✅ 2026-08-16 `bin/build-pages.mjs`（locale × page，marked，FAQ/TOC 自动；vite 插件构建期渲染、产物不入库）                                             |
+| 7   | /help 帮助中心 + /changelog 页（方向七 2/3）     | 1~2 天    | ✅ 2026-08-16 /help、/help/embed-api、/changelog（en + zh-CN）；CHANGELOG 中文版待补                                                                    |
+| 8   | PPT E2E（方向四 1）                              | 小时级    | ✅ 已由战役覆盖：format-parity / embed-save-default / resave-idempotence / visual-roundtrip / corpus 均含 pptx 打开-编辑-保存-导 PDF                    |
+| 9   | 性能基线审计（方向四 2 前半）                    | 半天      | ✅ 2026-08-16 线上基线已测（见方向四 2 的"基线"小节）+ 首刀：api.js 改按需加载（PR）                                                                    |
+| 10  | 首页/编辑器路由拆分（方向六 2，基线之后做）      | 1~2 天    | ✅ 2026-08-16 `/` 静态落地（无编辑器 bundle）+ `/editor` 编辑器入口（editor.html），旧深链/iframe 内联重定向，见 explorations/2026-08-16-route-split.md |
+| 11  | 预取/SW 预缓存决策（方向四 2 后半，拆分后再测）  | 1 天      | ↻ 决策已给：不做无差别 idle 预取，改"意图触发预取"（见方向四 2）；SW 预缓存待路由拆分后测                                                               |
+| 12  | WebMCP 薄适配 + origin trial（专节）             | 1 天      |                                                                                                                                                         |
+| 13  | 外链发布稿（方向二 3，指向 /changelog 与新功能） | 用户主导  |                                                                                                                                                         |
+| 14  | agent-collab（方向五）                           | 大周期    |                                                                                                                                                         |
 
 排序理由：
 

--- a/editor.html
+++ b/editor.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <link href="img/64.png" rel="shortcut icon" />
+    <link rel="icon" type="image/png" href="img/64.png" />
+    <link rel="manifest" href="manifest.json" />
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#000000" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+
+    <!-- The editor route: /editor?new=docx|xlsx|pptx creates, /editor?file=<url> or
+         ?src=<url> opens, /editor?embed=1 is the iframe integration surface, and
+         /editor?open=local takes a file the landing page stashed in IndexedDB.
+         The homepage / is a static landing page (index.html) that never loads the
+         editor stack; it redirects legacy deep links (/?src=, /?embed=1, ...) here.
+         Not a page for search engines. -->
+    <title>Document Editor</title>
+    <meta name="robots" content="noindex" />
+    <!-- No-flash theme restore: apply a forced light/dark before first paint so a
+         dark-mode visitor never sees a white flash. 'system' leaves the attributes
+         off and the token layer's media query decides. Kept inline and tiny. -->
+    <script>
+      try {
+        var t = localStorage.getItem('ran-theme');
+        if (t === 'dark' || t === 'light') {
+          document.documentElement.setAttribute('data-ran-theme', t);
+          document.documentElement.setAttribute('theme', t);
+        }
+      } catch (e) {}
+    </script>
+    <!-- ranui design-token layer (vendored from ranui/dist/ranui.css, re-synced by bin/build.sh).
+         Loaded before home.css so the landing hero's --ran-* tokens resolve on first paint. -->
+    <link rel="stylesheet" href="/ran-fonts/fonts.css" />
+    <link rel="stylesheet" href="/ran-tokens.css" />
+  </head>
+
+  <body>
+    <div id="app" class="w-full h-full">
+      <div id="iframe"></div>
+    </div>
+
+    <noscript>
+      <p style="max-width: 720px; margin: 0 auto; padding: 24px; font-family: system-ui, sans-serif">
+        This editor requires JavaScript to run. Please enable JavaScript to open or create a document.
+      </p>
+    </noscript>
+  </body>
+  <script type="module" src="./index.ts"></script>
+</html>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,22 @@
     <link href="img/64.png" rel="shortcut icon" />
     <link rel="icon" type="image/png" href="img/64.png" />
     <link rel="manifest" href="manifest.json" />
+    <!-- Route split: / is a static landing page, /editor hosts the app. Deep links
+         that used to target / (?file= ?src= ?new= ?open=local ?embed= ?embedded=
+         ?readonly ?agent) and any embedding iframe keep working: hand them to
+         /editor with the same query before anything renders. -->
+    <script>
+      (function () {
+        try {
+          var q = location.search;
+          var deep = /[?&](file|src|new|open|embed|embedded|readonly|agent)(=|&|$)/.test(q);
+          var framed = window.parent !== window;
+          if (deep || framed) {
+            location.replace('/editor' + (q || (framed ? '?embed=1' : '')) + location.hash);
+          }
+        } catch (e) {}
+      })();
+    </script>
     <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
     <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#000000" />
     <meta name="mobile-web-app-capable" content="yes" />
@@ -148,10 +164,16 @@
       }
     </script>
 
-    <!-- The OnlyOffice DocsAPI loader is fetched on demand (lib/onlyoffice-editor.ts
-         loadEditorApi) when a document is opened or created; a synchronous tag here
-         was render-blocking (~0.5 s of LCP) for visitors who only read the landing. -->
-    <link rel="prefetch" href="/web-apps/apps/api/documents/api.js" as="script" />
+    <!-- Static page: ranui components come from the vendored per-component IIFEs
+         (same as every other landing page); the file picker hand-off to /editor is
+         public/open-local.js; the language select is public/lang-switch.js. -->
+    <script src="/ranui-iife/button.iife.js" defer></script>
+    <script src="/ranui-iife/card.iife.js" defer></script>
+    <script src="/ranui-iife/select.iife.js" defer></script>
+    <script src="/ranui-iife/theme-switch.iife.js" defer></script>
+    <script src="/lang-switch.js" defer></script>
+    <script src="/open-local.js" defer></script>
+    <script src="/landing-prefetch.js" defer></script>
   </head>
 
   <body>
@@ -164,293 +186,288 @@
         />
       </symbol>
     </svg>
-    <div id="app" class="w-full h-full">
-      <!-- Crawlable landing hero. Rendered in the served HTML for SEO/GEO; hidden
-           the moment a document opens (body.landing-active toggles it, see index.ts). -->
-      <section id="landing-hero">
-        <header class="bar">
-          <div class="wrap">
-            <a class="brand" href="/"><span class="logo">D</span>Document Editor</a>
-            <nav>
-              <a class="navlink" href="/offline-document-editor">Offline</a>
-              <a class="navlink" href="/no-signup-document-editor">No sign-up</a>
-              <a class="navlink gh" href="https://github.com/ranuts/document" rel="noopener" target="_blank">
-                <svg class="ghmark" aria-hidden="true"><use href="#gh-mark"></use></svg> GitHub
-              </a>
-              <span class="lang-wrap">
-                <svg class="langmark" aria-hidden="true" viewBox="0 0 16 16">
-                  <circle cx="8" cy="8" r="6.25" fill="none" stroke="currentColor" stroke-width="1.5" />
-                  <path
-                    d="M1.75 8h12.5M8 1.75c1.7 1.8 2.6 3.9 2.6 6.25S9.7 12.45 8 14.25M8 1.75c-1.7 1.8-2.6 3.9-2.6 6.25s.9 4.45 2.6 6.25"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.2"
-                  />
-                </svg>
-                <r-select class="lang-select" type="text" value="en" aria-label="Language">
-                  <r-option value="en">EN</r-option>
-                  <r-option value="zh-CN">中文</r-option>
-                </r-select>
-              </span>
-            </nav>
-          </div>
-        </header>
-
-        <div class="hero wrap">
-          <div class="hero-copy">
-            <span class="chip reveal d1"><span class="dot"></span>Local-first · <b>open source</b></span>
-            <h1 class="reveal d2">
-              Open Word, Excel &amp; PowerPoint files, <span class="accent">right in your browser.</span>
-            </h1>
-            <p class="sub reveal d3">
-              No Office installed? View any DOCX, XLSX or PPTX instantly — and edit it when you need to. Everything runs
-              on your device: no upload, no sign-up, works offline.
-            </p>
-            <div class="cta reveal d4">
-              <r-button type="primary" id="hero-open">Open a file</r-button>
-              <r-button id="hero-new-docx">New Word</r-button>
-              <r-button id="hero-new-xlsx">New Excel</r-button>
-              <r-button id="hero-new-pptx">New PowerPoint</r-button>
-            </div>
-            <div class="trust reveal d5">
-              <span>0 bytes uploaded</span><span>no account</span><span>works offline</span
-              ><span>.docx .xlsx .pptx .csv</span>
-            </div>
-          </div>
-
-          <!-- Decorative "document being edited locally" window — pure CSS, no JS,
-               so the static localized homepages can reuse it verbatim. -->
-          <div class="docwin reveal d3" aria-hidden="true">
-            <div class="dw-bar">
-              <span class="dw-dots"><i></i><i></i><i></i></span>
-              <span class="dw-file">report.docx</span>
-              <span class="dw-badge">saved locally ✓</span>
-            </div>
-            <div class="dw-tabs">
-              <span class="on">.docx</span><span>.xlsx</span><span>.pptx</span><span>.csv</span>
-            </div>
-            <div class="dw-body">
-              <div class="dw-sheet">
-                <span class="dl t"></span>
-                <span class="dl w92"></span>
-                <span class="dl w78"></span>
-                <p class="dw-text"><mark>Everything you type stays on this device.</mark><i class="caret"></i></p>
-                <span class="dl w85"></span>
-                <span class="dl w60"></span>
-              </div>
-              <aside class="dw-note">
-                <b>You · just now</b>
-                <span>0 bytes uploaded — check the network tab.</span>
-              </aside>
-            </div>
-            <div class="dw-net"><i class="ok"></i>network · 0 requests · 0 bytes out</div>
-          </div>
-        </div>
-
-        <!-- The highest-frequency job: someone got a file and has no Office.
-             Format entry points, each backed by a dedicated landing page. -->
-        <div class="section wrap">
-          <div class="section-head">
-            <span class="eyebrow">Open a file</span>
-            <h2>No Office installed? No problem.</h2>
-          </div>
-          <div class="formats">
-            <a class="fmt" href="/open/docx">
-              <r-card hoverable>
-                <div class="card-body">
-                  <div class="k">.DOCX</div>
-                  <h3>Open DOCX</h3>
-                  <p>View any Word document with full formatting — fonts, tables, images intact.</p>
-                  <span class="fmt-go">Open a DOCX →</span>
-                </div>
-              </r-card>
-            </a>
-            <a class="fmt" href="/open/xlsx">
-              <r-card hoverable>
-                <div class="card-body">
-                  <div class="k">.XLSX</div>
-                  <h3>Open XLSX</h3>
-                  <p>Formulas, charts and multiple sheets, fully rendered.</p>
-                  <span class="fmt-go">Open an XLSX →</span>
-                </div>
-              </r-card>
-            </a>
-            <a class="fmt" href="/open/pptx">
-              <r-card hoverable>
-                <div class="card-body">
-                  <div class="k">.PPTX</div>
-                  <h3>Open PPTX</h3>
-                  <p>Slides with layouts, themes and media preserved, straight in the browser.</p>
-                  <span class="fmt-go">Open a PPTX →</span>
-                </div>
-              </r-card>
-            </a>
-            <a class="fmt" href="/open/pdf">
-              <r-card hoverable>
-                <div class="card-body">
-                  <div class="k">.PDF</div>
-                  <h3>Open PDF</h3>
-                  <p>Read, comment and annotate a PDF, then save it back — nothing uploaded.</p>
-                  <span class="fmt-go">Open a PDF →</span>
-                </div>
-              </r-card>
-            </a>
-            <a class="fmt" href="/convert/xlsx-to-csv">
-              <r-card hoverable>
-                <div class="card-body">
-                  <div class="k">.XLSX → .CSV</div>
-                  <h3>Convert between formats</h3>
-                  <p>Turn spreadsheets into CSV and back — locally, without uploading a byte.</p>
-                  <span class="fmt-go">Convert a file →</span>
-                </div>
-              </r-card>
-            </a>
-          </div>
-        </div>
-
-        <div class="section wrap">
-          <div class="section-head">
-            <span class="eyebrow">Why it's different</span>
-            <h2>Private by design, not by promise</h2>
-          </div>
-          <div class="cards">
-            <r-card hoverable>
-              <div class="card-body">
-                <div class="k">100% CLIENT-SIDE</div>
-                <h3>Files never leave your device</h3>
-                <p>Every document is opened, edited and saved locally. There is no server to upload to.</p>
-              </div>
-            </r-card>
-            <r-card hoverable>
-              <div class="card-body">
-                <div class="k">NO ACCOUNT</div>
-                <h3>Nothing to sign up for</h3>
-                <p>No email, no login wall. Open the page and start editing immediately.</p>
-              </div>
-            </r-card>
-            <r-card hoverable>
-              <div class="card-body">
-                <div class="k">PWA · OFFLINE</div>
-                <h3>Install it, use it on a plane</h3>
-                <p>Add it to your home screen and it keeps working with no internet connection.</p>
-              </div>
-            </r-card>
-            <r-card hoverable>
-              <div class="card-body">
-                <div class="k">AGPL-3.0</div>
-                <h3>Open source &amp; self-hostable</h3>
-                <p>Audit exactly what runs, or host your own copy. Powered by OnlyOffice.</p>
-              </div>
-            </r-card>
-          </div>
-        </div>
-
-        <div class="section wrap">
-          <div class="section-head">
-            <span class="eyebrow">Process</span>
-            <h2>How it works</h2>
-          </div>
-          <div class="steps">
-            <div class="step">
-              <div class="n">01</div>
-              <h3>Open a file</h3>
-              <p>Drop in a DOCX, XLSX, PPTX or CSV — or start a blank one.</p>
-              <span class="loc">stays on device</span>
-            </div>
-            <div class="step">
-              <div class="n">02</div>
-              <h3>Edit for real</h3>
-              <p>Full formatting, tables, charts and formulas via OnlyOffice.</p>
-              <span class="loc">stays on device</span>
-            </div>
-            <div class="step">
-              <div class="n">03</div>
-              <h3>Save it back</h3>
-              <p>Export to the same format. Nothing was ever uploaded.</p>
-              <span class="loc">stays on device</span>
-            </div>
-          </div>
-        </div>
-
-        <div class="section wrap faq-sec">
-          <div class="section-head">
-            <span class="eyebrow">FAQ</span>
-            <h2>Questions, answered</h2>
-          </div>
-          <div class="faq">
-            <div class="qa">
-              <details open>
-                <summary>Are my files uploaded anywhere?</summary>
-                <p class="a">
-                  No. There is no server. Files are opened and saved locally on your device and are never uploaded — you
-                  can verify it in the network tab, or read the source.
-                </p>
-              </details>
-              <details>
-                <summary>Which formats can I edit?</summary>
-                <p class="a">
-                  Word (DOCX), Excel (XLSX), PowerPoint (PPTX) and CSV, powered by OnlyOffice running in WebAssembly.
-                </p>
-              </details>
-              <details>
-                <summary>Does it work offline?</summary>
-                <p class="a">
-                  Yes. It is an installable PWA — once loaded it keeps working with no internet, because all editing
-                  runs locally in your browser.
-                </p>
-              </details>
-              <details>
-                <summary>Do I need an account?</summary>
-                <p class="a">No account, no sign-up, no email. Open the page and edit.</p>
-              </details>
-            </div>
-          </div>
-        </div>
-
-        <div class="eco">
-          <div class="wrap">
-            <span class="eco-label">
-              <svg class="gitmark" aria-hidden="true"><use href="#gh-mark"></use></svg>
-              Part of the ran ecosystem · all open source
-            </span>
-            <nav>
-              <span class="here"><b>edit.chaxus.com</b> <small>Office editor</small></span>
-              <a href="https://ran.chaxus.com" rel="noopener" target="_blank">
-                <b>ran.chaxus.com</b> <small>UI components</small>
-              </a>
-            </nav>
-          </div>
-        </div>
-
-        <footer class="foot wrap">
-          <span>© 2026 Document Editor · runs on your device</span>
+    <!-- Crawlable landing hero. This page is static: no editor bundle is loaded here;
+         every CTA navigates to /editor (see editor.html). -->
+    <section id="landing-hero">
+      <header class="bar">
+        <div class="wrap">
+          <a class="brand" href="/"><span class="logo">D</span>Document Editor</a>
           <nav>
-            <a href="/help">Help</a>
-            <a href="/changelog">Changelog</a>
-            <a href="/embed-document-editor">Embed API</a>
-            <a href="/private-document-editor">Privacy</a>
-            <a href="/offline-document-editor">Offline editor</a>
-            <a href="/no-signup-document-editor">No sign-up</a>
-            <a href="/open/docx">Open DOCX</a>
-            <a href="/convert/xlsx-to-csv">XLSX → CSV</a>
-            <a href="https://github.com/ranuts/document" rel="noopener" target="_blank">GitHub</a>
+            <a class="navlink" href="/offline-document-editor">Offline</a>
+            <a class="navlink" href="/no-signup-document-editor">No sign-up</a>
+            <a class="navlink gh" href="https://github.com/ranuts/document" rel="noopener" target="_blank">
+              <svg class="ghmark" aria-hidden="true"><use href="#gh-mark"></use></svg> GitHub
+            </a>
+            <span class="lang-wrap">
+              <svg class="langmark" aria-hidden="true" viewBox="0 0 16 16">
+                <circle cx="8" cy="8" r="6.25" fill="none" stroke="currentColor" stroke-width="1.5" />
+                <path
+                  d="M1.75 8h12.5M8 1.75c1.7 1.8 2.6 3.9 2.6 6.25S9.7 12.45 8 14.25M8 1.75c-1.7 1.8-2.6 3.9-2.6 6.25s.9 4.45 2.6 6.25"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.2"
+                />
+              </svg>
+              <r-select class="lang-select" type="text" value="en" aria-label="Language">
+                <r-option value="en" data-href="/">EN</r-option>
+                <r-option value="zh-CN" data-href="/zh-CN/">中文</r-option>
+              </r-select>
+            </span>
           </nav>
-          <r-theme-switch class="theme-switch" label="Theme"></r-theme-switch>
-          <span class="lic">AGPL-3.0</span>
-        </footer>
-      </section>
+        </div>
+      </header>
 
-      <div id="iframe"></div>
-    </div>
+      <div class="hero wrap">
+        <div class="hero-copy">
+          <span class="chip reveal d1"><span class="dot"></span>Local-first · <b>open source</b></span>
+          <h1 class="reveal d2">
+            Open Word, Excel &amp; PowerPoint files, <span class="accent">right in your browser.</span>
+          </h1>
+          <p class="sub reveal d3">
+            No Office installed? View any DOCX, XLSX or PPTX instantly — and edit it when you need to. Everything runs
+            on your device: no upload, no sign-up, works offline.
+          </p>
+          <div class="cta reveal d4">
+            <r-button type="primary" id="hero-open" data-open-local="/editor?open=local">Open a file</r-button>
+            <a href="/editor?new=docx" data-prefetch="docx"><r-button id="hero-new-docx">New Word</r-button></a>
+            <a href="/editor?new=xlsx" data-prefetch="xlsx"><r-button id="hero-new-xlsx">New Excel</r-button></a>
+            <a href="/editor?new=pptx" data-prefetch="pptx"><r-button id="hero-new-pptx">New PowerPoint</r-button></a>
+          </div>
+          <div class="trust reveal d5">
+            <span>0 bytes uploaded</span><span>no account</span><span>works offline</span
+            ><span>.docx .xlsx .pptx .csv</span>
+          </div>
+        </div>
 
-    <!-- The landing hero above is static HTML and already crawlable without JS.
-         This only tells no-JS visitors that the interactive editor needs JS. -->
-    <noscript>
-      <p style="max-width: 720px; margin: 0 auto; padding: 24px; font-family: system-ui, sans-serif">
-        This editor requires JavaScript to run — the landing content above describes what it does. Please enable
-        JavaScript to start editing.
-      </p>
-    </noscript>
+        <!-- Decorative "document being edited locally" window — pure CSS, no JS,
+               so the static localized homepages can reuse it verbatim. -->
+        <div class="docwin reveal d3" aria-hidden="true">
+          <div class="dw-bar">
+            <span class="dw-dots"><i></i><i></i><i></i></span>
+            <span class="dw-file">report.docx</span>
+            <span class="dw-badge">saved locally ✓</span>
+          </div>
+          <div class="dw-tabs"><span class="on">.docx</span><span>.xlsx</span><span>.pptx</span><span>.csv</span></div>
+          <div class="dw-body">
+            <div class="dw-sheet">
+              <span class="dl t"></span>
+              <span class="dl w92"></span>
+              <span class="dl w78"></span>
+              <p class="dw-text"><mark>Everything you type stays on this device.</mark><i class="caret"></i></p>
+              <span class="dl w85"></span>
+              <span class="dl w60"></span>
+            </div>
+            <aside class="dw-note">
+              <b>You · just now</b>
+              <span>0 bytes uploaded — check the network tab.</span>
+            </aside>
+          </div>
+          <div class="dw-net"><i class="ok"></i>network · 0 requests · 0 bytes out</div>
+        </div>
+      </div>
+
+      <!-- The highest-frequency job: someone got a file and has no Office.
+             Format entry points, each backed by a dedicated landing page. -->
+      <div class="section wrap">
+        <div class="section-head">
+          <span class="eyebrow">Open a file</span>
+          <h2>No Office installed? No problem.</h2>
+        </div>
+        <div class="formats">
+          <a class="fmt" href="/open/docx">
+            <r-card hoverable>
+              <div class="card-body">
+                <div class="k">.DOCX</div>
+                <h3>Open DOCX</h3>
+                <p>View any Word document with full formatting — fonts, tables, images intact.</p>
+                <span class="fmt-go">Open a DOCX →</span>
+              </div>
+            </r-card>
+          </a>
+          <a class="fmt" href="/open/xlsx">
+            <r-card hoverable>
+              <div class="card-body">
+                <div class="k">.XLSX</div>
+                <h3>Open XLSX</h3>
+                <p>Formulas, charts and multiple sheets, fully rendered.</p>
+                <span class="fmt-go">Open an XLSX →</span>
+              </div>
+            </r-card>
+          </a>
+          <a class="fmt" href="/open/pptx">
+            <r-card hoverable>
+              <div class="card-body">
+                <div class="k">.PPTX</div>
+                <h3>Open PPTX</h3>
+                <p>Slides with layouts, themes and media preserved, straight in the browser.</p>
+                <span class="fmt-go">Open a PPTX →</span>
+              </div>
+            </r-card>
+          </a>
+          <a class="fmt" href="/open/pdf">
+            <r-card hoverable>
+              <div class="card-body">
+                <div class="k">.PDF</div>
+                <h3>Open PDF</h3>
+                <p>Read, comment and annotate a PDF, then save it back — nothing uploaded.</p>
+                <span class="fmt-go">Open a PDF →</span>
+              </div>
+            </r-card>
+          </a>
+          <a class="fmt" href="/convert/xlsx-to-csv">
+            <r-card hoverable>
+              <div class="card-body">
+                <div class="k">.XLSX → .CSV</div>
+                <h3>Convert between formats</h3>
+                <p>Turn spreadsheets into CSV and back — locally, without uploading a byte.</p>
+                <span class="fmt-go">Convert a file →</span>
+              </div>
+            </r-card>
+          </a>
+        </div>
+      </div>
+
+      <div class="section wrap">
+        <div class="section-head">
+          <span class="eyebrow">Why it's different</span>
+          <h2>Private by design, not by promise</h2>
+        </div>
+        <div class="cards">
+          <r-card hoverable>
+            <div class="card-body">
+              <div class="k">100% CLIENT-SIDE</div>
+              <h3>Files never leave your device</h3>
+              <p>Every document is opened, edited and saved locally. There is no server to upload to.</p>
+            </div>
+          </r-card>
+          <r-card hoverable>
+            <div class="card-body">
+              <div class="k">NO ACCOUNT</div>
+              <h3>Nothing to sign up for</h3>
+              <p>No email, no login wall. Open the page and start editing immediately.</p>
+            </div>
+          </r-card>
+          <r-card hoverable>
+            <div class="card-body">
+              <div class="k">PWA · OFFLINE</div>
+              <h3>Install it, use it on a plane</h3>
+              <p>Add it to your home screen and it keeps working with no internet connection.</p>
+            </div>
+          </r-card>
+          <r-card hoverable>
+            <div class="card-body">
+              <div class="k">AGPL-3.0</div>
+              <h3>Open source &amp; self-hostable</h3>
+              <p>Audit exactly what runs, or host your own copy. Powered by OnlyOffice.</p>
+            </div>
+          </r-card>
+        </div>
+      </div>
+
+      <div class="section wrap">
+        <div class="section-head">
+          <span class="eyebrow">Process</span>
+          <h2>How it works</h2>
+        </div>
+        <div class="steps">
+          <div class="step">
+            <div class="n">01</div>
+            <h3>Open a file</h3>
+            <p>Drop in a DOCX, XLSX, PPTX or CSV — or start a blank one.</p>
+            <span class="loc">stays on device</span>
+          </div>
+          <div class="step">
+            <div class="n">02</div>
+            <h3>Edit for real</h3>
+            <p>Full formatting, tables, charts and formulas via OnlyOffice.</p>
+            <span class="loc">stays on device</span>
+          </div>
+          <div class="step">
+            <div class="n">03</div>
+            <h3>Save it back</h3>
+            <p>Export to the same format. Nothing was ever uploaded.</p>
+            <span class="loc">stays on device</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="section wrap faq-sec">
+        <div class="section-head">
+          <span class="eyebrow">FAQ</span>
+          <h2>Questions, answered</h2>
+        </div>
+        <div class="faq">
+          <div class="qa">
+            <details open>
+              <summary>Are my files uploaded anywhere?</summary>
+              <p class="a">
+                No. There is no server. Files are opened and saved locally on your device and are never uploaded — you
+                can verify it in the network tab, or read the source.
+              </p>
+            </details>
+            <details>
+              <summary>Which formats can I edit?</summary>
+              <p class="a">
+                Word (DOCX), Excel (XLSX), PowerPoint (PPTX) and CSV, powered by OnlyOffice running in WebAssembly.
+              </p>
+            </details>
+            <details>
+              <summary>Does it work offline?</summary>
+              <p class="a">
+                Yes. It is an installable PWA — once loaded it keeps working with no internet, because all editing runs
+                locally in your browser.
+              </p>
+            </details>
+            <details>
+              <summary>Do I need an account?</summary>
+              <p class="a">No account, no sign-up, no email. Open the page and edit.</p>
+            </details>
+          </div>
+        </div>
+      </div>
+
+      <div class="eco">
+        <div class="wrap">
+          <span class="eco-label">
+            <svg class="gitmark" aria-hidden="true"><use href="#gh-mark"></use></svg>
+            Part of the ran ecosystem · all open source
+          </span>
+          <nav>
+            <span class="here"><b>edit.chaxus.com</b> <small>Office editor</small></span>
+            <a href="https://ran.chaxus.com" rel="noopener" target="_blank">
+              <b>ran.chaxus.com</b> <small>UI components</small>
+            </a>
+          </nav>
+        </div>
+      </div>
+
+      <footer class="foot wrap">
+        <span>© 2026 Document Editor · runs on your device</span>
+        <nav>
+          <a href="/help">Help</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/embed-document-editor">Embed API</a>
+          <a href="/private-document-editor">Privacy</a>
+          <a href="/offline-document-editor">Offline editor</a>
+          <a href="/no-signup-document-editor">No sign-up</a>
+          <a href="/open/docx">Open DOCX</a>
+          <a href="/convert/xlsx-to-csv">XLSX → CSV</a>
+          <a href="https://github.com/ranuts/document" rel="noopener" target="_blank">GitHub</a>
+        </nav>
+        <r-theme-switch class="theme-switch" label="Theme"></r-theme-switch>
+        <span class="lic">AGPL-3.0</span>
+      </footer>
+    </section>
+
+    <!-- Register the service worker from the homepage too, so the landing works
+         offline / installs as an app; the update policy lives with the editor
+         (lib/sw-update.ts), where a document may be open. -->
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', function () {
+          navigator.serviceWorker.register('./sw.js').catch(function () {});
+        });
+      }
+    </script>
   </body>
-  <script type="module" src="./index.ts"></script>
 </html>

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,6 @@ import {
   hideControlPanel,
   hideLanding,
   showControlPanel,
-  showLanding,
   showMenuGuide,
 } from './lib/ui';
 import 'ranui/button';
@@ -72,33 +71,9 @@ window.showControlPanel = showControlPanel;
 createFixedActionButton();
 createControlPanel();
 
-// Wire the landing hero CTAs: primary opens the file picker, secondary starts a
-// blank DOCX. Both funnel into the same flows the legacy control panel uses.
-const heroOpen = document.getElementById('hero-open');
-if (heroOpen) heroOpen.addEventListener('click', () => onOpenDocument());
-// One secondary create button per format — mirrors the FAB menu, which only
-// exists once a document is open.
-for (const ext of ['docx', 'xlsx', 'pptx']) {
-  const btn = document.getElementById(`hero-new-${ext}`);
-  if (btn) btn.addEventListener('click', () => void window.onCreateNew(`.${ext}`));
-}
-
-// Wire the ranui <r-select> language switch: it emits a `change` CustomEvent with
-// { value } — map the locale to the localized homepage URL. (Static pages can't
-// run the web component and fall back to a native <select>.)
-const langSelect = document.querySelector('#landing-hero r-select.lang-select');
-if (langSelect) {
-  langSelect.addEventListener('change', (event) => {
-    const value = (event as CustomEvent<{ value?: string }>).detail?.value;
-    // Guard: r-select can emit `change` while initializing its value on load.
-    // Navigating on a same-as-current-locale event reloads the page and wipes
-    // deep-link params (?new=docx, ?locale=…), so only act on a real switch.
-    const onZhPage = location.pathname.startsWith('/zh-CN');
-    if (value === 'zh-CN' && !onZhPage) location.href = '/zh-CN/';
-    else if (value === 'en' && onZhPage) location.href = '/';
-  });
-}
-
+// This bundle runs on /editor (editor.html). The homepage / is a static landing
+// page whose CTAs navigate here (?new=, ?open=local); legacy deep links on /
+// are redirected here by an inline script in index.html.
 // Check for file or src parameter in URL
 // Both parameters support opening document from URL
 // Priority: file > src (for backward compatibility)
@@ -149,7 +124,8 @@ const isEmbedded = document.body.classList.contains('embed-mode');
 if (documentUrl || isEmbedded || createNewOnLoad || openLocalOnLoad) {
   hideLanding();
 } else {
-  showLanding();
+  // Bare /editor with nothing to open: the landing lives at / now.
+  window.location.replace('/');
 }
 
 if (documentUrl) {
@@ -176,8 +152,8 @@ if (documentUrl) {
     if (file) {
       await openLocalFile(file);
     } else {
-      // Stale deep link (reload, bookmarked URL): nothing pending — show the hero.
-      showLanding();
+      // Stale deep link (reload, bookmarked URL): nothing pending -- back to the landing.
+      window.location.replace('/');
     }
   });
 }

--- a/public/embed-demo.html
+++ b/public/embed-demo.html
@@ -272,10 +272,10 @@
 
       <section class="viewer">
         <div class="strip">
-          <span><code>&lt;iframe src="/?embed=1"&gt;</code></span>
+          <span><code>&lt;iframe src="/editor?embed=1"&gt;</code></span>
           <span id="status">loading</span>
         </div>
-        <iframe id="editorFrame" src="./?embed=1" title="Document editor"></iframe>
+        <iframe id="editorFrame" src="./editor?embed=1" title="Document editor"></iframe>
       </section>
     </main>
 

--- a/public/embed-document-editor.html
+++ b/public/embed-document-editor.html
@@ -64,7 +64,7 @@
               {
                 "@type": "HowToStep",
                 "name": "Add the iframe",
-                "text": "Add an iframe pointing at the editor with ?embed=1, sized to your layout."
+                "text": "Add an iframe pointing at /editor?embed=1, sized to your layout."
               },
               {
                 "@type": "HowToStep",
@@ -86,7 +86,7 @@
                 "name": "How do I embed the document editor?",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "Add one iframe pointing at the editor with ?embed=1, then drive it with a postMessage API to open and save documents. A working demo is at /embed-demo.html."
+                  "text": "Add one iframe pointing at /editor?embed=1, then drive it with a postMessage API to open and save documents. A working demo is at /embed-demo.html."
                 }
               },
               {
@@ -223,7 +223,7 @@
       <h2>Add it with one iframe</h2>
       <pre><code>&lt;iframe
   id="documentEditor"
-  src="https://edit.chaxus.com/?embed=1&amp;embedOrigin=https://your-app.example.com"
+  src="https://edit.chaxus.com/editor?embed=1&amp;embedOrigin=https://your-app.example.com"
   style="width: 100%; height: 720px; border: 0"
 &gt;&lt;/iframe&gt;</code></pre>
       <p>
@@ -254,7 +254,7 @@ iframe.contentWindow.postMessage({ id, type: 'document:save', payload: { targetE
 
       <h2>How it works</h2>
       <ol>
-        <li>Add the iframe pointing at the editor with <code>?embed=1</code>, sized to your layout.</li>
+        <li>Add the iframe pointing at <code>/editor?embed=1</code>, sized to your layout.</li>
         <li>
           Wait for the <code>document:ready</code> event, then send <code>document:open-url</code>,
           <code>open-file</code> or <code>open-buffer</code>.
@@ -290,8 +290,8 @@ send('document:set-readonly', { readonly: false });</code></pre>
       <div class="faq">
         <h3>How do I embed the document editor?</h3>
         <p>
-          Add one iframe pointing at the editor with <code>?embed=1</code>, then drive it with a postMessage API to open
-          and save documents. A working demo is at <a href="/embed-demo.html">/embed-demo.html</a>.
+          Add one iframe pointing at <code>/editor?embed=1</code>, then drive it with a postMessage API to open and save
+          documents. A working demo is at <a href="/embed-demo.html">/embed-demo.html</a>.
         </p>
         <h3>Does the editor see my users' auth tokens?</h3>
         <p>

--- a/public/landing-prefetch.js
+++ b/public/landing-prefetch.js
@@ -1,0 +1,60 @@
+// Intent-triggered prefetch for the static homepage: hovering / focusing an
+// Open / New CTA starts pulling the editor engine (loader, app shell, SDK) so
+// the click that follows lands on a warm cache. Same URL list and rules as
+// lib/prefetch.ts (which serves the FAB menu inside /editor); kept in plain JS
+// because the landing page ships no bundle. Skipped on Save-Data / 2G.
+(function () {
+  var APP = { docx: 'documenteditor', xlsx: 'spreadsheeteditor', pptx: 'presentationeditor' };
+  var SDK = { docx: 'word', xlsx: 'cell', pptx: 'slide' };
+  var LOADER = '/web-apps/apps/api/documents/api.js';
+  var requested = {};
+
+  function allowed() {
+    var c = navigator.connection;
+    if (!c) return true;
+    if (c.saveData) return false;
+    return !(c.effectiveType === 'slow-2g' || c.effectiveType === '2g');
+  }
+
+  function urls(kind) {
+    var list = [LOADER];
+    if (kind && APP[kind]) {
+      list.push('/web-apps/apps/' + APP[kind] + '/main/app.js');
+      list.push('/sdkjs/' + SDK[kind] + '/sdk-all-min.js');
+      list.push('/sdkjs/' + SDK[kind] + '/sdk-all.js');
+    }
+    return list;
+  }
+
+  function prefetch(kind) {
+    if (!allowed()) return;
+    urls(kind).forEach(function (href) {
+      if (requested[href]) return;
+      requested[href] = true;
+      var link = document.createElement('link');
+      link.rel = 'prefetch';
+      link.setAttribute('as', 'script');
+      link.href = href;
+      document.head.appendChild(link);
+    });
+  }
+
+  function arm(el, kind) {
+    if (!el) return;
+    var fired = false;
+    function fire() {
+      if (fired) return;
+      fired = true;
+      prefetch(kind);
+    }
+    ['pointerenter', 'focus', 'touchstart'].forEach(function (evt) {
+      el.addEventListener(evt, fire, { passive: true, once: true });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    arm(document.getElementById('hero-open'));
+    var nodes = document.querySelectorAll('[data-prefetch]');
+    for (var i = 0; i < nodes.length; i++) arm(nodes[i], nodes[i].getAttribute('data-prefetch'));
+  });
+})();

--- a/public/open-local.js
+++ b/public/open-local.js
@@ -4,7 +4,7 @@
 // app (loaded via `?open=local`) picks it up on boot — see lib/pending-open.ts,
 // which owns the same DB/store/key names. Everything stays on-device.
 //
-// Usage: <r-button data-open-local="/?locale=zh-CN&open=local">…</r-button>
+// Usage: <r-button data-open-local="/editor?locale=zh-CN&open=local">…</r-button>
 // The attribute value is the app URL to navigate to after stashing the file.
 (function () {
   var DB_NAME = 'document-handoff';
@@ -43,11 +43,11 @@
     var input = document.createElement('input');
     input.type = 'file';
     // Keep in sync with the app's picker (lib/document.ts).
-    input.accept = '.docx,.xlsx,.pptx,.doc,.xls,.ppt,.csv';
+    input.accept = '.docx,.xlsx,.pptx,.doc,.xls,.ppt,.csv,.pdf';
     input.style.display = 'none';
     document.body.appendChild(input);
 
-    var targetHref = '/?open=local';
+    var targetHref = '/editor?open=local';
 
     buttons.forEach(function (btn) {
       btn.addEventListener('click', function () {

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@ const CACHE_VERSION = 'SW_VERSION_PLACEHOLDER'.includes('PLACEHOLDER') ? 'dev-' 
 // old single 100-item cache was constantly evicting its own shell).
 const CORE_CACHE = `document-editor-core-${CACHE_VERSION}`;
 const RUNTIME_CACHE = `document-editor-runtime-${CACHE_VERSION}`;
-const ASSETS_TO_CACHE = ['./', './index.html', './manifest.json', './img/64.png'];
+const ASSETS_TO_CACHE = ['./', './index.html', './editor', './editor.html', './manifest.json', './img/64.png'];
 
 // Unhashed but deploy-coupled: stable filenames whose *content* changes every deploy.
 // Mirrors the group public/_headers pins to `Cache-Control: no-cache` — keep the two in sync.

--- a/public/zh-CN/embed-document-editor.html
+++ b/public/zh-CN/embed-document-editor.html
@@ -64,7 +64,7 @@
               {
                 "@type": "HowToStep",
                 "name": "加入 iframe",
-                "text": "加入一个指向编辑器、带 ?embed=1 的 iframe，按你的布局设置尺寸。"
+                "text": "加入一个指向 /editor?embed=1 的 iframe，按你的布局设置尺寸。"
               },
               {
                 "@type": "HowToStep",
@@ -86,7 +86,7 @@
                 "name": "怎么嵌入这个文档编辑器？",
                 "acceptedAnswer": {
                   "@type": "Answer",
-                  "text": "加入一个指向编辑器、带 ?embed=1 的 iframe，再用 postMessage API 驱动它打开与保存文档。可运行 demo 在 /embed-demo.html。"
+                  "text": "加入一个指向 /editor?embed=1 的 iframe，再用 postMessage API 驱动它打开与保存文档。可运行 demo 在 /embed-demo.html。"
                 }
               },
               {
@@ -218,7 +218,7 @@
       <h2>一个 iframe 就能接入</h2>
       <pre><code>&lt;iframe
   id="documentEditor"
-  src="https://edit.chaxus.com/?embed=1&amp;embedOrigin=https://your-app.example.com"
+  src="https://edit.chaxus.com/editor?embed=1&amp;embedOrigin=https://your-app.example.com"
   style="width: 100%; height: 720px; border: 0"
 &gt;&lt;/iframe&gt;</code></pre>
       <p>
@@ -247,7 +247,7 @@ iframe.contentWindow.postMessage({ id, type: 'document:save', payload: { targetE
 
       <h2>工作原理</h2>
       <ol>
-        <li>加入指向编辑器、带 <code>?embed=1</code> 的 iframe，按布局设尺寸。</li>
+        <li>加入指向 <code>/editor?embed=1</code> 的 iframe，按布局设尺寸。</li>
         <li>
           等 <code>document:ready</code> 事件，再发送 <code>document:open-url</code>、<code>open-file</code> 或
           <code>open-buffer</code>。
@@ -283,8 +283,8 @@ send('document:set-readonly', { readonly: false });</code></pre>
       <div class="faq">
         <h3>怎么嵌入这个文档编辑器？</h3>
         <p>
-          加入一个指向编辑器、带 <code>?embed=1</code> 的 iframe，再用 postMessage API 驱动它打开与保存文档。可运行 demo
-          在 <a href="/embed-demo.html">/embed-demo.html</a>。
+          加入一个指向 <code>/editor?embed=1</code> 的 iframe，再用 postMessage API 驱动它打开与保存文档。可运行 demo 在
+          <a href="/embed-demo.html">/embed-demo.html</a>。
         </p>
         <h3>编辑器会看到我用户的鉴权 token 吗？</h3>
         <p>

--- a/public/zh-CN/index.html
+++ b/public/zh-CN/index.html
@@ -159,10 +159,10 @@
             没装 Office？任何 DOCX、XLSX、PPTX 文件即开即看，需要时随手编辑——全部在你的设备本地运行，免注册、可离线。
           </p>
           <div class="cta reveal d4">
-            <r-button type="primary" data-open-local="/?locale=zh-CN&amp;open=local">打开文件</r-button>
-            <a href="/?locale=zh-CN&amp;new=docx"><r-button>新建 Word</r-button></a>
-            <a href="/?locale=zh-CN&amp;new=xlsx"><r-button>新建 Excel</r-button></a>
-            <a href="/?locale=zh-CN&amp;new=pptx"><r-button>新建 PPT</r-button></a>
+            <r-button type="primary" data-open-local="/editor?locale=zh-CN&amp;open=local">打开文件</r-button>
+            <a href="/editor?locale=zh-CN&amp;new=docx"><r-button>新建 Word</r-button></a>
+            <a href="/editor?locale=zh-CN&amp;new=xlsx"><r-button>新建 Excel</r-button></a>
+            <a href="/editor?locale=zh-CN&amp;new=pptx"><r-button>新建 PPT</r-button></a>
           </div>
           <div class="trust reveal d5">
             <span>不传服务器</span><span class="sep">·</span><span>免注册</span><span class="sep">·</span

--- a/public/zh-CN/no-signup-document-editor.html
+++ b/public/zh-CN/no-signup-document-editor.html
@@ -223,7 +223,7 @@
         文件。无需账号、无需登录、无需订阅，文件也不会传到任何服务器。
       </p>
 
-      <a class="cta" href="/?locale=zh-CN&amp;new=docx"><r-button type="primary">打开编辑器 →</r-button></a>
+      <a class="cta" href="/editor?locale=zh-CN&amp;new=docx"><r-button type="primary">打开编辑器 →</r-button></a>
 
       <p>
         大多数"免费"的在线编辑器都会要求你先注册账号，然后悄悄把你的文档上传到它们的服务器。而这个编辑器两样都不做。所有处理都通过

--- a/public/zh-CN/offline-document-editor.html
+++ b/public/zh-CN/offline-document-editor.html
@@ -223,7 +223,7 @@
         Chromebook、飞机上的笔记本，还是安卓平板。安装一次，离线也能一直用，完全在你的设备上运行。
       </p>
 
-      <a class="cta" href="/?locale=zh-CN&amp;new=docx"><r-button type="primary">打开编辑器 →</r-button></a>
+      <a class="cta" href="/editor?locale=zh-CN&amp;new=docx"><r-button type="primary">打开编辑器 →</r-button></a>
 
       <p>
         由于所有编辑都通过 WebAssembly 在你的浏览器本地运行——没有服务器——它不需要联网就能工作。加载一次，把它安装成

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ A privacy-first, browser-based document editor powered by OnlyOffice. Edit DOCX,
 - 🔒 **Privacy-first** — all processing happens locally, nothing is uploaded
 - 📝 **Multi-format** — DOCX, XLSX, PPTX, CSV editing plus PDF opening, and more
 - 🚀 **No server required** — pure frontend, deploy anywhere
-- 🌐 **Open from URL** — load documents via `?src=` or `?file=` parameters
+- 🌐 **Open from URL** — load documents via `/editor?src=` or `/editor?file=` (legacy `/?src=` redirects)
 - 📦 **PWA support** — install and use offline
 - 🌍 **Multi-language** — English, Chinese, and more
 - 🧩 **Embeddable** — full postMessage API for iframe integration
@@ -61,7 +61,7 @@ pnpm run dev
 ### Open a document
 
 1. Click the upload button to open a local file, or
-2. Pass a URL via query parameter: `?src=https://example.com/document.docx`
+2. Pass a URL via query parameter: `/editor?src=https://example.com/document.docx`
 
 > Remote URLs must support CORS.
 
@@ -96,7 +96,7 @@ Embed the editor in your application and control it via postMessage. The recomme
 ```html
 <iframe
   id="documentEditor"
-  src="https://your-deployment/?embed=1"
+  src="https://your-deployment/editor?embed=1"
   style="width: 100%; height: 720px; border: 0"
 ></iframe>
 ```

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -28,7 +28,7 @@
 - 🔒 **隐私优先** — 所有处理在本地完成，不上传任何数据
 - 📝 **多格式支持** — DOCX、XLSX、PPTX、CSV 等
 - 🚀 **无需服务器** — 纯前端实现，可部署到任意静态托管
-- 🌐 **URL 打开** — 通过 `?src=` 或 `?file=` 参数直接加载远程文档
+- 🌐 **URL 打开** — 通过 `/editor?src=` 或 `/editor?file=` 参数直接加载远程文档（旧的 `/?src=` 会跳转）
 - 📦 **PWA 支持** — 可安装，支持离线使用
 - 🌍 **多语言** — 中文、英文及更多语言
 - 🧩 **可嵌入** — 完整的 postMessage API 支持 iframe 集成
@@ -61,7 +61,7 @@ pnpm run dev
 ### 打开文档
 
 1. 点击上传按钮选择本地文件，或
-2. 通过 URL 参数传入：`?src=https://example.com/document.docx`
+2. 通过 URL 参数传入：`/editor?src=https://example.com/document.docx`
 
 > 远程 URL 需支持 CORS。
 
@@ -96,7 +96,7 @@ pnpm run dev
 ```html
 <iframe
   id="documentEditor"
-  src="https://your-deployment/?embed=1"
+  src="https://your-deployment/editor?embed=1"
   style="width: 100%; height: 720px; border: 0"
 ></iframe>
 ```

--- a/test/e2e/app-smoke.spec.ts
+++ b/test/e2e/app-smoke.spec.ts
@@ -1,16 +1,37 @@
 import { expect, test } from './lib/l0';
 
-test('homepage loads without page errors', async ({ page }) => {
+test('homepage is the static landing: hero present, no editor bundle', async ({ page }) => {
   const pageErrors: string[] = [];
   page.on('pageerror', (error) => pageErrors.push(error.message));
 
   await page.goto('/');
 
+  await expect(page.locator('#landing-hero')).toBeVisible();
+  await expect(page.locator('#hero-open')).toBeVisible();
+  // Route split: / never mounts the editor shell.
+  await expect(page.locator('#iframe')).toHaveCount(0);
+  await expect(page.locator('#fab-container')).toHaveCount(0);
+  expect(page.url()).not.toContain('/editor');
+  expect(pageErrors).toEqual([]);
+});
+
+test('/editor?new=docx mounts the editor shell; legacy /?new=docx redirects there', async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await page.goto('/?new=docx');
+  await page.waitForURL(/\/editor\?new=docx/);
   await expect(page.locator('#app')).toBeVisible();
   await expect(page.locator('#iframe')).toBeAttached();
   await expect(page.locator('#fab-container')).toBeAttached();
   await expect(page.locator('#control-panel-container')).toBeAttached();
   expect(pageErrors).toEqual([]);
+});
+
+test('bare /editor with nothing to open goes back to the landing', async ({ page }) => {
+  await page.goto('/editor');
+  await page.waitForURL((u) => u.pathname === '/');
+  await expect(page.locator('#landing-hero')).toBeVisible();
 });
 
 test('manifest and service worker assets are reachable', async ({ request }) => {

--- a/test/unit/landing-pages.test.ts
+++ b/test/unit/landing-pages.test.ts
@@ -129,7 +129,7 @@ describe('landing pages', () => {
   });
 
   it('zh-CN CTAs stay in Chinese; "open your <format>" never lands on a blank new docx', () => {
-    const allowed = new Set(['/zh-CN/', '/?locale=zh-CN&amp;new=docx', '/embed-demo.html']);
+    const allowed = new Set(['/zh-CN/', '/editor?locale=zh-CN&amp;new=docx', '/embed-demo.html']);
     for (const { route, html } of pages.filter((p) => p.route.startsWith('/zh-CN/') && p.route !== '/zh-CN/')) {
       const m = html.match(/<a class="cta" href="([^"]+)"><r-button[^>]*>([^<]+)</);
       if (!m) continue;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,12 @@ const cleanUrls = (publicDirName: string): Plugin => {
     ): void => {
       const [pathname, query] = (req.url ?? '/').split('?');
       if (pathname === '/' || pathname.includes('.')) return next();
+      // Vite HTML entries at the project root (/editor -> editor.html) resolve
+      // like the static pages under public/ do; Cloudflare Pages does the same.
+      if (fs.existsSync(path.join(__dirname, `${pathname}.html`))) {
+        req.url = `${pathname}.html${query ? `?${query}` : ''}`;
+        return next();
+      }
       if (!pathname.endsWith('/') && fs.existsSync(path.join(root, pathname, 'index.html'))) {
         // directory URL without slash: redirect like Cloudflare Pages does
         res.writeHead(308, { Location: `${pathname}/${query ? `?${query}` : ''}` });
@@ -82,6 +88,13 @@ export default defineConfig(() => {
     publicDir: publicDirName,
     build: {
       outDir: 'dist',
+      // Two HTML entries: / (static landing, no editor bundle) and /editor (the app).
+      rollupOptions: {
+        input: {
+          main: resolve(__dirname, 'index.html'),
+          editor: resolve(__dirname, 'editor.html'),
+        },
+      },
     },
     plugins: [generatedPages(), cleanUrls(publicDirName)],
     resolve: {


### PR DESCRIPTION
## Summary
Roadmap item 10 (方向六 2): split the homepage from the editor.
- `/` = `index.html`, now a **static landing page** (no editor bundle): same hero/SEO/JSON-LD, ranui IIFEs + `lang-switch.js` + `open-local.js` (file hand-off via IndexedDB → `/editor?open=local`) + new `public/landing-prefetch.js` (intent prefetch, same rules as `lib/prefetch.ts`); inline SW registration
- `/editor` = new `editor.html` hosting `index.ts` (`?new=` `?file=` `?src=` `?readonly` `?embed=1` `?open=local` `?agent`), `noindex`; bare `/editor` and stale `?open=local` go back to `/`
- **Back-compat**: inline script at the top of `/` redirects `/?file= /?src= /?new= /?open= /?embed= /?embedded= /?readonly /?agent` and any framed load to `/editor` with the same query — external embeds and existing E2E URLs keep working
- Vite two-entry MPA (`rollupOptions.input`), dev clean-URL middleware resolves `/editor`; `sw.js` precaches `./editor` + `./editor.html`; `embed-demo.html` iframe → `./editor?embed=1`; zh-CN homepage/landing CTAs → `/editor?locale=zh-CN&…`
- Docs: embed-api (en/zh), readme (en/zh), help content, embed landing pages, CLAUDE.md layout, roadmap ✅, CHANGELOG, `docs/explorations/2026-08-16-route-split.md`
- `app-smoke.spec.ts` rewritten: `/` is static (hero, no `#iframe`/`#fab-container`), `/?new=docx` → `/editor?new=docx` mounts the shell, bare `/editor` → `/`

## Test plan
- [x] unit 522 passed, lint:ts, format:check
- [x] full E2E on the branch (E2E_PORT=4176): **71 passed, 10 skipped** (main-site hero open via hand-off, entry-paths `?file=`/`?open=local`, embed-api, embed-regression, pdf, csv, comments, …)
- [ ] CI (incl. Pages semantics + preview smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)