### PR TITLE
refactor(test): adopt ranuts zip helpers in the OOXML fixture library

### DIFF
--- a/docs/changelogs/2026-08-15-v9-regression-campaign.md
+++ b/docs/changelogs/2026-08-15-v9-regression-campaign.md
@@ -283,3 +283,14 @@ gh workflow run nightly-corpus.yml -f limit=300     # 手动触发夜间
   `bin/build.sh` 重新同步 vendored 资产。核查发现入库的六个 IIFE 与 alpha.2 **逐字节相同**
   （alpha.3 的修复在 colorpicker/player/math 等未 vendored 的组件），变化的是 ES 主入口
   `dist/index.js`；ran-tokens 指纹不变。537 单测 + 71 条 E2E 全绿。
+- **ranuts 沉淀（用户要求）**：先"反向采用"——测试库 `test/e2e/lib/ooxml.ts` 里手写的
+  crc32 / stored-zip 写入 / 中央目录读取 / inflate 全部删掉，改用 ranuts 既有的
+  `createZip` / `readZipEntries` / `readZipEntry`（读取按中央目录取长度，比手写更稳）。
+  再"正向沉淀"——`chaxus/ran` PR #374 给 ranuts 新增 `utils/binary`：
+  `bytesToBase64`/`base64ToBytes`（分块，避免 `String.fromCharCode.apply` 在 ~100 KB
+  以上 RangeError——ranuts 自身 str.ts 也有这个隐患）、`isGzip`/`gunzipMaybe`/
+  `fetchMaybeGzip`（同一份 .gz 资源在不同托管下可能已被浏览器解码，只能按魔数判断）、
+  `isZipContainer`/`isHtmlDocument`（HTML 伪装成 .xls 的嗅探）、`decodeTextBytes`
+  （BOM→utf-8→gb18030→latin1 严格链）、`saveFileToDisk`（File System Access + 锚点兜底，
+  取消对话框 resolve false）。17 条新单测，ranuts 全量 765 通过。
+  发布后本仓再把 converter/E2E 里的对应实现换成 ranuts 版本。

--- a/test/e2e/comments.spec.ts
+++ b/test/e2e/comments.spec.ts
@@ -83,8 +83,8 @@ test.describe('comments survive a save (real editor)', () => {
     expect(result.error).toBeUndefined();
     const bytes = new Uint8Array(Buffer.from(result.b64, 'base64'));
     expect(zipEntryNames(bytes)).toContain('word/comments.xml');
-    expect(zipEntryText(bytes, 'word/comments.xml') || '').toContain('review note');
-    expect(zipEntryText(bytes, 'word/comments.xml') || '').toContain('审阅意见');
+    expect((await zipEntryText(bytes, 'word/comments.xml')) || '').toContain('review note');
+    expect((await zipEntryText(bytes, 'word/comments.xml')) || '').toContain('审阅意见');
   });
 
   test('xlsx: a cell comment added via the API is written to xl/comments1.xml', async ({ page }) => {
@@ -104,6 +104,6 @@ test.describe('comments survive a save (real editor)', () => {
     const names = zipEntryNames(bytes);
     const part = names.find((n) => /^xl\/comments\d*\.xml$/.test(n));
     expect(part, `comments part missing in ${names.join(',')}`).toBeTruthy();
-    expect(zipEntryText(bytes, part!) || '').toContain('cell note');
+    expect((await zipEntryText(bytes, part!)) || '').toContain('cell note');
   });
 });

