### PR TITLE
docs: homepage LCP after the route split (774 ms -> 354 ms on production)

### DIFF
--- a/docs/changelogs/2026-08-16-roadmap-sprint.md
+++ b/docs/changelogs/2026-08-16-roadmap-sprint.md
@@ -64,7 +64,12 @@ e2e-pages 串行 + wrangler 重启守护、ranui/ranuts 上游对齐夜检。
 
 首页 LCP 774 ms（TTFB 205 / render delay 569）；`?new=docx` 冷打开 ≈16 s
 （sdk-all.js 3 MB br 6.6 s + 14 个字体文件 6 s；字体仍 `cf-cache-status:
-DYNAMIC`）。拆分 + api.js 按需 + 意图预取上线后待复测。
+DYNAMIC`）。
+
+**拆分后复测（同日晚，全部合入并部署后，同一方法）**：首页 LCP
+**354 ms**（TTFB 146 / render delay 208），CLS 0——render delay 从 569 降到
+208，首页 HTML 里不再有任何编辑器 bundle（`/editor` 单独承载）。冷打开
+的字体 DYNAMIC 与 sdk-all.js 带宽项不变，等 CF Cache Rule 与预取生效后再测。
 
 ## 欠账 / 待用户
 

--- a/docs/superpowers/plans/2026-08-15-next-phase-roadmap.md
+++ b/docs/superpowers/plans/2026-08-15-next-phase-roadmap.md
@@ -225,6 +225,8 @@ WebMCP 接入本质是把同一批能力换个注册方式暴露出来。
      REVALIDATED/br，无法再压）；字体仍 `cf-cache-status: DYNAMIC`（CF
      Cache Rule 待用户在面板加）+ 空白 docx 竟拉 14 个字体文件（值得查
      fonts_loading 为何这么多——字体线归战役字体专项）。
+   - **拆分后复测（2026-08-16 晚，第 10/11 项上线后）**：首页 LCP 354 ms
+     （TTFB 146 / render delay 208），较基线 774 ms 降 54%。
    - **预取决策（第 11 项）**：不做无差别 idle 预取——sdk-all.js 3 MB 对
      只读落地页的访客是纯浪费；改为"意图触发"：hover/focus 到 Open/New
      按钮、文件选择框弹出时 `<link rel=prefetch>` sdk-all-min.js + sdk-all.js


### PR DESCRIPTION
Production re-measurement after #120/#127/#130 landed: homepage LCP 774 ms → 354 ms (render delay 569 → 208 ms, CLS 0), recorded in the sprint one-pager and the roadmap baseline section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)