### PR TITLE
feat(i18n): app shell in eight languages with per-key English fallback and RTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ notes. Entries describe what users experience, not internal refactors.
 
 ### Added
 
+- The interface is now available in eight languages — English, 简体中文,
+  日本語, 한국어, Deutsch, Español, Português and فارسی (right-to-left) —
+  following your browser language, or `?locale=<code>`.
 - Browser AI agents can drive the editor through WebMCP (Chrome origin trial):
   the page registers `open_document_url`, `open_document_buffer`,
   `save_document`, `set_readonly` and `get_document_state` when the browser

--- a/docs/explorations/2026-08-16-shell-locales.md
+++ b/docs/explorations/2026-08-16-shell-locales.md
@@ -1,0 +1,63 @@
+# 站点壳 i18n 扩到 8 种语言（多语言方向八·第 2 层）
+
+路线图方向八第 2 层。第 1 层（编辑器 UI 跟随访客语言，45 个 vendor 语言包）
+见 [2026-08-16-editor-ui-locale-passthrough.md](2026-08-16-editor-ui-locale-passthrough.md)；
+这一层补的是**我们自己的壳文案**（FAB 菜单、toast、错误提示）。
+
+## 语言与覆盖策略
+
+用户给的参考菜单是 8 种：English / 简体中文 / 日本語 / Español / Português /
+한국어 / Deutsch / فارسی。现在 `SHELL_LOCALES` 正是这 8 种。
+
+关键设计是**完整表 + 部分表**：
+
+```ts
+const completeMessages: Record<ZH | EN, I18nMessages> = { … };            // 47 键，必须齐全
+const partialMessages: Record<其余 6 种, Partial<I18nMessages>> = { … };   // 核心 19 键
+const messages = { ...completeMessages, ...partialMessages };
+t(key) => messages[cur]?.[key] || completeMessages.en[key] || key;         // 逐键回落
+```
+
+为什么不要求 8 种全齐：一是加一个新 UI 字符串会变成"八语同步"的负担，
+现实里必然拖成半吊子；二是没译到的键回落英文，比露出 `agentSend` 这种
+原始 key 好得多。**实验性的 AI 面板（`agent*`，`?agent=1` 才出现）刻意
+只保留 en/zh**——那批文案长且技术性强，机翻质量风险大，等有人 review 再补。
+核心 19 键（打开/新建/菜单/主题/保存提示/四类错误）六种语言全部译到。
+
+## RTL（فارسی）
+
+- `RTL_LANGUAGES` + `isRtlLanguage()`；新增 `applyDocumentLanguage()`，在
+  `index.ts` 启动时把 `<html lang>` 与 `dir` 写好（zh 写成 `zh-CN`）。
+  副作用留在应用入口而不是共享包里，包本身保持纯函数可测。
+- 真浏览器实测 `/editor?locale=fa&new=docx`：`dir=rtl`，FAB 菜单文字右对齐、
+  主题三档镜像排列，编辑器 iframe 不受影响（它是独立 document，vendor 无 fa
+  语言包，按既有规则回落英文界面）。截图核对无破版。
+- 静态落地页仍是 LTR：它们的 `lang`/`dir` 写死在 HTML 里，多语言落地页是
+  方向八第 3 层的事，届时 landing.css 要改用逻辑属性（margin-inline 等）。
+
+## 检测链
+
+不变（`?locale=` → cookie → localStorage → `navigator.languages`），只是
+`normalizeLanguage` 从"只认 zh/en"改成"认 `SHELL_LOCALES` 里的主子标签"。
+`?locale=ja` 现在壳与编辑器**都是**日语（此前只有编辑器是）；`?locale=fa`
+壳是波斯语、编辑器回落英语。存储的语言（`document-lang`）也走同一归一化，
+所以选过韩语刷新后仍是韩语。
+
+## 用例
+
+- `test/unit/i18n-locales.test.ts`（12 条）：8 种语言清单、每种语言核心 19 键
+  逐键断言"非空 / 不是原始 key / 与英文不同"（`SAME_AS_ENGLISH` 白名单放行
+  德语 `System`、葡语 `Menu` 这类同形词——它们是正确翻译而非漏译）、
+  未译键回落英文、只有 fa 是 RTL、`applyDocumentLanguage` 的 lang/dir、
+  存储语言跨刷新。
+- `test/unit/i18n.test.ts` 更新了 `?locale=ja` 的断言（壳也变日语），新增
+  `?locale=fa` 用例。
+
+## 后续
+
+- 第 3 层多语言落地页：靠 `bin/build-pages.mjs` 的 locale × page 模型批量
+  生成，`LOCALES` 表加语言即可；fa 需要 RTL 版 landing.css。建议先看 GSC
+  的非中英流量占比再决定首批语言。
+- 语言切换器目前仍只有 EN/中文——它切的是**落地页**，没有落地页的语言不该
+  出现在里面；等第 3 层再扩。
+- 若要给 fa 也配上母语编辑器界面，只能等 vendor 出 fa 语言包（当前 45 个里没有）。

