### PR TITLE
chore(seo): refresh sitemap lastmod from git history (22 pages changed today) + bin/sitemap-lastmod.mjs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ types/
 styles/
   base.css              # 全局样式（含 embed-mode 布局）
 public/               # v9 vendor（sdkjs / web-apps / x2t.wasm.gz / XOR 字体目录）+ 落地页、demo、SW
-bin/                  # build.sh、test-e2e-docker.sh、font-catalog.mjs、bundle_single_html.js、build-pages.mjs（markdown→/help /changelog；由 vite 插件 `generated-pages` 在 build/dev 时渲染进 public/，产物不入库）
+bin/                  # build.sh、test-e2e-docker.sh、font-catalog.mjs、bundle_single_html.js、build-pages.mjs（markdown→/help /changelog；由 vite 插件 `generated-pages` 在 build/dev 时渲染进 public/，产物不入库）、sitemap-lastmod.mjs（改完落地页/内容后跑一次，按 git 提交日期刷新 sitemap 的 lastmod，`--check` 可校验）
 content/              # 生成页面的 markdown 源（content/<locale>/*.md，frontmatter title/description）
 docs/                 # embed-api / fonts 文档、explorations/（每次改动的记录）、superpowers/plans/
 index.ts              # 编辑器入口（初始化事件、UI、PWA），挂在 editor.html

--- a/bin/sitemap-lastmod.mjs
+++ b/bin/sitemap-lastmod.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Refresh <lastmod> in public/sitemap.xml from git: each URL's date becomes the
+ * last commit that touched its source (index.html for /, the static HTML under
+ * public/, or the markdown sources of a generated page). Run after a content
+ * change and commit the result; search engines use lastmod to decide what to
+ * recrawl, and a stale value tells them nothing changed.
+ *
+ *   node bin/sitemap-lastmod.mjs          # rewrite public/sitemap.xml
+ *   node bin/sitemap-lastmod.mjs --check  # exit 1 if any lastmod would change
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { LOCALES, PAGES } from './build-pages.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const ORIGIN = 'https://edit.chaxus.com';
+const SITEMAP = resolve(ROOT, 'public/sitemap.xml');
+
+/** Source files whose history dates a route. */
+function sourcesFor(route) {
+  for (const page of PAGES) {
+    for (const [locale, src] of Object.entries(page.sources)) {
+      if (`${LOCALES[locale].prefix}/${page.slug}` === route) return [src, 'bin/build-pages.mjs'];
+    }
+  }
+  if (route === '/') return ['index.html'];
+  if (route.endsWith('/')) return [`public${route}index.html`];
+  return [`public${route}.html`];
+}
+
+function lastCommitDate(files) {
+  const existing = files.filter((f) => existsSync(resolve(ROOT, f)));
+  if (!existing.length) return null;
+  const out = execFileSync('git', ['log', '-1', '--format=%cs', '--', ...existing], { cwd: ROOT, encoding: 'utf8' });
+  return out.trim() || null;
+}
+
+const xml = readFileSync(SITEMAP, 'utf8');
+let changed = 0;
+const next = xml.replace(/<loc>([^<]+)<\/loc>(\s*)<lastmod>([^<]+)<\/lastmod>/g, (whole, loc, ws, current) => {
+  const route = loc.startsWith(ORIGIN) ? loc.slice(ORIGIN.length) : loc;
+  const date = lastCommitDate(sourcesFor(route));
+  if (!date || date === current) return whole;
+  changed++;
+  console.log(`  ${route}  ${current} -> ${date}`);
+  return `<loc>${loc}</loc>${ws}<lastmod>${date}</lastmod>`;
+});
+
+if (process.argv.includes('--check')) {
+  if (changed) {
+    console.error(`${changed} sitemap lastmod value(s) are stale. Run: node bin/sitemap-lastmod.mjs`);
+    process.exit(1);
+  }
+  console.log('sitemap lastmod values are current.');
+} else {
+  writeFileSync(SITEMAP, next);
+  console.log(changed ? `Updated ${changed} lastmod value(s).` : 'No lastmod changes.');
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "vite --host --force",
     "build": "sh ./bin/build.sh",
     "build:pages": "node bin/build-pages.mjs",
+    "sitemap:lastmod": "node bin/sitemap-lastmod.mjs",
     "build:single": "node bin/bundle_single_html.js",
     "preview": "vite preview",
     "tsc": "tsc --noEmit",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,49 +2,49 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://edit.chaxus.com/</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/zh-CN/</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/no-signup-document-editor</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/private-document-editor</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/edit-documents-without-account</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/open/docx</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/open/xlsx</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/open/pptx</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -74,61 +74,61 @@
   </url>
   <url>
     <loc>https://edit.chaxus.com/offline-document-editor</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/convert/xlsx-to-csv</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/convert/csv-to-xlsx</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/embed-document-editor</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/zh-CN/no-signup-document-editor</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/zh-CN/private-document-editor</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/zh-CN/edit-documents-without-account</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/zh-CN/open/docx</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/zh-CN/open/xlsx</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/zh-CN/open/pptx</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -158,25 +158,25 @@
   </url>
   <url>
     <loc>https://edit.chaxus.com/zh-CN/offline-document-editor</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/zh-CN/convert/xlsx-to-csv</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/zh-CN/convert/csv-to-xlsx</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://edit.chaxus.com/zh-CN/embed-document-editor</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-08-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>


### PR DESCRIPTION
After the GSC/Bing submission: 22 of 30 sitemap entries still said 2026-07-11 although every landing page changed today (footers, CTAs, embed/CSV content, route split). New `bin/sitemap-lastmod.mjs` (`pnpm run sitemap:lastmod`, `--check`) sets each URL's lastmod to the last commit touching its source (index.html, public/*.html, or a generated page's markdown), so recrawl signals stay honest; run it after content changes. CLAUDE.md notes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)