### PR TITLE
fix(v9): retry an open once when the editor, not the document, failed (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,14 @@ notes. Entries describe what users experience, not internal refactors.
 
 ### Fixed
 
+- Opening a local document no longer fails with "code -82 / the file could not
+  be opened" when the editor's font system is not up yet: that case is now
+  detected (imports run without fonts) and, if the open still fails for a
+  reason that is about the editor rather than the file, the document is
+  reopened once automatically. This is what made the same file open in a
+  freshly started browser and fail in one that had been running all day
+  (GitHub #144). When an open really does fail, the error toast now names the
+  underlying reason instead of only the numeric code.
 - Spreadsheets: using Review -> Remove/Resolve comments before clicking into
   the grid no longer fails silently and leaves undo in a broken state.
 

--- a/docs/explorations/2026-08-18-issue-144-open-conversion-environment-retry.md
+++ b/docs/explorations/2026-08-18-issue-144-open-conversion-environment-retry.md
@@ -1,0 +1,108 @@
+# issue #144：Chrome 打开本地文件报 -82，Edge 正常 —— 环境类打开失败自动重试
+
+日期：2026-08-18
+相关 issue：[#144](https://github.com/ranuts/document/issues/144)（chrome中打开文件出错）
+
+## 一、现象与用户给的关键约束
+
+- 两台 Win11，Chrome 135 / Chrome 150 打开本地 `.docx`（截图里是一个中文名文件）
+  弹厂商"打开文件时发生错误"对话框 + 我们的 toast `code -82`；
+- 同两台机器上 Edge 151 打开**同一批文件正常**；
+- 用户补充：**新建文档两个浏览器都正常，只有"打开本地文件"出错**。
+
+## 二、打开链路里 -82 到底从哪来
+
+v9 的打开是厂商内部完成的：`createPersonalEditorInstance` 把字节做成 blob URL
+交给 `document.url`，编辑器 Offline 控制器执行
+
+```js
+// web-apps/apps/documenteditor/main/app.js（Offline 控制器）
+e.doc.url ? (i = await AscCommon.x2t.convertToBin(t, e.doc.title, e.doc.fileType)) : (i = { binary: 'DOCY;v5;...' }); // ← 新建走这条，根本不过 x2t
+```
+
+两点直接对上用户的观察：
+
+1. **新建文档不经过 `convertToBin`**（用内置空 DOCY），所以"新建正常、打开出错"
+   不是文件的问题，而是**打开转换链路**的问题；
+2. `convertToBin` 的任何抛错都被 `x2t_helper.js` 重新包成
+   `Document conversion failed: ...`，落到 frame 的 unhandledrejection 上，由
+   `installOpenFailureGuard` 转成 `asc_onError(-82)` → 厂商对话框 + 我们的 toast。
+   **-82 因此是个笼统的出口**：文档真坏、x2t 缺导入器、以及编辑器自身还没初始化好，
+   三类完全不同的原因都长成同一张截图。
+
+## 三、为什么"同一份文件、同一台机器，Chrome 挂 Edge 好"
+
+`_convertDocument` 在写入源文件之前 `await self.fetchFonts()`，而厂商的
+`AscCommon.fetchFonts` 没有任何就绪判断：
+
+```js
+window.AscFonts.g_font_infos.forEach(function (w) {
+  ...
+  var U = AscCommon.g_font_loader.fontFilesPath;
+  A = AscCommon.g_font_loader.fontFiles[A];   // ← A 可能是 undefined
+  u.push(p(U + A.Id) ...)                     // ← 于是 .Id 抛 TypeError
+});
+```
+
+字体系统（`AscFonts.g_font_infos`、`g_font_loader.fontFiles`）与文档打开是**并行**
+初始化的，谁先到手取决于缓存冷热、网络与 CPU。线上实测（`edit.chaxus.com`，
+无痕 profile）能看到这段窗口：
+
+| t(ms) | g_font_infos | fontFiles | x2t 就绪 |
+| ----- | ------------ | --------- | -------- |
+| 2884  | undefined    | 无 loader | false    |
+| 3174  | 193          | 268       | false    |
+| 4153  | 193          | 268       | **true** |
+
+冷 profile 下 x2t 要先下载并解压 ~10 MB 的 `x2t.wasm.gz`，字体系统稳赢；
+**缓存全热的浏览器**里 x2t 从 Cache API 秒开，转换可能跑在字体系统前面，
+于是 `fetchFonts` 抛 TypeError → `Document conversion failed` → -82。
+这正好解释"天天开着的 Chrome 挂、刚装的 Edge 好"，且与 Chrome 版本无关
+（135 和 150 都挂）。
+
+仓库里本来就有一半的防护（`prepareEditorIframe` 守卫 3），但它只判断
+`AscFonts.g_font_infos` 是不是数组，**没管厂商真正解引用的
+`g_font_loader.fontFiles[i].Id`**，所以只堵住了两个坑里的一个。
+
+复现验证：真实语料（POI 的 `saut_page.docx` 等）改成中文名 `22 小爱同学.docx`
+打线上，冷 profile 三份全部 15～24 s 打开成功——**文件名与文件本身都被排除**
+（与语料战役第 2 天推翻"中文名 P0"的结论一致）。用户那侧的触发条件是浏览器
+状态，不是文档。
+
+## 四、修复
+
+1. **`isFontSystemReady()`**（新，导出可测）：`g_font_infos` 是数组、且非空时
+   `g_font_loader.fontFiles` 必须也是非空数组，否则 `fetchFonts` 一律回
+   `cb([])`。导入不需要字体，宁可无字体导入，也不能让打开失败。
+2. **`classifyOpenFailure()`**（新，导出可测）：把打开失败分成两类——
+   - `document`：`Conversion failed with code: N`、emscripten `Aborted(...)`、
+     `missing function`、`RuntimeError` → x2t 真的看过这些字节并拒绝，重试无意义；
+   - `environment`：`Cannot read properties of undefined`、`X2T module`、
+     `Failed to fetch` 等 → 编辑器自身没就绪／资源没到，文档大概率没问题。
+3. **环境类失败自动重试一次**：`retryCurrentOpen()` 用同一份字节重建编辑器
+   （连带重来的还有字体系统、x2t 模块、图片管线），期间给用户一条 info toast；
+   只重试一次，第二次仍失败才按原路弹 -82。重试用 `openGeneration` 代际号
+   标记每次构建，旧 frame 迟到的重复 rejection 不会算到新文档头上。
+4. **-82 toast 带上真实原因**：以前用户只能截到 `code -82`，现在附
+   `[Document conversion failed: ...]`（截断 160 字），下一份 issue 就能直接看出
+   是文档问题还是环境问题。
+
+## 五、用例（用例固化制度）
+
+- `test/unit/onlyoffice-editor.test.ts`：`isFontSystemReady` 三态、
+  `classifyOpenFailure` 两类共 5 条断言。
+- `test/e2e/open-retry.spec.ts`（新）：在真实编辑器里把**本次会话的第一次**
+  `AscCommon.x2t.convertToBin` 换成抛
+  `Document conversion failed: TypeError: Cannot read properties of undefined (reading 'Id')`
+  （与真实竞态同形），断言：故障确实触发过、文档最终加载完成、没有厂商错误框、
+  没有 -82、重建后的编辑器还能正常保存。
+- `test/e2e/open-failure.spec.ts`（原有）反向钉住：垃圾字节 `.xlsx` 是
+  `document` 类失败，**不重试**、立刻报错、保存快速拒绝。
+
+## 六、遗留
+
+- 真正的时序竞态无法在 CI 里稳定复现，本轮用故障注入固化行为；若线上仍有
+  用户报 -82，toast 里的原因文本会直接给出下一步方向。
+- 同批新 issue [#145](https://github.com/ranuts/document/issues/145)（安卓 Chrome
+  幻灯片初始缩放 31%、反复改缩放后报错）另案：现有 E2E 只跑桌面 Chromium，
+  缺移动端（触摸 + devicePixelRatio + 缩放）覆盖，需要先补一条移动模拟用例。

--- a/docs/test-matrix.md
+++ b/docs/test-matrix.md
@@ -8,7 +8,7 @@
 图例：`ER` = embed-regression.spec、`OF` = open-failure.spec、`SD` =
 embed-save-default.spec、`HX` = html-as-xls.spec、`FN` = filename-matrix.spec、
 `EA` = embed-api.spec、`AS` = app-smoke.spec、`CO` = corpus.spec、`SW` = sw-warm.spec、
-`RI` = resave-idempotence.spec、`FP` = format-parity.spec。
+`RI` = resave-idempotence.spec、`FP` = format-parity.spec、`OR` = open-retry.spec。
 
 ## A. 格式 × 操作（合成语料 = PR 档；真实语料 = 🌙）
 
@@ -25,6 +25,7 @@ embed-save-default.spec、`HX` = html-as-xls.spec、`FN` = filename-matrix.spec�
 | 评论                        | ⬜         | ⬜  | ⬜                    | ⬜              | ⬜   | ⬜        | —   | ⬜                                                                  |
 | 再打开→再保存（幂等）       | ⬜         | ⬜  | ⬜                    | ⬜              | ⬜   | ⬜        | ⬜  | ⬜                                                                  |
 | 打开失败可见 + 保存快速拒绝 | —          | —   | OF                    | —               | —    | —         | —   | ⬜                                                                  |
+| 环境类打开失败自动重试      | —          | —   | OR（故障注入）        | —               | —    | —         | —   | ⬜                                                                  |
 | 裸 `document:save` 默认格式 | SD         | ⬜  | FN                    | HX（→xlsx）     | ⬜   | ⬜        | ER  | ⬜                                                                  |
 
 ## B. 输入特征

--- a/lib/onlyoffice-editor.ts
+++ b/lib/onlyoffice-editor.ts
@@ -358,6 +358,109 @@ let currentDocumentBlobUrl: string | null = null;
  * Returns true once every treatment is in place on some frame, so the caller
  * can stop re-applying.
  */
+// The document currently being opened, kept so an open that fails for an
+// environment reason can be retried with the same bytes (see
+// retryCurrentOpen). Cleared on the next user-initiated open.
+type OpenAttempt = {
+  fileName: string;
+  fileType: string;
+  binData?: ArrayBuffer;
+  readonly: boolean;
+  retried: boolean;
+};
+let currentOpenAttempt: OpenAttempt | null = null;
+// Bumped for every editor build (a user-initiated open and its retry alike).
+// Each frame's failure guard captures the generation it was installed for, so
+// the duplicate rejections a torn-down frame keeps emitting cannot report an
+// error against the document that replaced it.
+let openGeneration = 0;
+// Generation whose open failure has already been acted on (reported, or
+// answered with a retry). The vendor leaves both the inner conversion promise
+// and loadDocument's own promise unhandled, so every failure arrives twice.
+let handledFailureGeneration = -1;
+
+/**
+ * Rebuild the editor once for the document that just failed to open.
+ * Returns whether a retry was started; `false` means the caller should report
+ * the failure to the user.
+ */
+function retryCurrentOpen(reason: string): boolean {
+  const attempt = currentOpenAttempt;
+  if (!attempt || attempt.retried) return false;
+  if (classifyOpenFailure(reason) !== 'environment') return false;
+  attempt.retried = true;
+  console.warn('[OO] retrying the open once after an environment failure:', reason);
+  (window as unknown as { message?: { info?: (msg: string) => void } }).message?.info?.(t('editorOpenRetrying'));
+  // Deferred: this runs from the failing frame's rejection handler, and the
+  // rebuild tears that frame down.
+  setTimeout(() => {
+    createEditorInstance({
+      fileName: attempt.fileName,
+      fileType: attempt.fileType,
+      binData: attempt.binData,
+      readonly: attempt.readonly,
+      isRetry: true,
+    }).catch((error) => {
+      console.error('[OO] open retry failed to start:', error);
+      markDocumentOpenFailed(String(error));
+    });
+  }, 0);
+  return true;
+}
+
+/**
+ * The parts of an editor frame the vendor's `AscCommon.fetchFonts` walks
+ * before the open conversion can proceed.
+ */
+export type FontSystemWindow = {
+  AscCommon?: {
+    fetchFonts?: (cb: (fonts: unknown[]) => void) => unknown;
+    g_font_loader?: { fontFiles?: unknown };
+  };
+  AscFonts?: { g_font_infos?: unknown };
+};
+
+/**
+ * Both halves of the font system have to be up before the vendor's
+ * `fetchFonts` is safe to run: it iterates `AscFonts.g_font_infos` and, for
+ * every face that needs styles, dereferences
+ * `AscCommon.g_font_loader.fontFiles[index].Id`. They are populated by
+ * different steps of the editor boot, so "g_font_infos exists" is not enough
+ * -- an entry read out of an empty `fontFiles` is `undefined` and `.Id`
+ * throws, which surfaces to the user as a -82 open error.
+ */
+export function isFontSystemReady(win: FontSystemWindow): boolean {
+  const infos = win.AscFonts?.g_font_infos;
+  if (!Array.isArray(infos)) return false;
+  // Nothing to look up: the loop body never runs, so an empty catalog is safe.
+  if (infos.length === 0) return true;
+  const files = win.AscCommon?.g_font_loader?.fontFiles;
+  return Array.isArray(files) && files.length > 0;
+}
+
+/**
+ * Open-conversion failures split into two very different kinds:
+ *
+ * - `document`: x2t ran and rejected these bytes ("Conversion failed with
+ *   code: 88", an emscripten `Aborted(...)` on an importer this wasm build
+ *   stubs out). Retrying is pointless -- the same bytes fail the same way --
+ *   so the user gets the error immediately.
+ * - `environment`: the editor tripped over its own boot state or over a
+ *   resource that did not arrive (a TypeError from a half-initialised SDK,
+ *   the x2t module missing or timing out, a failed fetch). Nothing is wrong
+ *   with the document, and a rebuilt editor usually opens it -- which is why
+ *   the same file opens in a freshly-started browser and fails in the one
+ *   that has been running all day (GitHub #144).
+ */
+export function classifyOpenFailure(message: string): 'document' | 'environment' {
+  if (/Conversion failed with code|Aborted\(|missing function|RuntimeError/i.test(message)) return 'document';
+  // The TypeError wordings of a half-initialised SDK, across engines.
+  if (/Cannot read propert|undefined is not an object|null is not an object/i.test(message)) return 'environment';
+  if (/is not a function|has no properties|can't access property/i.test(message)) return 'environment';
+  if (/X2T module|initialization timeout|Failed to fetch|NetworkError|load failed/i.test(message)) return 'environment';
+  return 'document';
+}
+
 // Open-conversion failure surfacing. The vendor's offline controller awaits
 // AscCommon.x2t.convertToBin inside loadDocument with no catch, so a failed
 // import (garbage or truncated bytes, HTML disguised as .xls/.xlsx, an x2t
@@ -380,6 +483,10 @@ function installOpenFailureGuard(win: Window): void {
   };
   if (w.__ooOpenFailureGuarded) return;
   w.__ooOpenFailureGuarded = true;
+  // The editor build this frame belongs to. A frame the retry replaced keeps
+  // emitting the rejections of its own failed open for a while; those must not
+  // be charged to the document that took its place.
+  const generation = openGeneration;
   win.addEventListener('unhandledrejection', (event) => {
     const reason = (event as PromiseRejectionEvent).reason as { message?: unknown } | undefined;
     const message = String(reason && typeof reason === 'object' ? (reason.message ?? reason) : reason);
@@ -397,10 +504,19 @@ function installOpenFailureGuard(win: Window): void {
       return;
     }
     // The vendor's async loadDocument leaves both the inner conversion
-    // promise and its own promise unhandled, so this fires twice per
-    // failure; report once.
-    if (documentOpenError) return;
+    // promise and its own promise unhandled, so this fires twice per failure;
+    // act once per editor build, and never for a superseded one.
+    if (generation !== openGeneration || documentOpenError) return;
+    if (handledFailureGeneration === generation) return;
+    handledFailureGeneration = generation;
     console.error('[OO] open conversion failed:', message);
+    // An environment-class failure (see classifyOpenFailure) says nothing
+    // about the document, so rebuild the editor once with the same bytes
+    // before telling the user the file cannot be opened. The rebuild starts
+    // the editor -- and its font system, x2t module and image pipeline --
+    // from scratch, which is what turned the failure into a success on a
+    // second, colder browser in GitHub #144.
+    if (retryCurrentOpen(message)) return;
     markDocumentOpenFailed(message);
     const api = w.Asc?.editor;
     if (!api || typeof api.sendEvent !== 'function') return;
@@ -437,23 +553,22 @@ function prepareEditorIframe(): boolean {
         console.log('[OO] SharedWorker shadowed in editor iframe (spellchecker uses a dedicated worker)');
       }
 
-      // 3. Guard the vendor build's AscCommon.fetchFonts: it reads
-      //    AscFonts.g_font_infos.forEach unconditionally, but on a cold
-      //    profile the open-document conversion can run before the font
-      //    system has populated that array, crashing the conversion
-      //    ("Cannot read properties of undefined (reading 'forEach')") and
-      //    leaving the document permanently half-open. Import conversions
-      //    don't need fonts, so report "no fonts" until the font system is
-      //    up; exports (PDF) happen much later, when it always is.
-      const ooWin = win as unknown as {
-        AscCommon?: { fetchFonts?: (cb: (fonts: unknown[]) => void) => unknown };
-        AscFonts?: { g_font_infos?: unknown };
-        __ooFetchFontsGuarded?: boolean;
-      };
+      // 3. Guard the vendor build's AscCommon.fetchFonts: the open-document
+      //    conversion awaits it (x2t_helper _convertDocument), and it walks
+      //    the font system with no readiness check of its own --
+      //    `AscFonts.g_font_infos.forEach(...)` and, per entry,
+      //    `AscCommon.g_font_loader.fontFiles[index].Id`. Whichever of the
+      //    two is not populated yet throws a TypeError that x2t_helper
+      //    rewraps as "Document conversion failed: ...", i.e. a -82 open
+      //    error on a perfectly good file. Import conversions don't need
+      //    fonts, so report "no fonts" until the whole font system is up;
+      //    exports (PDF) happen much later, when it always is.
+      const ooWin = win as unknown as FontSystemWindow & { __ooFetchFontsGuarded?: boolean };
       if (ooWin.AscCommon && typeof ooWin.AscCommon.fetchFonts === 'function' && !ooWin.__ooFetchFontsGuarded) {
         const origFetchFonts = ooWin.AscCommon.fetchFonts;
         ooWin.AscCommon.fetchFonts = function (cb: (fonts: unknown[]) => void) {
-          if (!ooWin.AscFonts || !Array.isArray(ooWin.AscFonts.g_font_infos)) {
+          if (!isFontSystemReady(ooWin)) {
+            console.warn('[OO] fetchFonts called before the font system was ready; importing without fonts');
             cb([]);
             return;
           }
@@ -1113,9 +1228,14 @@ function createPersonalEditorInstance(config: {
         // -82: the open conversion failed (see installOpenFailureGuard).
         const hint =
           code === -85 ? ` ${t('editorErrorFormatMismatch')}` : code === -82 ? ` ${t('editorErrorOpenFailed')}` : '';
+        // The numeric code alone is not diagnosable: every issue report so far
+        // arrived as a screenshot of this toast (#113, #144). When the open
+        // conversion is what failed we know exactly why, so put that reason in
+        // the toast too -- truncated, since it is vendor text.
+        const cause = code === -82 && documentOpenError ? ` [${documentOpenError.slice(0, 160)}]` : '';
         const detail = [code !== undefined ? `code ${code}` : '', data?.errorDescription].filter(Boolean).join(', ');
         (window as unknown as { message?: { error?: (msg: string) => void } }).message?.error?.(
-          `${t('editorErrorToast')}${detail ? ` (${detail})` : ''}${hint}`,
+          `${t('editorErrorToast')}${detail ? ` (${detail})` : ''}${hint}${cause}`,
         );
       },
     },
@@ -1129,7 +1249,20 @@ export function createEditorInstance(config: {
   fileType: string;
   binData?: ArrayBuffer;
   readonly?: boolean;
+  /** Set only by retryCurrentOpen: keeps the attempt's one retry budget. */
+  isRetry?: boolean;
 }): Promise<void> {
+  openGeneration += 1;
+  if (!config.isRetry) {
+    // A user-initiated open resets the retry budget for the new document.
+    currentOpenAttempt = {
+      fileName: config.fileName,
+      fileType: config.fileType,
+      binData: config.binData,
+      readonly: config.readonly ?? false,
+      retried: false,
+    };
+  }
   return queueEditorOperation(async () => {
     const { fileName, fileType, binData, readonly = false } = config;
     isReadonlyMode = readonly;

--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -169,6 +169,7 @@ export interface I18nMessages {
   editorErrorToast: string;
   editorErrorFormatMismatch: string;
   editorErrorOpenFailed: string;
+  editorOpenRetrying: string;
 
   // AI agent panel
   agentTitle: string;
@@ -239,6 +240,7 @@ const completeMessages: Record<LanguageCode.ZH | LanguageCode.EN, I18nMessages> 
     editorErrorToast: '文档处理出错',
     editorErrorFormatMismatch: '文件内容与扩展名不一致，请确认文件格式后重试',
     editorErrorOpenFailed: '文件无法打开：可能已损坏、格式不受支持，或内容与扩展名不符',
+    editorOpenRetrying: '打开文档时编辑器未就绪，正在自动重试…',
     agentTitle: 'AI 助手',
     agentOpenTip: '打开 AI 助手',
     agentSettings: '设置',
@@ -297,6 +299,7 @@ const completeMessages: Record<LanguageCode.ZH | LanguageCode.EN, I18nMessages> 
     editorErrorFormatMismatch: 'The file content does not match its extension; check the file format and try again',
     editorErrorOpenFailed:
       'The file could not be opened: it may be corrupted, in an unsupported format, or not what its extension says',
+    editorOpenRetrying: 'The editor was not ready when the document opened; retrying automatically...',
     agentTitle: 'AI Assistant',
     agentOpenTip: 'Open AI Assistant',
     agentSettings: 'Settings',

--- a/test/e2e/open-retry.spec.ts
+++ b/test/e2e/open-retry.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test } from './lib/l0';
+
+declare function post(type: string, payload?: Record<string, unknown>): Promise<any>;
+
+/**
+ * Environment-class open failures must be retried, not reported (GitHub #144:
+ * the same .docx opens in a freshly started browser and fails with
+ * "code -82" in the one that has been running all day).
+ *
+ * The vendor's open path awaits AscCommon.x2t.convertToBin with no catch, and
+ * everything it touches on the way -- the font system, the x2t module, the
+ * image pipeline -- is initialised concurrently with the document load. When
+ * one of those is not up yet the conversion rejects with a TypeError that
+ * x2t_helper rewraps as "Document conversion failed: ...", which reaches the
+ * user as -82 ("the file is corrupted or unsupported") even though the file is
+ * fine. lib/onlyoffice-editor.ts classifies such a rejection as environment
+ * (classifyOpenFailure) and rebuilds the editor once with the same bytes.
+ *
+ * The fault is injected at exactly the point the real race breaks: the first
+ * convertToBin call of the session rejects with the boot-state TypeError, the
+ * retried open runs for real.
+ */
+const FAULT_KEY = '__oo_x2t_open_fault__';
+
+test.describe('open retry after an environment failure (real editor)', () => {
+  test.describe.configure({ timeout: 180_000 });
+
+  test('a boot-state conversion failure is retried and the document opens', async ({ page, l0 }) => {
+    // The injected rejection travels the same route as the real one.
+    l0.allowFrameError(/Document conversion failed/);
+    l0.allowConsole(/Document conversion failed|open conversion failed|retrying the open|fetchFonts called before/);
+
+    await page.addInitScript(
+      ([key]) => {
+        // Arm once, in the top frame only: the editor iframe is torn down and
+        // rebuilt by the retry, and re-arming there would fault forever.
+        if (window.top === window) sessionStorage.setItem(key, 'armed');
+
+        type X2T = {
+          convertToBin?: (...args: unknown[]) => unknown;
+          __faultPatched?: boolean;
+        };
+        const patch = (): boolean => {
+          const x2t = (window as unknown as { AscCommon?: { x2t?: X2T } }).AscCommon?.x2t;
+          if (!x2t || typeof x2t.convertToBin !== 'function' || x2t.__faultPatched) return false;
+          const original = x2t.convertToBin.bind(x2t);
+          x2t.__faultPatched = true;
+          x2t.convertToBin = (...args: unknown[]) => {
+            if (sessionStorage.getItem(key) === 'armed') {
+              sessionStorage.setItem(key, 'fired');
+              // Verbatim shape of the real failure: the vendor's fetchFonts
+              // dereferencing g_font_loader.fontFiles[index].Id too early.
+              return Promise.reject(
+                new Error("Document conversion failed: TypeError: Cannot read properties of undefined (reading 'Id')"),
+              );
+            }
+            return original(...args);
+          };
+          return true;
+        };
+        if (!patch()) {
+          const timer = setInterval(() => {
+            if (patch()) clearInterval(timer);
+          }, 10);
+          setTimeout(() => clearInterval(timer), 120_000);
+        }
+      },
+      [FAULT_KEY],
+    );
+
+    // The app's own trace of the recovery, asserted below: a test that opened
+    // the document without ever going through the retry would otherwise look
+    // exactly the same.
+    const appLog: string[] = [];
+    page.on('console', (msg) => appLog.push(msg.text()));
+
+    await page.goto('/embed-demo.html');
+    await expect(page.locator('#status')).toHaveText('ready', { timeout: 60_000 });
+
+    const result = await page.evaluate(async () => {
+      const XLSX = (window as unknown as { XLSX: any }).XLSX;
+      const sheet = XLSX.utils.aoa_to_sheet([
+        ['retry', 'after', 'fault'],
+        [1, 2, 3],
+      ]);
+      const book = XLSX.utils.book_new();
+      XLSX.utils.book_append_sheet(book, sheet, 'Sheet1');
+      // SheetJS answers with an ArrayBuffer in some builds and a Uint8Array
+      // in others; the embed API wants the ArrayBuffer.
+      const written = XLSX.write(book, { bookType: 'xlsx', type: 'array' });
+      const buffer: ArrayBuffer = written instanceof ArrayBuffer ? written : written.buffer;
+      await post('document:open-buffer', {
+        fileName: 'retry-after-fault.xlsx',
+        buffer,
+        readonly: false,
+      });
+
+      // The real signal: the rebuilt editor finished loading the document.
+      const findApi = (win: Window): any => {
+        try {
+          const api = (win as any).Asc?.editor;
+          if (api && 'isDocumentLoadComplete' in api) return api;
+        } catch {
+          /* cross-origin */
+        }
+        for (let i = 0; i < win.frames.length; i++) {
+          const found = findApi(win.frames[i]);
+          if (found) return found;
+        }
+        return null;
+      };
+      const deadline = Date.now() + 120_000;
+      let loaded = false;
+      while (Date.now() < deadline) {
+        if (findApi(window)?.isDocumentLoadComplete) {
+          loaded = true;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+      return { loaded, fault: sessionStorage.getItem('__oo_x2t_open_fault__') };
+    });
+
+    // The fault really fired (a test that silently stopped injecting would
+    // otherwise pass forever) and the retry opened the document anyway.
+    expect(result.fault).toBe('fired');
+    expect(result.loaded).toBe(true);
+    expect(appLog.some((line) => /open conversion failed/.test(line))).toBe(true);
+    expect(appLog.some((line) => /retrying the open once after an environment failure/.test(line))).toBe(true);
+
+    // No open-error dialog and no -82 reached the user.
+    const editorFrame = page.frameLocator('iframe').frameLocator('iframe[name="frameEditor"]');
+    await expect(editorFrame.locator('.asc-window.modal.alert')).toHaveCount(0);
+    expect((await l0.ascErrors()).map((e) => e.id)).not.toContain('-82');
+
+    // The recovered document is a working editor, not a husk: it still saves.
+    const saved = await page.evaluate(async () => {
+      const saved = await post('document:save', { targetExt: 'XLSX' });
+      return { name: saved.file.name as string, size: saved.file.size as number };
+    });
+    expect(saved.name).toBe('retry-after-fault.xlsx');
+    expect(saved.size).toBeGreaterThan(0);
+  });
+});

--- a/test/unit/onlyoffice-editor.test.ts
+++ b/test/unit/onlyoffice-editor.test.ts
@@ -17,8 +17,10 @@ vi.mock(import('@ranuts/shared/document-utils'), async (importOriginal) => {
 });
 
 import {
+  classifyOpenFailure,
   createEditorInstance,
   getNormalizedFile,
+  isFontSystemReady,
   getReadonlyMode,
   getSavedFileMimeType,
   requestSaveDocument,
@@ -450,5 +452,44 @@ describe('onlyoffice-editor', () => {
     it('throws for unsupported types', () => {
       expect(() => toUint8Array('string data' as unknown as BlobPart)).toThrow('Unsupported saved data type');
     });
+  });
+});
+
+// The open path's two readiness/classification predicates (GitHub #144). Both
+// decide whether a perfectly good document is reported as unopenable, so they
+// are pinned here; the surrounding wiring is covered by test/e2e/open-retry.
+describe('open-conversion readiness and failure classification', () => {
+  const fontSystem = (infos: unknown, fontFiles: unknown) => ({
+    AscFonts: { g_font_infos: infos },
+    AscCommon: { g_font_loader: { fontFiles } },
+  });
+
+  it('reports the font system as unready until the catalog is an array', () => {
+    expect(isFontSystemReady({})).toBe(false);
+    expect(isFontSystemReady(fontSystem(undefined, [{ Id: '000' }]))).toBe(false);
+  });
+
+  it('reports an empty catalog as ready (the vendor loop never dereferences)', () => {
+    expect(isFontSystemReady(fontSystem([], undefined))).toBe(true);
+  });
+
+  it('requires the font files of a non-empty catalog (fontFiles[i].Id would throw)', () => {
+    expect(isFontSystemReady(fontSystem([{ Name: 'Arial' }], undefined))).toBe(false);
+    expect(isFontSystemReady(fontSystem([{ Name: 'Arial' }], []))).toBe(false);
+    expect(isFontSystemReady(fontSystem([{ Name: 'Arial' }], [{ Id: '000' }]))).toBe(true);
+  });
+
+  it('classifies x2t verdicts on the bytes as document failures (no retry)', () => {
+    expect(classifyOpenFailure('Document conversion failed: Error: Conversion failed with code: 88')).toBe('document');
+    expect(classifyOpenFailure('Aborted(missing function: _ZN10CHtmlFile2C1Ev)')).toBe('document');
+    expect(classifyOpenFailure('RuntimeError: memory access out of bounds')).toBe('document');
+  });
+
+  it('classifies editor boot-state and resource failures as environment failures', () => {
+    expect(
+      classifyOpenFailure("Document conversion failed: TypeError: Cannot read properties of undefined (reading 'Id')"),
+    ).toBe('environment');
+    expect(classifyOpenFailure('X2T module not found after script loading')).toBe('environment');
+    expect(classifyOpenFailure('Document conversion failed: TypeError: Failed to fetch')).toBe('environment');
   });
 });


### PR DESCRIPTION
Fixes the failure mode behind #144 (`chrome中打开文件出错`): opening a local
`.docx` shows the vendor dialog plus a `code -82` toast in the reporter's
everyday Chrome, while the same files open normally in a freshly installed
Edge on the same machines, and creating a document works in both.

## Why it happens

v9 opens documents inside the editor: the Offline controller awaits
`AscCommon.x2t.convertToBin` with no catch, and `x2t_helper` rewraps every
throw as `Document conversion failed: ...`, which `installOpenFailureGuard`
turns into `asc_onError(-82)`. So `-82` is a funnel: a genuinely broken file,
an importer this wasm build stubs out, and an editor that simply is not
initialised yet all produce the same screenshot. Creating a document takes the
`else` branch (a built-in empty DOCY) and never calls the converter — which is
exactly the asymmetry the reporter describes.

The concrete offender is the font system. The vendor's `fetchFonts` has no
readiness check of its own:

```js
window.AscFonts.g_font_infos.forEach(function (w) {
  A = AscCommon.g_font_loader.fontFiles[A];  // may be undefined
  u.push(p(U + A.Id) ...)                    // -> TypeError
});
```

`g_font_infos` and `g_font_loader.fontFiles` are populated concurrently with
the document load, so which side wins depends on cache warmth, network and
CPU — a browser with everything cached starts the conversion sooner and can
lose the race that a cold one wins. The guard already in the repo only checked
`g_font_infos`, not the entry that is actually dereferenced.

Ruled out along the way: the file and its name. Real POI corpus documents
renamed `22 小爱同学.docx` open against production in 15–24 s on cold
profiles, consistent with campaign day 2 overturning the "Chinese filename"
hypothesis.

## What changes

- `isFontSystemReady()` — the fetchFonts guard now requires both halves of the
  font system; until then imports run without fonts (they do not need them).
- `classifyOpenFailure()` — x2t verdicts on the bytes (`Conversion failed with
  code: N`, emscripten `Aborted(...)`, a missing importer) stay immediate
  errors; boot-state TypeErrors, a missing x2t module and failed fetches are
  environment failures.
- An environment failure rebuilds the editor **once** with the same bytes
  before anything is reported. Open generations keep a superseded frame's late
  duplicate rejections off the document that replaced it.
- The `-82` toast now names the underlying reason, so the next report is
  diagnosable from its screenshot alone (every issue so far arrived as a
  screenshot of the numeric code).

## Tests

- `test/e2e/open-retry.spec.ts` (new): injects the boot-state failure into the
  first `convertToBin` of a real editor session, then asserts the fault fired,
  the app logged the retry, the document loaded, no dialog or `-82` reached the
  user, and the recovered editor still saves.
- `test/e2e/open-failure.spec.ts` (unchanged) pins the other side: garbage
  bytes are a document failure, reported immediately with no retry.
- Unit coverage for both predicates.

Full unit suite (563) green; the open-path E2E subset (embed-regression,
embed-save-default, entry-paths, open-failure, open-retry — 18 tests) green.

Notes for #145 (Android slide zoom) are in the exploration doc; it needs mobile
emulation coverage we do not have yet and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)