--- a/docs/superpowers/plans/2026-08-15-next-phase-roadmap.md
+++ b/docs/superpowers/plans/2026-08-15-next-phase-roadmap.md
@@ -354,7 +354,10 @@ llms.txt 形成互补）。结构化数据用 FAQPage / HowTo，并入 sitemap�
    这样日/韩/德/西/葡用户打开文档时编辑器菜单已是母语，站点壳的 40 个词条
    暂时回落 en 也可接受。同时把 `zh-TW`→`zh-tw`、`pt-BR`→`pt` 之类的映射
    写成表 + 单测。
-2. **站点壳 i18n 补齐 6 种（半天）**：`i18n.ts` 词条 ≈40 个，一次性补
+2. ✅ 2026-08-16 已落地（见 explorations/2026-08-16-shell-locales.md）：8 种
+   语言（en/zh/ja/ko/de/es/pt/fa），核心 19 键全译、其余逐键回落英文，
+   agent 面板暂留英文；fa 走 `applyDocumentLanguage()` 设 `<html dir=rtl>`，
+   真浏览器核对无破版。**原计划描述**：`i18n.ts` 词条 ≈40 个，一次性补
    ja / es / pt / ko / de / fa；`Language` 类型从二选一改成联合；
    `?locale=` 与 `<r-select>` 语言切换器改数据驱动（一份 locale 清单供
    落地页语言菜单、lang-switch.js、sitemap 生成共用）。

--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ import { initEmbedApi } from './lib/embed-api';
 import { initEvents, setEventUICallbacks } from './lib/events';
 import { onCreateNew, onOpenDocument, openDocumentFromUrl, openLocalFile, setUICallbacks } from './lib/document';
 import { parseReadonly } from '@ranuts/shared/document-utils';
+import { applyDocumentLanguage } from '@ranuts/shared/i18n';
 import { getDocmentObj } from '@ranuts/shared/store';
 import { initAnalytics } from './lib/analytics';
 import {
@@ -34,6 +35,10 @@ declare global {
     };
   }
 }
+
+// Reflect the detected shell language on <html> (lang, and dir for RTL locales
+// like fa). The static landing pages carry their own lang/dir in the HTML.
+applyDocumentLanguage();
 
 // Initialize events
 initEvents();

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -32,15 +32,19 @@ import { getDocmentObj, setDocmentObj } from '@ranuts/shared/store';
   extension, the deployment `BASE_PATH` (handles `/document/` on GitHub Pages vs `/`),
   and `parseReadonly` for the `?readonly` query flag.
 - **document-types** — shared interfaces, incl. x2t/Emscripten module shapes.
-- **i18n** — `t(key)` translation over 9 languages; `getLanguage/setLanguage`;
-  `getOnlyOfficeLang()` maps to OnlyOffice's locale codes. Keys are typed via `I18nMessages`.
+- **i18n** — `t(key)` over the 8 shell locales in `SHELL_LOCALES`
+  (en/zh complete, the rest core-only with per-key English fallback);
+  `getLanguage/setLanguage`; `getOnlyOfficeLang()` resolves the _editor_ locale
+  (any of the 45 the vendor ships, `resolveEditorLocale`); `applyDocumentLanguage()`
+  sets `<html lang/dir>` (fa is RTL). Keys are typed via `I18nMessages`.
 - **store** — `[getDocmentObj, setDocmentObj]`, a ranuts signal over
   `{ fileName: string; file?: File; url?: string | URL }` (the current document).
 
 ## Gotchas
 