--- a/test/e2e/corpus.spec.ts
+++ b/test/e2e/corpus.spec.ts
@@ -175,9 +175,9 @@ test.describe('real-document corpus matrix', () => {
       // L2 for word/slide OOXML inputs: text of the input vs the saved output
       // (Node side; the page hands over base64). Capped to keep the transfer
       // sane; bigger files report "skipped".
-      await page.exposeFunction('__corpusTextCoverage', (inB64: string, outB64: string) => {
-        const before = ooxmlDocumentText(new Uint8Array(Buffer.from(inB64, 'base64')));
-        const after = ooxmlDocumentText(new Uint8Array(Buffer.from(outB64, 'base64')));
+      await page.exposeFunction('__corpusTextCoverage', async (inB64: string, outB64: string) => {
+        const before = await ooxmlDocumentText(new Uint8Array(Buffer.from(inB64, 'base64')));
+        const after = await ooxmlDocumentText(new Uint8Array(Buffer.from(outB64, 'base64')));
         return { ...textCoverage(before, after), inLen: before.length, outLen: after.length };
       });
 

--- a/test/e2e/docx-features.spec.ts
+++ b/test/e2e/docx-features.spec.ts
@@ -42,7 +42,7 @@ test.describe('docx feature round trips (real editor)', () => {
     const out = new Uint8Array(
       Buffer.from(await roundTrip(page, 'revisions.docx', toBase64(buildDocx('', body))), 'base64'),
     );
-    const xml = zipEntryText(out, 'word/document.xml') || '';
+    const xml = (await zipEntryText(out, 'word/document.xml')) || '';
     expect(xml).toMatch(/<w:ins\b[^>]*w:author="Reviewer"/);
     expect(xml).toMatch(/<w:del\b[^>]*w:author="Reviewer"/);
     expect(xml).toContain('<w:delText');
@@ -66,8 +66,8 @@ test.describe('docx feature round trips (real editor)', () => {
     const footer = names.find((n) => /^word\/footer\d+\.xml$/.test(n));
     expect(header, `no header part in ${names.join(',')}`).toBeTruthy();
     expect(footer, `no footer part in ${names.join(',')}`).toBeTruthy();
-    expect(ooxmlText(zipEntryText(out, header!) || '')).toContain('Header 页眉');
-    expect(ooxmlText(zipEntryText(out, footer!) || '')).toContain('Footer 页脚');
-    expect(ooxmlText(zipEntryText(out, 'word/document.xml') || '')).toContain('body text');
+    expect(ooxmlText((await zipEntryText(out, header!)) || '')).toContain('Header 页眉');
+    expect(ooxmlText((await zipEntryText(out, footer!)) || '')).toContain('Footer 页脚');
+    expect(ooxmlText((await zipEntryText(out, 'word/document.xml')) || '')).toContain('body text');
   });
 });

--- a/test/e2e/docx-ruby.spec.ts
+++ b/test/e2e/docx-ruby.spec.ts
@@ -37,7 +37,7 @@ test('the base word of a ruby annotation survives open + save', async ({ page })
     toBase64(buildDocx('', body)),
   );
 
-  const text = ooxmlText(zipEntryText(new Uint8Array(Buffer.from(b64, 'base64')), 'word/document.xml') || '');
+  const text = ooxmlText((await zipEntryText(new Uint8Array(Buffer.from(b64, 'base64')), 'word/document.xml')) || '');
   expect(text).toContain('東京');
   expect(text).toContain('Go to');
   expect(text).toContain('tomorrow');

--- a/test/e2e/entry-paths.spec.ts
+++ b/test/e2e/entry-paths.spec.ts
@@ -60,7 +60,7 @@ test.describe('entry paths (real editor)', () => {
     const download = await downloadPromise;
     expect(download.suggestedFilename()).toBe('url-open.docx');
     const bytes = new Uint8Array(readFileSync(await download.path()));
-    expect(ooxmlText(zipEntryText(bytes, 'word/document.xml') || '')).toContain('opened from a URL');
+    expect(ooxmlText((await zipEntryText(bytes, 'word/document.xml')) || '')).toContain('opened from a URL');
   });
 
   test('embed document:open-url fetches, opens and round-trips the document', async ({ page }) => {

--- a/test/e2e/lib/ooxml.ts
+++ b/test/e2e/lib/ooxml.ts
@@ -6,77 +6,16 @@
  * and no binary fixture lives in the repo.
  */
 
-import { inflateRawSync } from 'node:zlib';
+import { createZip, readZipEntries, readZipEntry } from 'ranuts/utils';
 
-const CRC_TABLE = (() => {
-  const table = new Uint32Array(256);
-  for (let n = 0; n < 256; n++) {
-    let c = n;
-    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
-    table[n] = c >>> 0;
-  }
-  return table;
-})();
-
-function crc32(bytes: Uint8Array): number {
-  let c = 0xffffffff;
-  for (let i = 0; i < bytes.length; i++) c = CRC_TABLE[(c ^ bytes[i]) & 0xff] ^ (c >>> 8);
-  return (c ^ 0xffffffff) >>> 0;
-}
-
-export function makeStoredZip(entries: Array<{ name: string; data: Uint8Array | string }>): Uint8Array {
-  const enc = new TextEncoder();
-  const chunks: number[] = [];
-  const central: number[] = [];
-  const u16 = (arr: number[], v: number) => arr.push(v & 0xff, (v >> 8) & 0xff);
-  const u32 = (arr: number[], v: number) => arr.push(v & 0xff, (v >> 8) & 0xff, (v >> 16) & 0xff, (v >> 24) & 0xff);
-  for (const { name, data } of entries) {
-    const nameBytes = enc.encode(name);
-    const bytes = typeof data === 'string' ? enc.encode(data) : data;
-    const crc = crc32(bytes);
-    const offset = chunks.length;
-    u32(chunks, 0x04034b50);
-    u16(chunks, 20);
-    u16(chunks, 0);
-    u16(chunks, 0);
-    u32(chunks, 0);
-    u32(chunks, crc);
-    u32(chunks, bytes.length);
-    u32(chunks, bytes.length);
-    u16(chunks, nameBytes.length);
-    u16(chunks, 0);
-    chunks.push(...nameBytes, ...bytes);
-
-    u32(central, 0x02014b50);
-    u16(central, 20);
-    u16(central, 20);
-    u16(central, 0);
-    u16(central, 0);
-    u32(central, 0);
-    u32(central, crc);
-    u32(central, bytes.length);
-    u32(central, bytes.length);
-    u16(central, nameBytes.length);
-    u16(central, 0);
-    u16(central, 0);
-    u16(central, 0);
-    u16(central, 0);
-    u32(central, 0);
-    u32(central, offset);
-    central.push(...nameBytes);
-  }
-  const centralOffset = chunks.length;
-  chunks.push(...central);
-  u32(chunks, 0x06054b50);
-  u16(chunks, 0);
-  u16(chunks, 0);
-  u16(chunks, entries.length);
-  u16(chunks, entries.length);
-  u32(chunks, central.length);
-  u32(chunks, centralOffset);
-  u16(chunks, 0);
-  return new Uint8Array(chunks);
-}
+/**
+ * Archive plumbing comes from ranuts (`createZip` / `readZipEntries` /
+ * `readZipEntry`): ecosystem first, and its reader takes sizes from the
+ * central directory, which is what makes it survive streaming-written
+ * archives. Only the OOXML-shaped helpers live here.
+ */
+export const makeStoredZip = (entries: ReadonlyArray<{ name: string; data: Uint8Array | string }>): Uint8Array =>
+  createZip(entries);
 
 const XML_HEAD = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 
@@ -269,59 +208,15 @@ export function buildPptx(title: string): Uint8Array {
   ]);
 }
 
-type ZipEntry = { name: string; method: number; compressedSize: number; localOffset: number };
-
-function zipEntries(bytes: Uint8Array): ZipEntry[] {
-  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-  let eocd = -1;
-  for (let i = bytes.length - 22; i >= 0 && i >= bytes.length - 65557; i--) {
-    if (view.getUint32(i, true) === 0x06054b50) {
-      eocd = i;
-      break;
-    }
-  }
-  if (eocd < 0) return [];
-  const count = view.getUint16(eocd + 10, true);
-  let off = view.getUint32(eocd + 16, true);
-  const entries: ZipEntry[] = [];
-  const dec = new TextDecoder();
-  for (let n = 0; n < count; n++) {
-    if (view.getUint32(off, true) !== 0x02014b50) break;
-    const method = view.getUint16(off + 10, true);
-    const compressedSize = view.getUint32(off + 20, true);
-    const nameLen = view.getUint16(off + 28, true);
-    const extraLen = view.getUint16(off + 30, true);
-    const commentLen = view.getUint16(off + 32, true);
-    const localOffset = view.getUint32(off + 42, true);
-    entries.push({
-      name: dec.decode(bytes.subarray(off + 46, off + 46 + nameLen)),
-      method,
-      compressedSize,
-      localOffset,
-    });
-    off += 46 + nameLen + extraLen + commentLen;
-  }
-  return entries;
-}
-
 /** Entry names of a zip (central directory walk); enough for L1 checks. */
 export function zipEntryNames(bytes: Uint8Array): string[] {
-  return zipEntries(bytes).map((e) => e.name);
+  return readZipEntries(bytes).map((e) => e.name);
 }
 
 /** Decoded text of one zip entry (stored or deflated) -- for L2 content checks on OOXML parts. */
-export function zipEntryText(bytes: Uint8Array, name: string): string | null {
-  const entry = zipEntries(bytes).find((e) => e.name === name);
-  if (!entry) return null;
-  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-  const lo = entry.localOffset;
-  if (view.getUint32(lo, true) !== 0x04034b50) return null;
-  const nameLen = view.getUint16(lo + 26, true);
-  const extraLen = view.getUint16(lo + 28, true);
-  const start = lo + 30 + nameLen + extraLen;
-  const raw = bytes.subarray(start, start + entry.compressedSize);
-  const data = entry.method === 8 ? new Uint8Array(inflateRawSync(raw)) : raw;
-  return new TextDecoder().decode(data);
+export async function zipEntryText(bytes: Uint8Array, name: string): Promise<string | null> {
+  const data = await readZipEntry(bytes, name);
+  return data ? new TextDecoder().decode(data) : null;
 }
 
 const XML_ENTITIES: Record<string, string> = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" };
@@ -438,7 +333,7 @@ export function buildXlsx(opts: {
  * fingerprints and other invisible off-slide text boxes that OnlyOffice
  * drops on save (vendor behavior, not user-visible content).
  */
-export function ooxmlDocumentText(bytes: Uint8Array): string {
+export async function ooxmlDocumentText(bytes: Uint8Array): Promise<string> {
   const names = zipEntryNames(bytes);
   const parts = names.includes('word/document.xml')
     ? ['word/document.xml']
@@ -454,7 +349,10 @@ export function ooxmlDocumentText(bytes: Uint8Array): string {
       // Ruby guide text (<w:rt>) is a known loss on save (the base word is
       // preserved by preprocessDocxRuby); compare base text only.
       .replace(/<w:rt\b[\s\S]*?<\/w:rt>/g, '');
-  return parts.map((n) => ooxmlText(withoutFields(withoutHidden(zipEntryText(bytes, n) || '')))).join('\n');
+  const texts = await Promise.all(
+    parts.map(async (n) => ooxmlText(withoutFields(withoutHidden((await zipEntryText(bytes, n)) || '')))),
+  );
+  return texts.join('\n');
 }
 
 /**

--- a/test/e2e/main-site.spec.ts
+++ b/test/e2e/main-site.spec.ts
@@ -68,7 +68,7 @@ test.describe('standalone site (real editor)', () => {
     const saved = await download.path();
     const bytes = new Uint8Array(readFileSync(saved));
     expect(bytes[0]).toBe(0x50);
-    expect(ooxmlText(zipEntryText(bytes, 'word/document.xml') || '')).toContain('main site paragraph typed');
+    expect(ooxmlText((await zipEntryText(bytes, 'word/document.xml')) || '')).toContain('main site paragraph typed');
   });
 
   test('New Excel from the hero creates a blank workbook that saves via Ctrl+S', async ({ page }) => {
@@ -91,6 +91,6 @@ test.describe('standalone site (real editor)', () => {
     expect(download.suggestedFilename()).toBe('New_Document.xlsx');
     const bytes = new Uint8Array(readFileSync(await download.path()));
     expect(bytes[0]).toBe(0x50);
-    expect(zipEntryText(bytes, 'xl/sharedStrings.xml') || '').toContain('hello');
+    expect((await zipEntryText(bytes, 'xl/sharedStrings.xml')) || '').toContain('hello');
   });
 });

--- a/test/e2e/resave-idempotence.spec.ts
+++ b/test/e2e/resave-idempotence.spec.ts
@@ -87,7 +87,7 @@ test.describe('re-open / re-save idempotence (real editor)', () => {
     const names = zipEntryNames(bytes);
     expect(names).toContain('word/document.xml');
     expect(names).toContain('[Content_Types].xml');
-    expect(ooxmlText(zipEntryText(bytes, 'word/document.xml') || '')).toContain('idempotent paragraph 往返');
+    expect(ooxmlText((await zipEntryText(bytes, 'word/document.xml')) || '')).toContain('idempotent paragraph 往返');
   });
 
   test('pptx: two round trips keep the slide and its title', async ({ page }) => {
@@ -106,6 +106,6 @@ test.describe('re-open / re-save idempotence (real editor)', () => {
     expect(names).toContain('ppt/presentation.xml');
     const slides = names.filter((n) => /^ppt\/slides\/slide\d+\.xml$/.test(n));
     expect(slides).toHaveLength(1);
-    expect(ooxmlText(zipEntryText(bytes, slides[0]) || '')).toContain('Idempotent Title 标题');
+    expect(ooxmlText((await zipEntryText(bytes, slides[0])) || '')).toContain('Idempotent Title 标题');
   });
 });

--- a/test/e2e/xlsx-panes.spec.ts
+++ b/test/e2e/xlsx-panes.spec.ts
@@ -47,7 +47,7 @@ test.describe('xlsx frozen panes / autofilter (real editor)', () => {
       return btoa(s);
     }, workbook());
     const bytes = new Uint8Array(Buffer.from(b64, 'base64'));
-    const sheet = zipEntryText(bytes, 'xl/worksheets/sheet1.xml') || '';
+    const sheet = (await zipEntryText(bytes, 'xl/worksheets/sheet1.xml')) || '';
     expect(sheet).toMatch(/<pane[^>]*state="frozen"/);
     expect(sheet).toMatch(/xSplit="1"/);
     expect(sheet).toMatch(/ySplit="1"/);
@@ -105,7 +105,8 @@ test.describe('xlsx frozen panes / autofilter (real editor)', () => {
       ),
     );
     expect(result.error).toBeUndefined();
-    const sheet = zipEntryText(new Uint8Array(Buffer.from(result.b64!, 'base64')), 'xl/worksheets/sheet1.xml') || '';
+    const sheet =
+      (await zipEntryText(new Uint8Array(Buffer.from(result.b64!, 'base64')), 'xl/worksheets/sheet1.xml')) || '';
     expect(sheet).toMatch(/<pane[^>]*state="frozen"/);
   });
 });


### PR DESCRIPTION
Ecosystem first: the fixture library had its own crc32, stored-zip writer, central-directory reader and inflate. ranuts already ships all four; its reader takes sizes from the central directory, which is what survives streaming-written archives. Readers become async (DecompressionStream); 13 affected E2E specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)