### PR TITLE
fix(v9): await the font system instead of importing without it (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,8 +85,9 @@ notes. Entries describe what users experience, not internal refactors.
   memory pressure (seen on Android after repeatedly changing the zoom): it
   repaints as soon as the canvas is restored.
 - Opening a local document no longer fails with "code -82 / the file could not
-  be opened" when the editor's font system is not up yet: that case is now
-  detected (imports run without fonts) and, if the open still fails for a
+  be opened" when the editor's font system is not up yet: the conversion now
+  waits for it (a fraction of a second, and only when it is actually behind)
+  instead of tripping over it, and, if the open still fails for a
   reason that is about the editor rather than the file, the document is
   reopened once automatically. This is what made the same file open in a
   freshly started browser and fail in one that had been running all day

--- a/docs/explorations/2026-08-18-issue-144-open-conversion-environment-retry.md
+++ b/docs/explorations/2026-08-18-issue-144-open-conversion-environment-retry.md
@@ -87,10 +87,30 @@ window.AscFonts.g_font_infos.forEach(function (w) {
    `[Document conversion failed: ...]`（截断 160 字），下一份 issue 就能直接看出
    是文档问题还是环境问题。
 
+## 四·补：从"跳过字体"改成"等字体"（同日追加）
+
+第一版守卫在字体系统没就绪时直接 `cb([])`（无字体导入）——那只是让崩溃变成
+降级，竞态本身还在。追加版把它改成**有序依赖**：`awaitFontSystem()` 把回调
+压住，等字体系统就绪再交给厂商实现，只有等待超预算（5 s）才退回无字体导入。
+浏览器里没法把字体目录变成同步加载，但让转换 await 它，等价于消除竞态。
+
+两个必须算清楚的账：
+
+- **代价**：就绪时立即放行，一分不花（单测断言此路径不排任何定时器）。
+  实测本地热缓存的一次正常打开等了 **200 ms**（4 个 50 ms 轮询）——这恰好
+  反向印证了根因：热缓存下转换确实跑在字体前面。冷 profile 则等 0（字体
+  ~3.2 s 就绪，x2t ~4.2 s 才就绪）。E2E 把这个值钉在 2 s 以内，一旦某个环境
+  下字体系统性地输掉竞速、每次打开凭空多等几秒，用例先红。
+- **字体加载失败**：单个字体文件失败由厂商自己 `.catch` 吞掉，与我们无关；
+  整个字体目录都没到，则等满 5 s 后退回无字体导入——也就是第一版的行为，
+  不新增任何挂起路径。
+
 ## 五、用例（用例固化制度）
 
 - `test/unit/onlyoffice-editor.test.ts`：`isFontSystemReady` 三态、
-  `classifyOpenFailure` 两类共 5 条断言。
+  `classifyOpenFailure` 两类，外加 `awaitFontSystem` 四条（就绪即放行且不排
+  定时器、迟到就绪后放行并记录等待毫秒、超时退回 `cb([])` 且不留定时器、
+  默认预算上限）。
 - `test/e2e/open-retry.spec.ts`（新）：在真实编辑器里把**本次会话的第一次**
   `AscCommon.x2t.convertToBin` 换成抛
   `Document conversion failed: TypeError: Cannot read properties of undefined (reading 'Id')`
@@ -98,6 +118,7 @@ window.AscFonts.g_font_infos.forEach(function (w) {
   没有 -82、重建后的编辑器还能正常保存。
 - `test/e2e/open-failure.spec.ts`（原有）反向钉住：垃圾字节 `.xlsx` 是
   `document` 类失败，**不重试**、立刻报错、保存快速拒绝。
+- `open-retry.spec.ts` 第二条：正常打开时真实记录的字体等待必须 < 2 s。
 
 ## 六、遗留
 

--- a/docs/explorations/2026-08-18-issue-144-open-conversion-environment-retry.md
+++ b/docs/explorations/2026-08-18-issue-144-open-conversion-environment-retry.md
@@ -105,6 +105,11 @@ window.AscFonts.g_font_infos.forEach(function (w) {
   整个字体目录都没到，则等满 5 s 后退回无字体导入——也就是第一版的行为，
   不新增任何挂起路径。
 
+**自查 review 补的一处**：等待期间编辑器 frame 可能已被销毁（用户开了别的文档、
+或打开失败触发了重开），此时把回调交回死掉的 realm 会抛错，而且是**在定时器里抛**
+——等于宿主页面的未捕获错误。已加 try/catch 并补单测（原函数与回调都抛"dead realm"，
+断言不外抛且定时器已清）。
+
 ## 五、用例（用例固化制度）
 
 - `test/unit/onlyoffice-editor.test.ts`：`isFontSystemReady` 三态、

--- a/lib/onlyoffice-editor.ts
+++ b/lib/onlyoffice-editor.ts
@@ -438,6 +438,71 @@ export function isFontSystemReady(win: FontSystemWindow): boolean {
   return Array.isArray(files) && files.length > 0;
 }
 
+// How long the open conversion waits for the font system before giving up on
+// it. Measured on production, the font system is ready about a second BEFORE
+// the x2t module is (fonts at ~3.2 s, x2t at ~4.2 s), so the normal path waits
+// zero; the cap only bounds the case where a font system never comes up, which
+// then degrades to the fontless import that shipped in #146 instead of hanging
+// the open.
+export const FONT_SYSTEM_WAIT_MS = 5_000;
+const FONT_SYSTEM_POLL_MS = 50;
+// Milliseconds the last conversion spent waiting for fonts. Zero on the normal
+// path; asserted by the E2E suite so a systematic wait (an environment where
+// fonts always lose the race) shows up as a failing test rather than as a
+// silent few seconds added to every open.
+export const FONT_WAIT_PROBE = '__ooFontWaitMs';
+
+/**
+ * The dependency the vendor never declared. `fetchFonts` is awaited by the
+ * open conversion (x2t_helper `_convertDocument`, shared with the export
+ * path), but the font system it walks is initialised in parallel with the
+ * document load -- so whether it is ready when the conversion asks is a race
+ * decided by cache warmth, network and CPU, and losing it is a TypeError that
+ * fails the whole open with -82 (GitHub #144).
+ *
+ * Ordering the two is what removes the race rather than papering over it: hold
+ * the callback until the font system is up, then hand over to the vendor's own
+ * implementation. A browser cannot make the catalog load synchronous, but the
+ * conversion can wait for it, which buys the same guarantee. Two things keep
+ * the wait from becoming a new failure mode: it is capped, and the fallback is
+ * exactly what the code did before (report no fonts -- imports survive
+ * without them). Individual font files that fail to download are the vendor's
+ * business; its own fetchFonts already swallows those.
+ */
+export function awaitFontSystem(
+  win: FontSystemWindow,
+  original: (cb: (fonts: unknown[]) => void) => unknown,
+  cb: (fonts: unknown[]) => void,
+  options: { timeoutMs?: number; intervalMs?: number } = {},
+): void {
+  const { timeoutMs = FONT_SYSTEM_WAIT_MS, intervalMs = FONT_SYSTEM_POLL_MS } = options;
+  const record = (waited: number): void => {
+    (win as Record<string, unknown>)[FONT_WAIT_PROBE] = waited;
+  };
+  if (isFontSystemReady(win)) {
+    record(0);
+    original.call(win.AscCommon, cb);
+    return;
+  }
+  let waited = 0;
+  const timer = setInterval(() => {
+    waited += intervalMs;
+    if (isFontSystemReady(win)) {
+      clearInterval(timer);
+      record(waited);
+      console.log(`[OO] open conversion waited ${waited} ms for the font system`);
+      original.call(win.AscCommon, cb);
+      return;
+    }
+    if (waited >= timeoutMs) {
+      clearInterval(timer);
+      record(waited);
+      console.warn(`[OO] font system still not ready after ${timeoutMs} ms; importing without fonts`);
+      cb([]);
+    }
+  }, intervalMs);
+}
+
 /**
  * Open-conversion failures split into two very different kinds:
  *
@@ -560,22 +625,18 @@ function prepareEditorIframe(): boolean {
       //    `AscCommon.g_font_loader.fontFiles[index].Id`. Whichever of the
       //    two is not populated yet throws a TypeError that x2t_helper
       //    rewraps as "Document conversion failed: ...", i.e. a -82 open
-      //    error on a perfectly good file. Import conversions don't need
-      //    fonts, so report "no fonts" until the whole font system is up;
-      //    exports (PDF) happen much later, when it always is.
+      //    error on a perfectly good file. awaitFontSystem turns that race
+      //    into an ordered dependency: the conversion waits for the font
+      //    system instead of walking a half-built one, and only a wait that
+      //    runs out of budget degrades to a fontless import.
       const ooWin = win as unknown as FontSystemWindow & { __ooFetchFontsGuarded?: boolean };
       if (ooWin.AscCommon && typeof ooWin.AscCommon.fetchFonts === 'function' && !ooWin.__ooFetchFontsGuarded) {
         const origFetchFonts = ooWin.AscCommon.fetchFonts;
         ooWin.AscCommon.fetchFonts = function (cb: (fonts: unknown[]) => void) {
-          if (!isFontSystemReady(ooWin)) {
-            console.warn('[OO] fetchFonts called before the font system was ready; importing without fonts');
-            cb([]);
-            return;
-          }
-          return origFetchFonts.call(this, cb);
+          awaitFontSystem(ooWin, origFetchFonts, cb);
         };
         ooWin.__ooFetchFontsGuarded = true;
-        console.log('[OO] AscCommon.fetchFonts guarded against uninitialized font system');
+        console.log('[OO] AscCommon.fetchFonts now waits for the font system before converting');
       }
 
       // 4. Serverless image pipeline. The SDK expects a Document Server to

--- a/lib/onlyoffice-editor.ts
+++ b/lib/onlyoffice-editor.ts
@@ -487,18 +487,24 @@ export function awaitFontSystem(
   let waited = 0;
   const timer = setInterval(() => {
     waited += intervalMs;
-    if (isFontSystemReady(win)) {
-      clearInterval(timer);
-      record(waited);
-      console.log(`[OO] open conversion waited ${waited} ms for the font system`);
-      original.call(win.AscCommon, cb);
-      return;
-    }
-    if (waited >= timeoutMs) {
-      clearInterval(timer);
-      record(waited);
-      console.warn(`[OO] font system still not ready after ${timeoutMs} ms; importing without fonts`);
-      cb([]);
+    const ready = isFontSystemReady(win);
+    if (!ready && waited < timeoutMs) return;
+    clearInterval(timer);
+    record(waited);
+    // The frame this callback belongs to may have been torn down while we
+    // waited (the user opened another document, or the open failed and was
+    // retried). Handing over to a dead realm throws, and it would throw inside
+    // a timer, i.e. as an uncaught error in the host page.
+    try {
+      if (ready) {
+        console.log(`[OO] open conversion waited ${waited} ms for the font system`);
+        original.call(win.AscCommon, cb);
+      } else {
+        console.warn(`[OO] font system still not ready after ${timeoutMs} ms; importing without fonts`);
+        cb([]);
+      }
+    } catch (error) {
+      console.warn('[OO] font wait resolved into a frame that is gone:', error);
     }
   }, intervalMs);
 }

--- a/test/e2e/open-retry.spec.ts
+++ b/test/e2e/open-retry.spec.ts
@@ -141,4 +141,55 @@ test.describe('open retry after an environment failure (real editor)', () => {
     expect(saved.name).toBe('retry-after-fault.xlsx');
     expect(saved.size).toBeGreaterThan(0);
   });
+
+  test('waiting for the font system costs a fraction of a second, not seconds', async ({ page }) => {
+    // awaitFontSystem orders the conversion behind the font system instead of
+    // letting it walk a half-built one. What that ordering costs is measured
+    // here rather than assumed: a warm local run waits ~200 ms (four poll
+    // intervals), a cold one waits zero because the fonts are ready about a
+    // second before the x2t module even loads. The bound is what matters --
+    // an environment where fonts systematically lose the race would add
+    // seconds to every open, and this test is how that shows up.
+    await page.goto('/embed-demo.html');
+    await expect(page.locator('#status')).toHaveText('ready', { timeout: 60_000 });
+
+    const waited = await page.evaluate(async () => {
+      const XLSX = (window as unknown as { XLSX: any }).XLSX;
+      const sheet = XLSX.utils.aoa_to_sheet([
+        ['font', 'wait'],
+        [1, 2],
+      ]);
+      const book = XLSX.utils.book_new();
+      XLSX.utils.book_append_sheet(book, sheet, 'Sheet1');
+      const written = XLSX.write(book, { bookType: 'xlsx', type: 'array' });
+      const buffer: ArrayBuffer = written instanceof ArrayBuffer ? written : written.buffer;
+      await post('document:open-buffer', { fileName: 'font-wait.xlsx', buffer, readonly: false });
+
+      const findFrame = (win: Window): Window | null => {
+        try {
+          const api = (win as any).Asc?.editor;
+          if (api && 'isDocumentLoadComplete' in api) return win;
+        } catch {
+          /* cross-origin */
+        }
+        for (let i = 0; i < win.frames.length; i++) {
+          const found = findFrame(win.frames[i]);
+          if (found) return found;
+        }
+        return null;
+      };
+      const deadline = Date.now() + 120_000;
+      while (Date.now() < deadline) {
+        const frame = findFrame(window) as (Window & { __ooFontWaitMs?: number; Asc?: any }) | null;
+        if (frame?.Asc?.editor?.isDocumentLoadComplete) return frame.__ooFontWaitMs ?? null;
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+      return null;
+    });
+
+    // null would mean fetchFonts never ran at all, which is itself a change
+    // worth failing on: the conversion is supposed to go through the guard.
+    expect(waited).not.toBeNull();
+    expect(waited).toBeLessThan(2_000);
+  });
 });