-- `t(key)` is typed against `I18nMessages` — adding a UI string means adding the key
-  to **every** language map in `i18n.ts`, or `t` won't type-check.
+- `t(key)` is typed against `I18nMessages` — a new UI string must be added to the two
+  **complete** tables (en + zh) or `t` won't type-check; the other locales are
+  `Partial` and fall back to English per key, so translating them can come later.
 - `store` holds a `File`/`Blob` — don't serialize it to localStorage.
 - This package depends on `ranuts`; keep it that way (it's the app's shared layer,
   not a zero-dep generic lib).

--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -14,6 +14,18 @@ export enum LanguageCode {
   ZH = 'zh',
   /** English (internal) */
   EN = 'en',
+  /** Japanese */
+  JA = 'ja',
+  /** Korean */
+  KO = 'ko',
+  /** German */
+  DE = 'de',
+  /** Spanish */
+  ES = 'es',
+  /** Portuguese */
+  PT = 'pt',
+  /** Persian (right-to-left) */
+  FA = 'fa',
 }
 
 /**
@@ -26,7 +38,29 @@ export enum OnlyOfficeLanguageCode {
   EN = 'en',
 }
 
-export type Language = LanguageCode.ZH | LanguageCode.EN;
+/** Any shell language (the enum's member union). */
+export type Language = LanguageCode;
+
+/**
+ * Shell languages, in the order the language menu shows them. English and
+ * Chinese are complete; the others translate the core UI and fall back to
+ * English per missing key (see `messages` below and `t()`).
+ */
+export const SHELL_LOCALES: readonly Language[] = [
+  LanguageCode.EN,
+  LanguageCode.ZH,
+  LanguageCode.JA,
+  LanguageCode.KO,
+  LanguageCode.DE,
+  LanguageCode.ES,
+  LanguageCode.PT,
+  LanguageCode.FA,
+];
+
+/** Right-to-left shell languages (drives `<html dir>`, see applyDocumentLanguage). */
+export const RTL_LANGUAGES: readonly Language[] = [LanguageCode.FA];
+
+export const isRtlLanguage = (lang: Language): boolean => RTL_LANGUAGES.includes(lang);
 
 /**
  * Editor (OnlyOffice) UI locales shipped by the vendored web-apps build --
@@ -175,7 +209,15 @@ export interface I18nMessages {
   agentToolErrorPrefix: string;
 }
 
-const messages: Record<Language, I18nMessages> = {
+/**
+ * en and zh are complete (`I18nMessages`); every other locale is a partial
+ * table -- a missing key falls back to English in `t()`. That keeps adding a
+ * new UI string a two-language change instead of an eight-language one, and
+ * an untranslated string shows in English rather than as a raw key. The
+ * experimental agent panel (`agent*`, opt-in via ?agent=1) is deliberately
+ * English-only outside en/zh until someone reviews those translations.
+ */
+const completeMessages: Record<LanguageCode.ZH | LanguageCode.EN, I18nMessages> = {
   [LanguageCode.ZH]: {
     webOffice: 'Web Office',
     uploadDocument: '查看/编辑文档',
@@ -295,6 +337,157 @@ const messages: Record<Language, I18nMessages> = {
   },
 };
 
+/** Core shell strings for the remaining locales (machine-drafted, reviewed for tone). */
+const partialMessages: Record<Exclude<Language, LanguageCode.ZH | LanguageCode.EN>, Partial<I18nMessages>> = {
+  [LanguageCode.JA]: {
+    webOffice: 'Web Office',
+    uploadDocument: 'ドキュメントを開く / 編集',
+    newWord: 'Word を新規作成',
+    newExcel: 'Excel を新規作成',
+    newPowerPoint: 'PowerPoint を新規作成',
+    menu: 'メニュー',
+    menuGuide: 'メニューは右下にあります。カーソルを合わせると開きます（閉じると次回から表示されません）',
+    themeLabel: 'テーマ',
+    themeSystem: 'システム',
+    themeLight: 'ライト',
+    themeDark: 'ダーク',
+    fileSavedSuccess: 'ファイルを保存しました: ',
+    documentLoaded: 'ドキュメントを読み込みました: ',
+    failedToLoadEditor: 'エディターを読み込めませんでした。OnlyOffice API が正しく配置されているか確認してください。',
+    unsupportedFileType: 'サポートされていないファイル形式: ',
+    invalidFileObject: '無効なファイルです',
+    documentOperationFailed: 'ドキュメントの操作に失敗しました: ',
+    editorErrorToast: 'ドキュメントエラー',
+    editorErrorFormatMismatch: 'ファイルの内容が拡張子と一致しません。形式を確認してからもう一度お試しください',
+    editorErrorOpenFailed:
+      'ファイルを開けませんでした。破損しているか、サポートされていない形式か、拡張子と内容が異なる可能性があります',
+  },
+  [LanguageCode.KO]: {
+    webOffice: 'Web Office',
+    uploadDocument: '문서 열기 / 편집',
+    newWord: '새 Word 문서',
+    newExcel: '새 Excel 문서',
+    newPowerPoint: '새 PowerPoint 문서',
+    menu: '메뉴',
+    menuGuide: '메뉴는 오른쪽 아래에 있습니다. 마우스를 올리면 열립니다(닫으면 다시 표시되지 않습니다)',
+    themeLabel: '테마',
+    themeSystem: '시스템',
+    themeLight: '라이트',
+    themeDark: '다크',
+    fileSavedSuccess: '파일을 저장했습니다: ',
+    documentLoaded: '문서를 불러왔습니다: ',
+    failedToLoadEditor: '편집기를 불러오지 못했습니다. OnlyOffice API가 올바르게 설치되어 있는지 확인하세요.',
+    unsupportedFileType: '지원하지 않는 파일 형식: ',
+    invalidFileObject: '잘못된 파일입니다',
+    documentOperationFailed: '문서 작업에 실패했습니다: ',
+    editorErrorToast: '문서 오류',
+    editorErrorFormatMismatch: '파일 내용이 확장자와 일치하지 않습니다. 형식을 확인한 뒤 다시 시도하세요',
+    editorErrorOpenFailed:
+      '파일을 열 수 없습니다. 손상되었거나, 지원하지 않는 형식이거나, 확장자와 내용이 다를 수 있습니다',
+  },
+  [LanguageCode.DE]: {
+    webOffice: 'Web Office',
+    uploadDocument: 'Dokument öffnen / bearbeiten',
+    newWord: 'Neues Word-Dokument',
+    newExcel: 'Neue Excel-Tabelle',
+    newPowerPoint: 'Neue PowerPoint-Präsentation',
+    menu: 'Menü',
+    menuGuide:
+      'Das Menü ist unten rechts – zum Öffnen mit der Maus darauf zeigen (nach dem Schließen wird dieser Hinweis nicht mehr angezeigt)',
+    themeLabel: 'Design',
+    themeSystem: 'System',
+    themeLight: 'Hell',
+    themeDark: 'Dunkel',
+    fileSavedSuccess: 'Datei gespeichert: ',
+    documentLoaded: 'Dokument geladen: ',
+    failedToLoadEditor:
+      'Der Editor konnte nicht geladen werden. Bitte prüfen, ob die OnlyOffice-API korrekt eingebunden ist.',
+    unsupportedFileType: 'Nicht unterstützter Dateityp: ',
+    invalidFileObject: 'Ungültige Datei',
+    documentOperationFailed: 'Dokumentvorgang fehlgeschlagen: ',
+    editorErrorToast: 'Dokumentfehler',
+    editorErrorFormatMismatch:
+      'Der Inhalt der Datei passt nicht zur Dateiendung – bitte das Format prüfen und erneut versuchen',
+    editorErrorOpenFailed:
+      'Die Datei konnte nicht geöffnet werden: möglicherweise beschädigt, in einem nicht unterstützten Format, oder der Inhalt passt nicht zur Endung',
+  },
+  [LanguageCode.ES]: {
+    webOffice: 'Web Office',
+    uploadDocument: 'Abrir / editar documento',
+    newWord: 'Nuevo documento de Word',
+    newExcel: 'Nueva hoja de Excel',
+    newPowerPoint: 'Nueva presentación de PowerPoint',
+    menu: 'Menú',
+    menuGuide:
+      'El menú está abajo a la derecha: pasa el cursor para abrirlo (si lo cierras, no volverá a mostrarse este aviso)',
+    themeLabel: 'Tema',
+    themeSystem: 'Sistema',
+    themeLight: 'Claro',
+    themeDark: 'Oscuro',
+    fileSavedSuccess: 'Archivo guardado: ',
+    documentLoaded: 'Documento cargado: ',
+    failedToLoadEditor: 'No se pudo cargar el editor. Comprueba que la API de OnlyOffice esté instalada correctamente.',
+    unsupportedFileType: 'Tipo de archivo no admitido: ',
+    invalidFileObject: 'Archivo no válido',
+    documentOperationFailed: 'Error al procesar el documento: ',
+    editorErrorToast: 'Error del documento',
+    editorErrorFormatMismatch:
+      'El contenido del archivo no coincide con su extensión; comprueba el formato e inténtalo de nuevo',
+    editorErrorOpenFailed:
+      'No se pudo abrir el archivo: puede estar dañado, tener un formato no admitido o no corresponder a su extensión',
+  },
+  [LanguageCode.PT]: {
+    webOffice: 'Web Office',
+    uploadDocument: 'Abrir / editar documento',
+    newWord: 'Novo documento do Word',
+    newExcel: 'Nova planilha do Excel',
+    newPowerPoint: 'Nova apresentação do PowerPoint',
+    menu: 'Menu',
+    menuGuide:
+      'O menu fica no canto inferior direito: passe o cursor para abrir (ao fechar, este aviso não aparece novamente)',
+    themeLabel: 'Tema',
+    themeSystem: 'Sistema',
+    themeLight: 'Claro',
+    themeDark: 'Escuro',
+    fileSavedSuccess: 'Arquivo salvo: ',
+    documentLoaded: 'Documento carregado: ',
+    failedToLoadEditor: 'Não foi possível carregar o editor. Verifique se a API do OnlyOffice está instalada.',
+    unsupportedFileType: 'Tipo de arquivo não suportado: ',
+    invalidFileObject: 'Arquivo inválido',
+    documentOperationFailed: 'Falha na operação do documento: ',
+    editorErrorToast: 'Erro no documento',
+    editorErrorFormatMismatch:
+      'O conteúdo do arquivo não corresponde à extensão; verifique o formato e tente novamente',
+    editorErrorOpenFailed:
+      'Não foi possível abrir o arquivo: ele pode estar corrompido, em formato não suportado ou não corresponder à extensão',
+  },
+  [LanguageCode.FA]: {
+    webOffice: 'Web Office',
+    uploadDocument: 'باز کردن / ویرایش سند',
+    newWord: 'سند Word جدید',
+    newExcel: 'کاربرگ Excel جدید',
+    newPowerPoint: 'ارائهٔ PowerPoint جدید',
+    menu: 'منو',
+    menuGuide:
+      'منو در گوشهٔ پایین سمت راست است؛ نشانگر را روی آن ببرید تا باز شود (پس از بستن دیگر نمایش داده نمی‌شود)',
+    themeLabel: 'پوسته',
+    themeSystem: 'سیستم',
+    themeLight: 'روشن',
+    themeDark: 'تیره',
+    fileSavedSuccess: 'فایل ذخیره شد: ',
+    documentLoaded: 'سند بارگذاری شد: ',
+    failedToLoadEditor: 'ویرایشگر بارگذاری نشد. مطمئن شوید OnlyOffice API درست نصب شده است.',
+    unsupportedFileType: 'نوع فایل پشتیبانی نمی‌شود: ',
+    invalidFileObject: 'فایل نامعتبر است',
+    documentOperationFailed: 'عملیات روی سند ناموفق بود: ',
+    editorErrorToast: 'خطای سند',
+    editorErrorFormatMismatch: 'محتوای فایل با پسوند آن هم‌خوانی ندارد؛ قالب را بررسی و دوباره تلاش کنید',
+    editorErrorOpenFailed: 'فایل باز نشد: ممکن است خراب باشد، قالب آن پشتیبانی نشود، یا با پسوندش هم‌خوانی نداشته باشد',
+  },
+};
+
+const messages: Record<Language, Partial<I18nMessages>> = { ...completeMessages, ...partialMessages };
+
 class I18n {
   private currentLanguage: Language = LanguageCode.EN;
   /** Editor UI locale (see EDITOR_UI_LOCALES); detected alongside the shell language. */
@@ -321,9 +514,7 @@ class I18n {
   private normalizeLanguage(lang: string | null): Language | null {
     if (!lang) return null;
     const normalized = lang.toLowerCase().split(/[-_]/)[0];
-    if (normalized === 'zh') return LanguageCode.ZH;
-    if (normalized === 'en') return LanguageCode.EN;
-    return null;
+    return (SHELL_LOCALES as readonly string[]).includes(normalized) ? (normalized as Language) : null;
   }
 
   constructor() {
@@ -346,10 +537,10 @@ class I18n {
     if (!editorLocale) editorLocale = resolveEditorLocale(cookieLang);
 
     // 3. If not found in cookies, try localStorage (an explicit shell choice)
-    const savedLang = localStorageGetItem('document-lang') as Language;
-    if (savedLang && (savedLang === LanguageCode.ZH || savedLang === LanguageCode.EN)) {
+    const savedLang = this.normalizeLanguage(localStorageGetItem('document-lang'));
+    if (savedLang) {
       if (!detectedLang) detectedLang = savedLang;
-      if (!editorLocale) editorLocale = savedLang === LanguageCode.ZH ? OnlyOfficeLanguageCode.ZH_CN : 'en';
+      if (!editorLocale) editorLocale = resolveEditorLocale(savedLang);
     }
 
     // 4. If not found in localStorage, try navigator.language(s)
@@ -380,10 +571,11 @@ class I18n {
    * Set language
    */
   setLanguage(lang: Language): void {
-    if (lang === LanguageCode.ZH || lang === LanguageCode.EN) {
+    if ((SHELL_LOCALES as readonly string[]).includes(lang)) {
       this.currentLanguage = lang;
-      // An explicit shell choice also decides the editor language.
-      this.editorLocale = lang === LanguageCode.ZH ? OnlyOfficeLanguageCode.ZH_CN : OnlyOfficeLanguageCode.EN;
+      // An explicit shell choice also decides the editor language (falling back
+      // to English when the vendor ships no locale for it, e.g. fa).
+      this.editorLocale = resolveEditorLocale(lang) || OnlyOfficeLanguageCode.EN;
       localStorageSetItem('document-lang', lang);
       // Trigger language change event
       // eslint-disable-next-line n/no-unsupported-features/node-builtins
@@ -395,14 +587,15 @@ class I18n {
    * Get translated text
    */
   t(key: keyof I18nMessages): string {
-    return messages[this.currentLanguage][key] || messages[LanguageCode.EN][key] || key;
+    // Partial locales fall back to English key by key (see `messages`).
+    return messages[this.currentLanguage]?.[key] || completeMessages[LanguageCode.EN][key] || key;
   }
 
   /**
    * Get all messages
    */
   getMessages(): I18nMessages {
-    return messages[this.currentLanguage];
+    return { ...completeMessages[LanguageCode.EN], ...messages[this.currentLanguage] };
   }
 
   /**
@@ -426,3 +619,14 @@ export const t = (key: keyof I18nMessages): string => i18n.t(key);
 export const getLanguage = (): Language => i18n.getLanguage();
 export const setLanguage = (lang: Language): void => i18n.setLanguage(lang);
 export const getOnlyOfficeLang = (): string => i18n.getOnlyOfficeLang();
+
+/**
+ * Reflect the active shell language on <html> (`lang`, and `dir` for RTL
+ * locales). Called by the app entry; the static landing pages carry their own
+ * lang/dir in the served HTML.
+ */
+export const applyDocumentLanguage = (lang: Language = i18n.getLanguage()): void => {
+  if (typeof document === 'undefined') return;
+  document.documentElement.setAttribute('lang', lang === LanguageCode.ZH ? 'zh-CN' : lang);
+  document.documentElement.setAttribute('dir', isRtlLanguage(lang) ? 'rtl' : 'ltr');
+};

--- a/test/unit/i18n-locales.test.ts
+++ b/test/unit/i18n-locales.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  applyDocumentLanguage,
+  getLanguage,
+  isRtlLanguage,
+  LanguageCode,
+  SHELL_LOCALES,
+  setLanguage,
+  t,
+  type I18nMessages,
+  type Language,
+} from '@ranuts/shared/i18n';
+
+/**
+ * Shell locales beyond en/zh (roadmap direction eight, layer 2). English and
+ * Chinese are complete tables; the rest translate the *core* UI and fall back
+ * to English per key, so what is pinned here is: every locale covers the core
+ * set, nothing silently leaks a raw key, and RTL/lang attributes are applied.
+ */
+const CORE_KEYS: Array<keyof I18nMessages> = [
+  'uploadDocument',
+  'newWord',
+  'newExcel',
+  'newPowerPoint',
+  'menu',
+  'menuGuide',
+  'themeLabel',
+  'themeSystem',
+  'themeLight',
+  'themeDark',
+  'fileSavedSuccess',
+  'documentLoaded',
+  'failedToLoadEditor',
+  'unsupportedFileType',
+  'invalidFileObject',
+  'documentOperationFailed',
+  'editorErrorToast',
+  'editorErrorFormatMismatch',
+  'editorErrorOpenFailed',
+];
+
+/**
+ * Strings that are legitimately identical to English in a given locale --
+ * same word, not a missing translation. Anything else matching English fails.
+ */
+const SAME_AS_ENGLISH: Partial<Record<string, Array<keyof I18nMessages>>> = {
+  de: ['themeSystem'],
+  es: ['themeSystem'],
+  pt: ['menu', 'themeSystem'],
+};
+
+const restore = () => {
+  setLanguage(LanguageCode.EN);
+  document.documentElement.removeAttribute('dir');
+};
+
+describe('shell locales', () => {
+  it('ships the eight languages the language menu offers', () => {
+    expect([...SHELL_LOCALES]).toEqual(['en', 'zh', 'ja', 'ko', 'de', 'es', 'pt', 'fa']);
+  });
+
+  it.each(SHELL_LOCALES.filter((l) => l !== LanguageCode.EN))(
+    '%s translates every core string (no English leakage, no raw keys)',
+    (lang) => {
+      setLanguage(lang as Language);
+      try {
+        expect(getLanguage()).toBe(lang);
+        for (const key of CORE_KEYS) {
+          const value = t(key);
+          expect(value, `${lang}.${key}`).toBeTruthy();
+          expect(value, `${lang}.${key} is a raw key`).not.toBe(key);
+          // Every core string must actually differ from English.
+          setLanguage(LanguageCode.EN);
+          const english = t(key);
+          setLanguage(lang as Language);
+          if (!SAME_AS_ENGLISH[lang]?.includes(key)) {
+            expect(value, `${lang}.${key} not translated`).not.toBe(english);
+          }
+        }
+      } finally {
+        restore();
+      }
+    },
+  );
+
+  it('falls back to English for untranslated keys instead of showing the key', () => {
+    setLanguage(LanguageCode.DE);
+    try {
+      // The agent panel is deliberately English outside en/zh.
+      expect(t('agentSend')).toBe('Send');
+      expect(t('menu')).toBe('Menü');
+    } finally {
+      restore();
+    }
+  });
+
+  it('marks only Persian as right-to-left', () => {
+    for (const lang of SHELL_LOCALES) {
+      expect(isRtlLanguage(lang), lang).toBe(lang === LanguageCode.FA);
+    }
+  });
+
+  it('applyDocumentLanguage sets <html lang> and dir (zh keeps the zh-CN tag)', () => {
+    applyDocumentLanguage(LanguageCode.FA);
+    expect(document.documentElement.getAttribute('lang')).toBe('fa');
+    expect(document.documentElement.getAttribute('dir')).toBe('rtl');
+
+    applyDocumentLanguage(LanguageCode.ZH);
+    expect(document.documentElement.getAttribute('lang')).toBe('zh-CN');
+    expect(document.documentElement.getAttribute('dir')).toBe('ltr');
+
+    applyDocumentLanguage(LanguageCode.JA);
+    expect(document.documentElement.getAttribute('lang')).toBe('ja');
+    restore();
+  });
+
+  it('a stored language from any locale survives a reload', async () => {
+    localStorage.setItem('document-lang', 'ko');
+    window.history.pushState({}, '', '/');
+    vi.resetModules();
+    try {
+      const m = await import('@ranuts/shared/i18n');
+      expect(m.getLanguage()).toBe(LanguageCode.KO);
+      expect(m.getOnlyOfficeLang()).toBe('ko');
+    } finally {
+      localStorage.removeItem('document-lang');
+    }
+  });
+});

--- a/test/unit/i18n.test.ts
+++ b/test/unit/i18n.test.ts
@@ -126,12 +126,21 @@ describe('editor UI locale (getOnlyOfficeLang) follows the visitor beyond en/zh'
     for (const code of EDITOR_UI_LOCALES) expect(resolveEditorLocale(code)).toBe(code);
   });
 
-  it('?locale=ja gives an English shell with a Japanese editor', async () => {
+  it('?locale=ja gives a Japanese shell and a Japanese editor', async () => {
     window.history.pushState({}, '', '/?locale=ja');
     vi.resetModules();
     const m = await import('@ranuts/shared/i18n');
-    expect(m.getLanguage()).toBe(LanguageCode.EN);
+    expect(m.getLanguage()).toBe(LanguageCode.JA);
     expect(m.getOnlyOfficeLang()).toBe('ja');
+  });
+
+  it('?locale=fa gives a Persian shell but an English editor (no vendor locale)', async () => {
+    window.history.pushState({}, '', '/?locale=fa');
+    vi.resetModules();
+    const m = await import('@ranuts/shared/i18n');
+    expect(m.getLanguage()).toBe(LanguageCode.FA);
+    expect(m.getOnlyOfficeLang()).toBe('en');
+    expect(m.t('menu')).toBe('منو');
   });
 
   it('an unsupported ?locale (fa) falls back to the browser language for the editor', async () => {


### PR DESCRIPTION
## Summary
Roadmap direction eight, layer 2 (layer 1 = editor UI locale passthrough, #122). The shell strings (FAB menu, toasts, error notifications) now cover the eight languages the reference menu lists: English, 简体中文, 日本語, 한국어, Deutsch, Español, Português, فارسی.

- **Complete + partial tables**: `en`/`zh` stay `I18nMessages` (47 keys); the six new locales are `Partial<I18nMessages>` covering the core 19 strings, with per-key English fallback in `t()`. Adding a UI string therefore stays a two-language change, and an untranslated key shows English rather than a raw identifier. The experimental agent panel (`agent*`, `?agent=1`) is deliberately English outside en/zh until someone reviews those translations.
- **Detection**: `normalizeLanguage` now matches against `SHELL_LOCALES`, so `?locale=ja` gives a Japanese shell *and* editor; `?locale=fa` gives a Persian shell with an English editor (no vendor `fa` locale). A stored `document-lang` from any locale survives reloads.
- **RTL**: `RTL_LANGUAGES` / `isRtlLanguage` / new `applyDocumentLanguage()` (called from `index.ts`) set `<html lang>` and `dir`. Verified in a real browser at `/editor?locale=fa&new=docx`: menu right-aligned, theme pill mirrored, editor iframe unaffected, no broken layout.

## Test plan
- [x] `test/unit/i18n-locales.test.ts` (12): locale list, per-key core coverage for every locale (non-empty, not a raw key, differs from English except an allowlist of genuine same-word translations like German `System` / Portuguese `Menu`), English fallback, RTL flags, `applyDocumentLanguage`, stored language across reload
- [x] `i18n.test.ts` updated (`?locale=ja` shell is now Japanese) + new `?locale=fa` case; unit suite 550 passed; lint:ts; format:check
- [x] E2E smoke (app-smoke, main-site, entry-paths): 9 passed
- [ ] CI

Landing pages stay en + zh-CN — multi-language landing pages are layer 3 (generator already models locale × page); the language switcher is unchanged because it switches *landing pages*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)