### PR TITLE
fix(v9): release the retry bytes once the document is open (#144)

### DIFF
--- a/docs/explorations/2026-08-18-issue-144-open-conversion-environment-retry.md
+++ b/docs/explorations/2026-08-18-issue-144-open-conversion-environment-retry.md
@@ -106,3 +106,18 @@ window.AscFonts.g_font_infos.forEach(function (w) {
 - 同批新 issue [#145](https://github.com/ranuts/document/issues/145)（安卓 Chrome
   幻灯片初始缩放 31%、反复改缩放后报错）另案：现有 E2E 只跑桌面 Chromium，
   缺移动端（触摸 + devicePixelRatio + 缩放）覆盖，需要先补一条移动模拟用例。
+
+## 七、打开成功后释放重试用的字节（二次 review）
+
+`currentOpenAttempt` 为了"环境类失败重开一次"保留了整份 `binData`，但它**只在
+下次打开时被覆盖，打开成功后从不释放**——编辑器自己持有一份文档、挂载用的 blob
+是第二份，这里就成了第三份，整个会话常驻。#145 的现场恰恰是移动端内存压力导致
+canvas 被丢弃，留这份压舱物是反着来的。
+
+`onDocumentReady` 里加 `releaseOpenAttemptBytes()`。安全性来自
+`installOpenFailureGuard` 自己的 `documentContentReady` 分支：文档一旦加载完成，
+之后任何转换失败都被当作"导出失败"处理，不会再走到 `retryCurrentOpen`，所以释放
+之后没有人还会来要这份字节。重试预算（`retried`）仍然保留。
+
+反向验证：去掉 `releaseOpenAttemptBytes()` 调用，用例
+`releases the retry bytes once the document is open` 变红（`expected true to be false`）。

--- a/lib/onlyoffice-editor.ts
+++ b/lib/onlyoffice-editor.ts
@@ -380,6 +380,22 @@ let openGeneration = 0;
 let handledFailureGeneration = -1;
 
 /**
+ * Drop the bytes held for a possible retry, keeping the attempt itself so the
+ * one-retry budget is still tracked. Called once the open has succeeded: from
+ * that point installOpenFailureGuard takes its `documentContentReady` branch
+ * and treats every further conversion failure as a failed export, so no retry
+ * can ask for these bytes again.
+ */
+function releaseOpenAttemptBytes(): void {
+  if (currentOpenAttempt) currentOpenAttempt.binData = undefined;
+}
+
+/** Whether a retry could still be served from bytes we are holding. */
+export function openAttemptHoldsBytes(): boolean {
+  return Boolean(currentOpenAttempt?.binData);
+}
+
+/**
  * Rebuild the editor once for the document that just failed to open.
  * Returns whether a retry was started; `false` means the caller should report
  * the failure to the user.
@@ -1202,6 +1218,12 @@ function createPersonalEditorInstance(config: {
       },
       onDocumentReady: () => {
         markDocumentContentReady();
+        // The open succeeded, so the retry budget is spent and the bytes kept
+        // for it are dead weight -- the editor holds the document itself, and
+        // the blob it was mounted from is a second copy already. Keeping a
+        // third for the rest of the session is exactly the kind of ballast
+        // that gets a phone's canvas discarded under memory pressure (#145).
+        releaseOpenAttemptBytes();
         // Re-apply in case the header rendered after onAppReady.
         prepareEditorIframe();
         // Readonly opens mount with full edit permissions and get locked

--- a/test/unit/onlyoffice-editor.test.ts
+++ b/test/unit/onlyoffice-editor.test.ts
@@ -21,6 +21,7 @@ import {
   createEditorInstance,
   getNormalizedFile,
   isFontSystemReady,
+  openAttemptHoldsBytes,
   getReadonlyMode,
   getSavedFileMimeType,
   requestSaveDocument,
@@ -239,6 +240,23 @@ describe('onlyoffice-editor', () => {
       expect(DocEditor).toHaveBeenCalledTimes(1);
       return DocEditor.mock.calls[0][1] as any;
     }
+
+    // The bytes are kept only so an environment-class open failure can be
+    // retried with them (#144). Once the document is open that retry is
+    // unreachable, and a third copy of a large document (the editor holds one,
+    // the blob it mounted from another) is exactly the ballast that gets a
+    // phone's canvas discarded under memory pressure (#145).
+    it('releases the retry bytes once the document is open', async () => {
+      const config = await createAndGetConfig({
+        fileName: 'held.xlsx',
+        fileType: 'xlsx',
+        binData: new ArrayBuffer(1024),
+      });
+
+      expect(openAttemptHoldsBytes()).toBe(true);
+      config.events.onDocumentReady();
+      expect(openAttemptHoldsBytes()).toBe(false);
+    });
 
     it('always passes a non-empty Guest user to avoid the getInitials crash (#25)', async () => {
       const config = await createAndGetConfig({


### PR DESCRIPTION
Review finding on #146.

`currentOpenAttempt` keeps the document's bytes so an environment-class open
failure can be retried with them — but nothing ever drops them. They stay for
the rest of the session, overwritten only by the next open.

That is a third copy of the document: the editor holds the document itself,
and the blob URL it was mounted from is a second. #145's field report is a
phone discarding the editor's canvas under memory pressure, which is exactly
what that ballast makes likelier — a 30 MB deck costs 30 MB of nothing.

## Why releasing at `onDocumentReady` is safe

`installOpenFailureGuard` takes its `documentContentReady` branch from that
point on and treats every further conversion failure as a *failed export*,
never as an open worth retrying — so no code path can ask for these bytes
again. The retry budget (`retried`) itself is untouched, and a document that
never reaches ready keeps its bytes and its retry.

## Tests

`releases the retry bytes once the document is open` drives the real
`createEditorInstance`, fires the captured `onDocumentReady`, and asserts the
buffer is gone. Reverse-verified: without the release it fails on the
still-held buffer (`expected true to be false`).

Full unit suite (564) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)