### PR TITLE
fix(v9): never leave the conversion waiting on a callback that will not come (#144)

### DIFF
--- a/docs/explorations/2026-08-18-issue-144-open-conversion-environment-retry.md
+++ b/docs/explorations/2026-08-18-issue-144-open-conversion-environment-retry.md
@@ -110,12 +110,36 @@ window.AscFonts.g_font_infos.forEach(function (w) {
 ——等于宿主页面的未捕获错误。已加 try/catch 并补单测（原函数与回调都抛"dead realm"，
 断言不外抛且定时器已清）。
 
+**自查 review 补的第二处（更要命）**：上面那个 try/catch 一并把
+`original.call(...)`（厂商 `fetchFonts`）也包了进去，而厂商这个函数**会同步抛**
+——它在 `AscFonts.g_font_infos.forEach` 里直接取 `g_font_loader.fontFiles[index].Id`，
+只要索引落空就是 TypeError。调用方 `x2t_helper.js` 的
+`fetchFonts` 是 `new Promise((resolve, reject) => AscCommon.fetchFonts(cb))`，
+**只有回调被调用才 resolve**。于是：
+
+- 同步路径（字体已就绪那一支）抛出是好事：它发生在调用方的 executor 里，
+  会 reject 整个打开 → -82 → `installOpenFailureGuard` 重试。故意不包。
+- 定时器路径抛出被吞掉后，没有任何人 settle 那个 Promise，转换永远 await
+  一个不会来的回调 —— 正是 `installOpenFailureGuard` 当初要消灭的**永久转圈**，
+  而且连 -82 都不会报。
+
+改法：catch 里在 `ready` 分支补一次 `cb([])`（自身再包一层 try），把它降级成
+和"等超时"完全一样的无字体导入；同时把 `isFontSystemReady(win)` 与 `record()`
+也移进 try——前者裸抛还会漏掉 `clearInterval`，留下永不停止的 interval。
+
+反向验证：去掉这次的 `cb([])` 兜底，新用例 `answers a throwing vendor
+fetchFonts with a fontless import, never with silence` 立刻变红
+（`expected "vi.fn()" to be called 1 times, but got 0 times`——回调零次，即挂起）；
+去掉 `isFontSystemReady` 外的 try，`stops polling when reading the frame itself
+starts throwing` 变红（`Cannot access a dead realm` 从定时器里裸抛出来）。
+
 ## 五、用例（用例固化制度）
 
 - `test/unit/onlyoffice-editor.test.ts`：`isFontSystemReady` 三态、
-  `classifyOpenFailure` 两类，外加 `awaitFontSystem` 四条（就绪即放行且不排
+  `classifyOpenFailure` 两类，外加 `awaitFontSystem` 八条（就绪即放行且不排
   定时器、迟到就绪后放行并记录等待毫秒、超时退回 `cb([])` 且不留定时器、
-  默认预算上限）。
+  frame 消失时不外抛、**厂商同步抛错时仍把 `cb([])` 交出去且只交一次**、
+  正常交接时兜底不插手、读 frame 抛错时停止轮询、默认预算上限）。
 - `test/e2e/open-retry.spec.ts`（新）：在真实编辑器里把**本次会话的第一次**
   `AscCommon.x2t.convertToBin` 换成抛
   `Document conversion failed: TypeError: Cannot read properties of undefined (reading 'Id')`

--- a/lib/onlyoffice-editor.ts
+++ b/lib/onlyoffice-editor.ts
@@ -487,15 +487,25 @@ export function awaitFontSystem(
   let waited = 0;
   const timer = setInterval(() => {
     waited += intervalMs;
-    const ready = isFontSystemReady(win);
+    // Reading the frame is itself a realm access: if it throws, keep the
+    // failure out of the timer and stop polling rather than leaving an
+    // interval running forever.
+    let ready: boolean;
+    try {
+      ready = isFontSystemReady(win);
+    } catch (error) {
+      clearInterval(timer);
+      console.warn('[OO] font wait could not read the editor frame:', error);
+      return;
+    }
     if (!ready && waited < timeoutMs) return;
     clearInterval(timer);
-    record(waited);
     // The frame this callback belongs to may have been torn down while we
     // waited (the user opened another document, or the open failed and was
     // retried). Handing over to a dead realm throws, and it would throw inside
     // a timer, i.e. as an uncaught error in the host page.
     try {
+      record(waited);
       if (ready) {
         console.log(`[OO] open conversion waited ${waited} ms for the font system`);
         original.call(win.AscCommon, cb);
@@ -504,7 +514,23 @@ export function awaitFontSystem(
         cb([]);
       }
     } catch (error) {
-      console.warn('[OO] font wait resolved into a frame that is gone:', error);
+      console.warn('[OO] font wait could not hand the conversion over:', error);
+      // The vendor's fetchFonts throws synchronously when it walks a font
+      // system that is up but incomplete (an index into a half-filled
+      // g_font_loader.fontFiles is undefined, and it dereferences .Id). On the
+      // ready path above that throw is useful: it happens inside the caller's
+      // promise executor, which rejects the open -- a -82 the failure guard
+      // then retries. In here there is no executor to catch it, and the
+      // conversion is awaiting a callback that would now never come, i.e. the
+      // permanent spinner installOpenFailureGuard exists to prevent. So answer
+      // it the way a timed-out wait is answered: a fontless import.
+      if (ready) {
+        try {
+          cb([]);
+        } catch {
+          // The frame really is gone; nothing is waiting on the callback.
+        }
+      }
     }
   }, intervalMs);
 }

--- a/test/unit/onlyoffice-editor.test.ts
+++ b/test/unit/onlyoffice-editor.test.ts
@@ -599,6 +599,64 @@ describe('awaitFontSystem', () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  // The vendor's fetchFonts throws synchronously when it walks a font system
+  // that is up but incomplete, and x2t_helper only settles the conversion from
+  // inside the callback (`new Promise(resolve => AscCommon.fetchFonts(...))`).
+  // Swallowing that throw without answering the callback is therefore not a
+  // degradation but a permanent spinner -- exactly what installOpenFailureGuard
+  // exists to prevent -- so the wait falls back to the fontless import.
+  it('answers a throwing vendor fetchFonts with a fontless import, never with silence', () => {
+    const win: any = notReady();
+    const original = vi.fn(() => {
+      throw new TypeError("Cannot read properties of undefined (reading 'Id')");
+    });
+    const cb = vi.fn();
+    awaitFontSystem(win, original, cb, { timeoutMs: 500, intervalMs: 50 });
+    win.AscFonts.g_font_infos = [{ Name: 'Arial' }];
+    win.AscCommon.g_font_loader.fontFiles = [{ Id: '000' }];
+    expect(() => vi.advanceTimersByTime(50)).not.toThrow();
+    expect(original).toHaveBeenCalledTimes(1);
+    // The conversion gets its answer, and only one of them.
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith([]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not answer twice when the vendor takes the callback', () => {
+    const win: any = notReady();
+    const original = vi.fn();
+    const cb = vi.fn();
+    awaitFontSystem(win, original, cb, { timeoutMs: 500, intervalMs: 50 });
+    win.AscFonts.g_font_infos = [{ Name: 'Arial' }];
+    win.AscCommon.g_font_loader.fontFiles = [{ Id: '000' }];
+    vi.advanceTimersByTime(50);
+    expect(original).toHaveBeenCalledWith(cb);
+    // The vendor owns the callback from here; the fallback must stay out.
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('stops polling when reading the frame itself starts throwing', () => {
+    // The synchronous entry is deliberately unguarded (it runs inside the
+    // caller's promise executor, which turns a throw into a rejected open), so
+    // the frame only dies once the wait is already on the timer.
+    let alive = true;
+    const win: any = {
+      AscCommon: { g_font_loader: {} },
+      get AscFonts(): Record<string, unknown> {
+        if (!alive) throw new Error('Cannot access a dead realm');
+        return {};
+      },
+    };
+    const original = vi.fn();
+    const cb = vi.fn();
+    awaitFontSystem(win, original, cb, { timeoutMs: 500, intervalMs: 50 });
+    alive = false;
+    // An uncaught throw here would also leave the interval running forever.
+    expect(() => vi.advanceTimersByTime(50)).not.toThrow();
+    expect(vi.getTimerCount()).toBe(0);
+    expect(original).not.toHaveBeenCalled();
+  });
+
   it('keeps the default wait short enough to stay under the save readiness budget', () => {
     expect(FONT_SYSTEM_WAIT_MS).toBeLessThanOrEqual(10_000);
   });


### PR DESCRIPTION
Follow-up review finding on #148 (already merged).

The `try/catch` that keeps a dead realm from throwing out of the timer also
wrapped the handover to the vendor's `fetchFonts` — and that function throws
**synchronously**. It walks `AscFonts.g_font_infos` and, per entry,
dereferences `AscCommon.g_font_loader.fontFiles[index].Id`
([sdkjs/word/sdk-all-min.js:3800](public/sdkjs/word/sdk-all-min.js#L3800)), so
a font system that is up but incomplete is a TypeError rather than a clean
return.

The conversion is settled **only from inside the callback**
([x2t_helper.js:820](public/sdkjs/common/wasm/x2t/x2t_helper.js#L820)):

```js
return new Promise(function (resolve, reject) {
  window['AscCommon']['fetchFonts'](function (data) { /* ... */ resolve(); });
});
```

So swallowing that throw without answering the callback does not degrade the
open, it **hangs** it: no rejection, therefore no -82, no failure guard, no
retry — the permanent spinner `installOpenFailureGuard` exists to prevent. And
the timer path is the primary path of #148 (a late font system is the whole
point of the wait).

## What changes

- The `ready` branch's catch now falls back to `cb([])` — exactly the answer a
  timed-out wait already gives — wrapped in its own `try` for the case where
  the frame really is gone.
- The synchronous path stays deliberately unguarded: it runs inside the
  caller's promise executor, where a throw *is* the correct outcome (rejected
  open → -82 → the #146 retry).
- `isFontSystemReady(win)` and the wait probe move inside the `try` too. A
  throw there escaped the timer as well, and skipped `clearInterval`, leaving a
  poll running forever.

## Tests

Three unit cases, all reverse-verified:

| test | with the fix removed |
| --- | --- |
| answers a throwing vendor `fetchFonts` with a fontless import, never with silence | red: `expected "vi.fn()" to be called 1 times, but got 0 times` — the callback is never answered, i.e. the hang |
| does not answer twice when the vendor takes the callback | guards the fallback from firing on the normal path |
| stops polling when reading the frame itself starts throwing | red: `Cannot access a dead realm` thrown straight out of `advanceTimersByTime` |

Full unit suite (573) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)