--- a/test/unit/onlyoffice-editor.test.ts
+++ b/test/unit/onlyoffice-editor.test.ts
@@ -581,6 +581,24 @@ describe('awaitFontSystem', () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it('survives the editor frame disappearing while it waits', () => {
+    const win: any = notReady();
+    // What a torn-down frame looks like from here: touching it throws.
+    const original = vi.fn(() => {
+      throw new Error('Cannot access a dead realm');
+    });
+    const cb = vi.fn(() => {
+      throw new Error('Cannot access a dead realm');
+    });
+    awaitFontSystem(win, original, cb, { timeoutMs: 200, intervalMs: 50 });
+    win.AscFonts.g_font_infos = [{ Name: 'Arial' }];
+    win.AscCommon.g_font_loader.fontFiles = [{ Id: '000' }];
+    // Would otherwise throw out of a timer, i.e. uncaught in the host page.
+    expect(() => vi.advanceTimersByTime(50)).not.toThrow();
+    expect(original).toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it('keeps the default wait short enough to stay under the save readiness budget', () => {
     expect(FONT_SYSTEM_WAIT_MS).toBeLessThanOrEqual(10_000);
   });

--- a/test/unit/onlyoffice-editor.test.ts
+++ b/test/unit/onlyoffice-editor.test.ts
@@ -17,10 +17,12 @@ vi.mock(import('@ranuts/shared/document-utils'), async (importOriginal) => {
 });
 
 import {
+  awaitFontSystem,
   classifyOpenFailure,
   compactViewportCustomization,
   createEditorInstance,
   isCompactViewport,
+  FONT_SYSTEM_WAIT_MS,
   getNormalizedFile,
   isFontSystemReady,
   getReadonlyMode,
@@ -525,5 +527,61 @@ describe('compact viewport customization', () => {
     // The left rail stays: it is the way back to the thumbnails panel that
     // applyCompactSlideLayout collapses.
     expect(customization.layout.leftMenu).toBeUndefined();
+  });
+});
+
+// The open conversion must wait for the font system rather than walk a
+// half-built one (GitHub #144). The wait has to stay bounded: a font system
+// that never comes up degrades to a fontless import, it must not hang the open.
+describe('awaitFontSystem', () => {
+  const ready = () => ({
+    AscFonts: { g_font_infos: [{ Name: 'Arial' }] },
+    AscCommon: { g_font_loader: { fontFiles: [{ Id: '000' }] } },
+  });
+  const notReady = () => ({ AscFonts: {}, AscCommon: { g_font_loader: {} } });
+
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('delegates immediately when the font system is already up (the normal path)', () => {
+    const original = vi.fn();
+    const cb = vi.fn();
+    awaitFontSystem(ready(), original, cb);
+    expect(original).toHaveBeenCalledWith(cb);
+    expect(cb).not.toHaveBeenCalled();
+    // Nothing is scheduled, so a ready font system costs no time at all.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('delegates as soon as a late font system comes up', () => {
+    const win: any = notReady();
+    const original = vi.fn();
+    const cb = vi.fn();
+    awaitFontSystem(win, original, cb, { timeoutMs: 1000, intervalMs: 50 });
+    vi.advanceTimersByTime(200);
+    expect(original).not.toHaveBeenCalled();
+    win.AscFonts.g_font_infos = [{ Name: 'Arial' }];
+    win.AscCommon.g_font_loader.fontFiles = [{ Id: '000' }];
+    vi.advanceTimersByTime(50);
+    expect(original).toHaveBeenCalledWith(cb);
+    expect(cb).not.toHaveBeenCalled();
+    expect(win.__ooFontWaitMs).toBe(250);
+  });
+
+  it('falls back to a fontless import when the font system never comes up', () => {
+    const win: any = notReady();
+    const original = vi.fn();
+    const cb = vi.fn();
+    awaitFontSystem(win, original, cb, { timeoutMs: 500, intervalMs: 50 });
+    vi.advanceTimersByTime(500);
+    expect(original).not.toHaveBeenCalled();
+    expect(cb).toHaveBeenCalledWith([]);
+    expect(win.__ooFontWaitMs).toBe(500);
+    // Bounded: no timer is left running to fire again.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('keeps the default wait short enough to stay under the save readiness budget', () => {
+    expect(FONT_SYSTEM_WAIT_MS).toBeLessThanOrEqual(10_000);
   });
 });


### PR DESCRIPTION
Follow-up to #146. That PR stopped the crash by answering an unready font
system with `cb([])` — a fontless import. It turned a failure into a
degradation, but the race itself was still there: whether the open conversion
meets a built font system still depended on cache warmth.

This orders the two instead. `awaitFontSystem` holds the vendor's `fetchFonts`
callback until both halves of the font system are populated, then delegates to
the vendor implementation — so the conversion runs *with* fonts rather than
around them. A browser cannot make the catalog load synchronous, but the
conversion can wait for it, which buys the same guarantee.

## The two risks, measured rather than assumed

**Does it cost time?** A ready font system delegates synchronously and
schedules nothing (asserted in a unit test: zero timers). Where it does wait:

| profile | wait |
| --- | --- |
| warm local open | **~200 ms** (4 poll intervals) |
| cold profile | **0** — fonts are ready ~3.2 s, x2t only at ~4.2 s |

The warm number is itself the proof of the race: with everything cached, x2t
starts before the fonts land, which is exactly the reporter's situation.
`open-retry.spec.ts` now records the real wait and fails above 2 s, so an
environment where fonts systematically lose the race shows up as a red test
instead of seconds silently added to every open.

**What if font loading fails?** Two layers, both covered: individual font
downloads are already swallowed by the vendor's own `fetchFonts` (`.catch`
per request), and a font catalog that never arrives times out after 5 s and
falls back to exactly the previous behaviour — the fontless import from #146,
never a hang.

Side benefit: `_convertDocument` is shared with the export path, where fonts
are not optional (PDF), so waiting improves export fidelity too.

## Tests

- Unit: delegates immediately when ready (and schedules nothing); delegates as
  soon as a late font system comes up, recording the waited ms; falls back to
  `cb([])` after the cap and leaves no timer behind; the default budget stays
  bounded.
- E2E: `open-retry.spec.ts` gains the measured-wait test above; the retry and
  no-retry specs are unchanged and still green.

Full unit suite (567) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)