### PR TITLE
fix(v9): give the slide the phone's screen and repaint a lost canvas (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,14 @@ notes. Entries describe what users experience, not internal refactors.
 
 ### Fixed
 
+- Presentations on a phone now use the screen: the slide thumbnails, the right
+  panel, the rulers and the notes pane are folded away on narrow viewports and
+  the slide starts fitted to the width, so it opens at a readable size instead
+  of a stamp in the middle of the screen (GitHub #145). The thumbnails come
+  back from the left rail.
+- The editor no longer stays blank when the browser discards its canvas under
+  memory pressure (seen on Android after repeatedly changing the zoom): it
+  repaints as soon as the canvas is restored.
 - Opening a local document no longer fails with "code -82 / the file could not
   be opened" when the editor's font system is not up yet: that case is now
   detected (imports run without fonts) and, if the open still fails for a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,7 +485,10 @@ v7 代码分支（OO_VARIANT、页面级 x2t 打开转换、empty_bin 模板、v
   之后每次 asc_DownloadAs 被静默丢弃）、整表序列设置（守卫 7：全选后
   asc_GetSeriesSettings 按 1048576×16384 建序列直接 OOM 崩渲染进程）、
   评论批量操作（守卫 8：无选区时 removeAllComments/resolveAllComments 读
-  `_getSelection().ranges` 抛错且漏开历史事务）、字体加载加速、
+  `_getSelection().ranges` 抛错且漏开历史事务）、画布上下文丢失（守卫 9：
+  移动端内存紧张时浏览器丢弃 canvas backing store，vendor 完全不监听
+  contextlost/contextrestored，编辑器停在白屏；捕获阶段监听后用
+  `WordControl.OnResize()` 重绘）、字体加载加速、
   `installOpenFailureGuard`（打开转换失败 → asc_onError -82 + toast + 遮罩终止 +
   保存快速拒绝）——其中 image pipeline 修的是"文档含图片
   时保存令主线程永久卡死"：无服务器时 sendImgUrls 注册不了图片，DOCY

--- a/docs/explorations/2026-08-18-issue-145-mobile-slide-zoom-and-canvas-loss.md
+++ b/docs/explorations/2026-08-18-issue-145-mobile-slide-zoom-and-canvas-loss.md
@@ -1,0 +1,95 @@
+# issue #145：安卓 Chrome 幻灯片初始缩放 31%、改几次缩放后变白 —— 手机版式 + 画布上下文丢失守卫
+
+日期：2026-08-18
+相关 issue：[#145](https://github.com/ranuts/document/issues/145)
+
+## 一、现象
+
+- 安卓 Chrome 打开幻灯片，**初始缩放只有 31%**（幻灯片缩成屏幕中间一小块）；
+- **反复改几次缩放之后"报错"**，用户截图是一张几乎全白、只剩滚动条与两个占位框的页面。
+
+## 二、复现（Playwright Pixel 5 模拟，本地生产构建）
+
+| 量                     | 修复前     |
+| ---------------------- | ---------- |
+| 视口宽                 | 393 px     |
+| 画布区 `#id_viewer` 宽 | **191 px** |
+| 打开后的缩放           | **12%**    |
+
+版式实测（截图见 PR）：左侧图标栏 40 px + 幻灯片缩略图面板 ~105 px +
+右侧图标栏 ~38 px + 底部备注栏，**三分之二以上的宽度给了侧边面板**，
+留给幻灯片的只有一条 191 px 的窄缝，"适应幻灯片"于是算出 12%。
+用户设备更宽（或横屏），同样机制下算出 31%。
+
+根因不是缩放算法，而是**手机上跑的是桌面版编辑器**：厂商确实带了移动版
+bundle（`web-apps/apps/presentationeditor/mobile/`），但**只有 `main`
+（桌面）bundle 带这套离线 x2t 补丁**（`grep convertToBin` 在 mobile bundle 里
+0 命中，`window.isOffline` 同样只在 main 里），所以 `type: 'mobile'` 一旦切过去，
+本地文件根本打不开。移动版要能用，得先把离线补丁移植进去 —— 属于 vendor
+层的独立工作，本轮不做。
+
+## 三、修复一：紧凑版式（≤600 px 视口）
+
+`compactViewportCustomization()` + `applyCompactSlideLayout()`：
+
+- `layout.rightMenu: false`（对象设置面板在 393 px 上本来就没法用）；
+- `hideNotes: true`、`hideRulers: true`、`compactHeader: true`；
+- `zoom: -2`（适应宽度，而不是适应整页）；
+- 文档就绪后对**幻灯片文档**调 `api.ShowThumbnails(false)` 收起缩略图面板，
+  再 `zoomFitToWidth()` 重新适配 —— **左侧图标栏刻意保留**，用户可以从那里
+  把缩略图面板叫回来；翻页也不依赖它（主视图直接滚动，状态栏有页码）。
+
+Pixel 5 实测：画布 191 → **337 px**，初始缩放 12% → **24%**（一半的提升来自
+收起缩略图：只关面板时 245 px / 17%）。桌面视口完全不受影响。
+
+顺带的收益：缩略图面板每张幻灯片一个 canvas，收起后 frame 里的 canvas 数量
+大幅下降 —— 这直接关系到下面第二个问题。
+
+## 四、修复二：画布上下文丢失守卫（守卫 9）
+
+用户截图里"全白 + 滚动条还在"是 **2D canvas backing store 被丢弃**的典型形态：
+移动版 Chrome 在内存紧张时会丢弃 canvas 内容，每次改缩放都会按 devicePixelRatio
+（安卓常见 2.75～3.5）重新分配大块 canvas，反复改缩放正是最容易触发的操作。
+
+而这份 vendor 构建**完全没监听** `contextlost` / `contextrestored`
+（`grep -rl contextlost public/sdkjs public/web-apps` 只命中无关的 monaco 文件），
+所以一旦丢弃，编辑器就永远停在白屏。
+
+`prepareEditorIframe` 新增守卫 9：在编辑器 frame 的 document 上以**捕获阶段**
+（这两个事件不冒泡）监听 `contextlost` / `contextrestored` / `webglcontextrestored`，
+触发时调 `Asc.editor.WordControl.OnResize()` 强制重绘。
+
+重绘手段是实测挑出来的（把 `#id_viewer` 涂白后逐个试）：
+
+| 调用                         | 是否重绘                     |
+| ---------------------------- | ---------------------------- |
+| `window` 派发 `resize` 事件  | 否（尺寸没变，SDK 直接跳过） |
+| `api.Resize()`               | 否                           |
+| `WordControl.UpdateHorRuler` | 否                           |
+| **`WordControl.OnResize()`** | **是**                       |
+| `WordControl.OnScroll()`     | 是（兜底）                   |
+
+注意 `contextlost` **不能 `preventDefault()`**：按 HTML 规范，事件未被取消时
+浏览器才会恢复上下文并派发 `contextrestored`。
+
+## 五、用例
+
+`test/e2e/mobile-slide.spec.ts`（新，Pixel 5 模拟，仅 chromium）：
+
+1. 版式：画布宽 > 视口的 75%、初始缩放 ≥ 20%、右侧面板宽度为 0；
+2. 缩放连打（in/out/fit/100 共 8 次）：无 `asc_onError`、无厂商弹框、
+   画布仍有内容（逐像素统计非白像素）；
+3. 上下文丢失恢复：涂白画布 → 派发 `contextlost` + `contextrestored` →
+   断言画面被重绘回来。**去掉守卫 9 后该用例确实变红**（已实测验证）。
+
+单测补 `isCompactViewport` / `compactViewportCustomization` 两组断言。
+
+## 六、诚实的边界
+
+- 第 3 条用例用的是**合成事件**：真实的 backing store 丢弃无法按需触发，
+  所以它钉住的是"丢弃后能恢复"的接线，而不是"安卓一定不再丢弃"。
+- 桌面模拟里**没能复现**用户说的"报错"（8 次缩放连打无任何错误），
+  所以不排除用户遇到的是渲染进程被系统回收（Aw, Snap）之类的更粗暴的失败；
+  真是那样的话，紧凑版式带来的 canvas 数量下降与内存占用下降仍然有帮助。
+- 真正的解法是把离线补丁移植到 vendor 的移动版 bundle，让手机跑触摸 UI；
+  已记在待办里，需要单独一轮。

--- a/docs/test-matrix.md
+++ b/docs/test-matrix.md
@@ -8,7 +8,7 @@
 图例：`ER` = embed-regression.spec、`OF` = open-failure.spec、`SD` =
 embed-save-default.spec、`HX` = html-as-xls.spec、`FN` = filename-matrix.spec、
 `EA` = embed-api.spec、`AS` = app-smoke.spec、`CO` = corpus.spec、`SW` = sw-warm.spec、
-`RI` = resave-idempotence.spec、`FP` = format-parity.spec、`OR` = open-retry.spec。
+`RI` = resave-idempotence.spec、`FP` = format-parity.spec、`OR` = open-retry.spec、`MS` = mobile-slide.spec。
 
 ## A. 格式 × 操作（合成语料 = PR 档；真实语料 = 🌙）
 
@@ -47,6 +47,7 @@ embed-save-default.spec、`HX` = html-as-xls.spec、`FN` = filename-matrix.spec�
 
 | 环境                                                                                         | 覆盖                                                                                                                                                                                                                                              |
 | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 手机视口（Pixel 5 模拟，桌面 vendor bundle）                                                 | `MS` = mobile-slide.spec（紧凑版式后的画布宽度与初始缩放、缩放连打无错误、画布上下文丢失后重绘）；真实安卓设备 ⬜                                                                                                                                 |
 | 全新 profile 冷启动                                                                          | 每个 Playwright 用例即冷 profile                                                                                                                                                                                                                  |
 | SW 已控制页面（老用户）                                                                      | `SW` = sw-warm.spec（第二次加载由 SW 控制页面与编辑器 frame，打开+保存往返）；"SW 缓存旧构建"升级路径：策略改为新 SW 等待、无文档时才 SKIP_WAITING + 重载（`lib/sw-update.ts`，单测 `test/unit/sw-update.test.ts` + sw.js 契约）；双构建端到端 ⬜ |
 | standalone 主站                                                                              | AS（加载 / manifest）；编辑器路径 ⬜                                                                                                                                                                                                              |

--- a/lib/onlyoffice-editor.ts
+++ b/lib/onlyoffice-editor.ts
@@ -1036,6 +1036,58 @@ function prepareEditorIframe(): boolean {
         console.log('[OO] comment bulk-action guard installed (no-op without a cell selection)');
       }
 
+      // 9. Canvas context loss. Mobile Chrome discards 2D canvas backing stores
+      //    under memory pressure, and this vendor build listens for neither
+      //    `contextlost` nor `contextrestored` (grep: zero hits in sdkjs), so
+      //    the editor is left showing a blank white page with live scrollbars
+      //    -- what GitHub #145 reports after repeatedly changing the zoom of a
+      //    presentation on Android, where every zoom step reallocates canvases
+      //    at the device pixel ratio. The lever that actually repaints is
+      //    WordControl.OnResize (verified: a wiped canvas comes back to a full
+      //    render; a plain window resize event does not, the SDK skips it when
+      //    the size is unchanged).
+      //
+      //    Note: the `contextlost` event must NOT be canceled. Per the HTML
+      //    spec the UA restores the context only when the event goes
+      //    uncanceled, and it then fires `contextrestored`.
+      const lossWin = win as unknown as {
+        __ooCanvasLossGuarded?: boolean;
+        Asc?: { editor?: { WordControl?: { OnResize?: () => void; OnScroll?: () => void } } };
+      };
+      if (!lossWin.__ooCanvasLossGuarded) {
+        const repaintEditor = (): void => {
+          const control = lossWin.Asc?.editor?.WordControl;
+          try {
+            if (typeof control?.OnResize === 'function') control.OnResize();
+            else if (typeof control?.OnScroll === 'function') control.OnScroll();
+          } catch (error) {
+            console.warn('[OO] repaint after canvas context loss failed:', error);
+          }
+        };
+        // Capture phase: these events do not bubble, but capture still reaches
+        // the document on the way down.
+        doc.addEventListener(
+          'contextlost',
+          () => {
+            console.warn('[OO] editor canvas context lost (memory pressure); waiting for restore');
+            // Some restores arrive without a paint; nudge either way.
+            win.setTimeout(repaintEditor, 500);
+          },
+          true,
+        );
+        for (const restored of ['contextrestored', 'webglcontextrestored']) {
+          doc.addEventListener(
+            restored,
+            () => {
+              console.log('[OO] editor canvas context restored; repainting');
+              repaintEditor();
+            },
+            true,
+          );
+        }
+        lossWin.__ooCanvasLossGuarded = true;
+      }
+
       if (
         win.__ooSharedWorkerShadowed &&
         ooWin.__ooFetchFontsGuarded &&
@@ -1073,6 +1125,49 @@ function prepareEditorIframe(): boolean {
  */
 export const DEFAULT_UI_THEME = 'theme-classic-light';
 export const UI_THEME_STORAGE_KEY = 'ui-theme-id';
+
+/**
+ * Phone-sized viewports (GitHub #145). The vendor ships a separate mobile app
+ * bundle, but only its desktop ("main") build carries this package's offline
+ * x2t patch, so a phone gets the desktop UI -- whose fixed chrome (left rail
+ * plus slide thumbnails, right rail, notes pane) eats about three quarters of
+ * a 393 px viewport. What is left is a ~190 px strip, and "fit slide" then
+ * computes a zoom in the low tens of percent: the reporter saw 31 %, a Pixel 5
+ * viewport measures 12 %.
+ */
+export const COMPACT_VIEWPORT_MAX_WIDTH = 600;
+
+export function isCompactViewport(width: number = typeof window === 'undefined' ? 0 : window.innerWidth): boolean {
+  return width > 0 && width <= COMPACT_VIEWPORT_MAX_WIDTH;
+}
+
+/**
+ * Customization overrides for a phone: give the document the width the side
+ * panels were spending, and start at fit-to-width instead of fit-to-slide.
+ * The status bar stays -- it carries the zoom control and the slide counter,
+ * and the main view scrolls through the slides, so nothing becomes
+ * unreachable. Desktop viewports get none of this.
+ */
+export function compactViewportCustomization(): Record<string, unknown> {
+  return {
+    compactHeader: true,
+    hideRulers: true,
+    // Presentations only; ignored by the other editors.
+    hideNotes: true,
+    layout: {
+      // The left rail stays: it is how the slide thumbnails, comments and
+      // search are reached, and applyCompactSlideLayout collapses the
+      // thumbnails panel itself (which is the real space hog) in a way the
+      // user can undo from that rail. The right panel's object settings need
+      // more width than a phone has.
+      rightMenu: false,
+    },
+    // -2 = fit to width (-1 = fit to page). On a phone the slide should use
+    // the full width; the vendor's fit-to-page also budgets for the notes
+    // pane and toolbars and lands far smaller.
+    zoom: -2,
+  };
+}
 
 export function resolveUiTheme(): string {
   // Follows the site's ranui theme (dark site -> theme-dark) unless the user
@@ -1158,6 +1253,7 @@ function createPersonalEditorInstance(config: {
         about: false,
         hideRightMenu: true,
         uiTheme: resolveUiTheme(),
+        ...(isCompactViewport() ? compactViewportCustomization() : {}),
         features: {
           // Spellcheck is fully disabled (mode:false turns it off, not just
           // locks the toggle): its engine is imported inside a worker on
@@ -1204,6 +1300,7 @@ function createPersonalEditorInstance(config: {
         markDocumentContentReady();
         // Re-apply in case the header rendered after onAppReady.
         prepareEditorIframe();
+        applyCompactSlideLayout(normalizedType);
         // Readonly opens mount with full edit permissions and get locked
         // here instead (asc_setRestriction only works once the document is
         // loaded). Read the live flag rather than the captured config value:
@@ -1313,6 +1410,29 @@ export function createEditorInstance(config: {
   });
 }
 
+/**
+ * Presentations on a phone: the thumbnails panel is a third of the viewport
+ * (245 px of canvas out of 393 on a Pixel 5) and the slide is drawn in what is
+ * left, so "fit" lands at 17 %. Collapsing it and refitting to width gives the
+ * canvas 377 px and the slide 27 % -- the user can bring the panel back from
+ * the left rail. Navigation does not depend on it: the main view scrolls
+ * through the slides and the status bar keeps the slide counter.
+ */
+function applyCompactSlideLayout(documentType: string): void {
+  if (!isCompactViewport()) return;
+  if (DOCUMENT_TYPE_MAP[documentType] !== 'slide') return;
+  const api = getSdkEditorApi();
+  if (!api) return;
+  try {
+    api.ShowThumbnails?.(false);
+    // The canvas just got wider; the zoom the editor computed for the narrow
+    // one would leave the slide floating in the middle of the screen.
+    setTimeout(() => getSdkEditorApi()?.zoomFitToWidth?.(), 100);
+  } catch (error) {
+    console.warn('[OO] compact slide layout could not be applied:', error);
+  }
+}
+
 // Asc.c_oAscRestrictionType values (public SDK enum).
 const ASC_RESTRICTION_NONE = 0;
 const ASC_RESTRICTION_VIEW = 128;
@@ -1320,6 +1440,9 @@ const ASC_RESTRICTION_VIEW = 128;
 type SdkEditorApi = {
   asc_setRestriction?: (value: number) => void;
   asc_removeRestriction?: (value: number) => void;
+  /** Presentation editor: show/hide the slide thumbnails panel. */
+  ShowThumbnails?: (visible: boolean) => void;
+  zoomFitToWidth?: () => void;
 };
 
 // Locate the SDK API instance inside the (same-origin) editor iframe. The

--- a/test/e2e/mobile-slide.spec.ts
+++ b/test/e2e/mobile-slide.spec.ts
@@ -1,0 +1,154 @@
+import { devices } from '@playwright/test';
+import { expect, test } from './lib/l0';
+
+/**
+ * Presentations on a phone (GitHub #145: "slide in android chrome init zoom is
+ * 31%; after several times change zoom value; will be show error").
+ *
+ * Only the vendor's desktop ("main") bundle carries this package's offline x2t
+ * patch, so a phone gets the desktop UI. Its fixed chrome used to leave a
+ * ~190 px strip of a 393 px viewport for the slide, and "fit" then computed a
+ * zoom in the low tens of percent. lib/onlyoffice-editor.ts now drops the
+ * right panel, the rulers and the notes pane on compact viewports and
+ * collapses the slide thumbnails (reopenable from the left rail), which
+ * roughly doubles both numbers.
+ *
+ * The second half of the report -- a blank editor after repeated zoom changes
+ * -- matches a discarded canvas backing store, which mobile Chrome does under
+ * memory pressure and which this vendor build does not handle at all. Guard 9
+ * repaints on contextlost/contextrestored; the last test drives those events
+ * directly, since a real eviction cannot be provoked on demand.
+ */
+test.use({ ...devices['Pixel 5'] });
+
+// Installed in every frame before any page script: the editor lives in a
+// same-origin iframe, and each test needs its window to read the SDK state.
+const INSTALL_FRAME_FINDER = () => {
+  (window as any).__findEditorFrame = () => {
+    const visit = (win: Window): Window | null => {
+      try {
+        const api = (win as any).Asc?.editor;
+        if (api && 'isDocumentLoadComplete' in api) return win;
+      } catch {
+        /* cross-origin */
+      }
+      for (let i = 0; i < win.frames.length; i++) {
+        const found = visit(win.frames[i]);
+        if (found) return found;
+      }
+      return null;
+    };
+    return visit(window);
+  };
+};
+
+test.describe('presentation on a phone-sized viewport (real editor)', () => {
+  test.describe.configure({ timeout: 180_000 });
+  test.skip(({ browserName }) => browserName !== 'chromium', 'device emulation needs chromium');
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(INSTALL_FRAME_FINDER);
+    await page.goto('/editor?new=pptx');
+    await page.waitForFunction(
+      () => {
+        const visit = (win: Window): boolean => {
+          try {
+            if ((win as any).Asc?.editor?.isDocumentLoadComplete) return true;
+          } catch {
+            /* cross-origin */
+          }
+          for (let i = 0; i < win.frames.length; i++) if (visit(win.frames[i])) return true;
+          return false;
+        };
+        return visit(window);
+      },
+      null,
+      { timeout: 150_000 },
+    );
+  });
+
+  test('the slide gets the viewport instead of the side panels', async ({ page }) => {
+    const layout = await page.evaluate(() => {
+      const win = (window as any).__findEditorFrame() as Window | null;
+      if (!win) throw new Error('editor frame not found');
+      const api = (win as any).Asc.editor;
+      const width = (selector: string) =>
+        Math.round(win.document.querySelector(selector)?.getBoundingClientRect().width ?? 0);
+      return {
+        viewport: win.innerWidth,
+        canvas: width('#id_viewer'),
+        rightMenu: width('[data-layout-name="rightMenu"]'),
+        zoom: api.WordControl?.m_nZoomValue ?? 0,
+      };
+    });
+
+    // Before the compact layout: 191 px of canvas and 12 % zoom on this
+    // viewport, i.e. the slide was a thumbnail in the middle of the screen.
+    expect(layout.canvas).toBeGreaterThan(layout.viewport * 0.75);
+    expect(layout.zoom).toBeGreaterThanOrEqual(20);
+    expect(layout.rightMenu).toBe(0);
+  });
+
+  test('changing the zoom repeatedly keeps the slide rendered and raises no error', async ({ page, l0 }) => {
+    const result = await page.evaluate(async () => {
+      const win = (window as any).__findEditorFrame() as Window | null;
+      if (!win) throw new Error('editor frame not found');
+      const api = (win as any).Asc.editor;
+      const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+      const zooms: number[] = [];
+      for (const step of ['zoomIn', 'zoomIn', 'zoomIn', 'zoomOut', 'zoomFitToPage', 'zoomIn', 'zoom100', 'zoomOut']) {
+        api[step]();
+        await wait(250);
+        zooms.push(api.WordControl?.m_nZoomValue ?? 0);
+      }
+      // The slide must still be drawn: a blank canvas is the failure users see.
+      const canvas = win.document.getElementById('id_viewer') as HTMLCanvasElement;
+      const context = canvas.getContext('2d')!;
+      const pixels = context.getImageData(0, 0, Math.min(canvas.width, 300), Math.min(canvas.height, 300)).data;
+      let painted = 0;
+      for (let i = 0; i < pixels.length; i += 4) {
+        if (pixels[i] < 240 || pixels[i + 1] < 240 || pixels[i + 2] < 240) painted++;
+      }
+      return {
+        zooms,
+        inkPercent: Math.round((painted / (pixels.length / 4)) * 1000) / 10,
+        dialog: win.document.querySelector('.asc-window.modal.alert')?.textContent?.trim() ?? null,
+      };
+    });
+
+    expect(result.zooms.every((zoom) => zoom > 0)).toBe(true);
+    expect(result.inkPercent).toBeGreaterThan(0);
+    expect(result.dialog).toBeNull();
+    expect(await l0.ascErrors()).toEqual([]);
+  });
+
+  test('a lost canvas context is repainted instead of leaving a blank editor', async ({ page }) => {
+    const recovery = await page.evaluate(async () => {
+      const win = (window as any).__findEditorFrame() as Window | null;
+      if (!win) throw new Error('editor frame not found');
+      const canvas = win.document.getElementById('id_viewer') as HTMLCanvasElement;
+      const context = canvas.getContext('2d')!;
+      const ink = () => {
+        const pixels = context.getImageData(0, 0, Math.min(canvas.width, 300), Math.min(canvas.height, 300)).data;
+        let painted = 0;
+        for (let i = 0; i < pixels.length; i += 4) {
+          if (pixels[i] < 240 || pixels[i + 1] < 240 || pixels[i + 2] < 240) painted++;
+        }
+        return Math.round((painted / (pixels.length / 4)) * 1000) / 10;
+      };
+      const before = ink();
+      // What a discarded backing store leaves behind.
+      context.fillStyle = '#fff';
+      context.fillRect(0, 0, canvas.width, canvas.height);
+      const wiped = ink();
+      canvas.dispatchEvent(new Event('contextlost'));
+      canvas.dispatchEvent(new Event('contextrestored'));
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      return { before, wiped, after: ink() };
+    });
+
+    expect(recovery.before).toBeGreaterThan(0);
+    expect(recovery.wiped).toBe(0);
+    expect(recovery.after).toBeGreaterThan(0);
+  });
+});

--- a/test/unit/onlyoffice-editor.test.ts
+++ b/test/unit/onlyoffice-editor.test.ts
@@ -18,7 +18,9 @@ vi.mock(import('@ranuts/shared/document-utils'), async (importOriginal) => {
 
 import {
   classifyOpenFailure,
+  compactViewportCustomization,
   createEditorInstance,
+  isCompactViewport,
   getNormalizedFile,
   isFontSystemReady,
   getReadonlyMode,
@@ -491,5 +493,37 @@ describe('open-conversion readiness and failure classification', () => {
     ).toBe('environment');
     expect(classifyOpenFailure('X2T module not found after script loading')).toBe('environment');
     expect(classifyOpenFailure('Document conversion failed: TypeError: Failed to fetch')).toBe('environment');
+  });
+});
+
+// Phone-sized viewports (GitHub #145). Only the vendor's desktop bundle can
+// open documents offline in this package, so a phone runs the desktop UI and
+// its side panels have to be trimmed for the slide to be readable.
+describe('compact viewport customization', () => {
+  it('treats phone widths as compact and desktop widths as not', () => {
+    expect(isCompactViewport(393)).toBe(true);
+    expect(isCompactViewport(600)).toBe(true);
+    expect(isCompactViewport(601)).toBe(false);
+    expect(isCompactViewport(1280)).toBe(false);
+    // A zero width means "no window" (SSR, tests): never guess compact.
+    expect(isCompactViewport(0)).toBe(false);
+  });
+
+  it('drops the panels that cost width and starts at fit-to-width', () => {
+    const customization = compactViewportCustomization() as {
+      compactHeader: boolean;
+      hideNotes: boolean;
+      hideRulers: boolean;
+      zoom: number;
+      layout: { rightMenu: boolean; leftMenu?: boolean };
+    };
+    expect(customization.compactHeader).toBe(true);
+    expect(customization.hideNotes).toBe(true);
+    expect(customization.hideRulers).toBe(true);
+    expect(customization.zoom).toBe(-2);
+    expect(customization.layout.rightMenu).toBe(false);
+    // The left rail stays: it is the way back to the thumbnails panel that
+    // applyCompactSlideLayout collapses.
+    expect(customization.layout.leftMenu).toBeUndefined();
   });
 });


### PR DESCRIPTION
Fixes #145 ("slide in android chrome init zoom is 31%; after several times
change zoom value; will be show error").

**Stacked on #146** (the #144 fix) — that commit shows up here until #146
merges.

## Why it happens

Only the vendor's desktop (`main`) bundle carries this package's offline x2t
patch — `mobile/dist/js/app.js` has zero `convertToBin` hits and no
`window.isOffline` — so `type: 'mobile'` would mount a UI that can never open
a local file. A phone therefore runs the desktop UI, whose fixed chrome eats
the viewport:

| Pixel 5 viewport (393 px) | before |
| --- | --- |
| canvas `#id_viewer` | **191 px** |
| zoom after open | **12 %** |

Left rail 40 px + slide thumbnails ~105 px + right rail ~38 px + notes pane —
two thirds of the screen — and "fit slide" then lands in the low tens of
percent. The reporter's wider device shows 31 % by the same mechanism.

The second symptom (a near-blank page with live scrollbars after changing the
zoom a few times) matches a discarded 2D canvas backing store, which mobile
Chrome does under memory pressure — every zoom step reallocates canvases at
the device pixel ratio. This build handles neither `contextlost` nor
`contextrestored` (`grep -rl contextlost public/sdkjs public/web-apps` only
hits an unrelated monaco file), so the editor stays blank forever.

## What changes

- **Compact layout for viewports ≤ 600 px**: no right panel, no rulers, no
  notes pane, compact header, `zoom: -2` (fit to width).
- **Thumbnails collapsed for presentations** once the document is ready, then
  refit. The left rail stays so the panel is one tap away, and navigation
  never depended on it. Measured: canvas 191 → **337 px**, zoom 12 % → **24 %**.
  As a side effect the frame stops holding one canvas per slide, which is
  exactly the memory pressure behind the second symptom.
- **Guard 9**: capture-phase `contextlost` / `contextrestored` /
  `webglcontextrestored` listeners in the editor frame that repaint via
  `WordControl.OnResize()`. That call was picked by experiment — a `resize`
  event, `Resize()` and the ruler updates all leave the wiped canvas blank.
  `contextlost` is deliberately not canceled: per the HTML spec the UA
  restores the context only when the event goes uncanceled.

Desktop viewports are untouched (`isCompactViewport()` gates everything).

## Tests

`test/e2e/mobile-slide.spec.ts` (new, Pixel 5 emulation, chromium only):

1. layout — canvas wider than 75 % of the viewport, zoom ≥ 20 %, right panel gone;
2. zoom churn (8 in/out/fit/100 steps) — no `asc_onError`, no vendor dialog,
   canvas still painted (non-white pixel count);
3. recovery — wipe the canvas, dispatch `contextlost` + `contextrestored`,
   assert it repaints. **Verified red with guard 9 disabled.**

Unit coverage for `isCompactViewport` and `compactViewportCustomization`.
Full unit suite (565) green; desktop suites (app-smoke, format-parity,
embed-regression) plus the new mobile suite — 26 tests — green.

## Honest limits

Test 3 uses synthetic events: a real eviction cannot be provoked on demand, so
it pins the recovery wiring, not that Android will stop evicting. The
emulation never reproduced an actual error dialog during zoom churn, so the
reporter may have hit something coarser (a reclaimed renderer); the smaller
canvas footprint helps there too. The real fix is porting the offline patch
into the vendor's mobile bundle so phones get the touch UI — noted in the
exploration doc as follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)