### PR TITLE
ci: bound every job, stop apt from hanging, and pin the wrangler compatibility date

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,56 @@
+name: Set up the toolchain
+description: pnpm, Node and the workspace install, plus Playwright browsers when asked for.
+
+inputs:
+  browsers:
+    description: >-
+      Space-separated Playwright browsers to install (for example "chromium" or
+      "webkit firefox"). Leave empty to skip the browser install entirely.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install pnpm
+      uses: pnpm/action-setup@v6
+      with:
+        run_install: false
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v7
+      with:
+        node-version: "lts/*"
+        cache: pnpm
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    - name: Resolve the Playwright version
+      if: inputs.browsers != ''
+      id: playwright
+      shell: bash
+      env:
+        BROWSERS: ${{ inputs.browsers }}
+      run: |
+        echo "version=$(pnpm exec playwright --version | awk '{ print $NF }')" >>"$GITHUB_OUTPUT"
+        echo "slug=${BROWSERS// /-}" >>"$GITHUB_OUTPUT"
+
+    # The browser binaries are the slow half of the install and they only ever
+    # change with the Playwright version, so a hit leaves just the apt step.
+    - name: Restore the Playwright browser cache
+      if: inputs.browsers != ''
+      id: browser-cache
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}-${{ steps.playwright.outputs.slug }}
+
+    - name: Install Playwright browsers
+      if: inputs.browsers != ''
+      shell: bash
+      env:
+        BROWSERS: ${{ inputs.browsers }}
+        BROWSERS_CACHED: ${{ steps.browser-cache.outputs.cache-hit }}
+      run: .github/scripts/install-playwright.sh $BROWSERS

--- a/.github/scripts/install-playwright.sh
+++ b/.github/scripts/install-playwright.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Install the Playwright browsers, with every attempt bounded and retried.
+#
+# `playwright install --with-deps` shells out to apt-get, and apt on the hosted
+# runners has repeatedly stalled forever immediately after fetching the release
+# indexes. Four CI runs in a single day were killed at GitHub's six-hour job
+# limit at exactly that point -- a different job each time, since all three e2e
+# jobs run this same step -- and each one had to be re-run by hand the next
+# morning. apt enforces no wall-clock limit of its own, so bound each attempt
+# here: an unreachable mirror now costs minutes and self-heals on the retry
+# instead of blocking a pull request overnight.
+set -euo pipefail
+
+browsers=("$@")
+if [ ${#browsers[@]} -eq 0 ]; then
+  browsers=(chromium)
+fi
+
+attempts=${PLAYWRIGHT_INSTALL_ATTEMPTS:-3}
+attempt_timeout=${PLAYWRIGHT_INSTALL_TIMEOUT:-300}
+
+# Stop apt from trickling along on a half-dead mirror indefinitely. This alone
+# would not have saved the six-hour runs (the stall happens with no bytes
+# moving at all), but it turns a slow mirror into a fast failure too.
+sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'CONF'
+Acquire::Retries "3";
+Acquire::http::Timeout "30";
+Acquire::https::Timeout "30";
+CONF
+
+# A cache hit restores the browser binaries but never the system libraries,
+# so the apt half still has to run.
+if [ "${BROWSERS_CACHED:-}" = "true" ]; then
+  command=(install-deps "${browsers[@]}")
+else
+  command=(install --with-deps "${browsers[@]}")
+fi
+
+for attempt in $(seq 1 "$attempts"); do
+  if timeout --kill-after=30s "${attempt_timeout}s" pnpm exec playwright "${command[@]}"; then
+    exit 0
+  fi
+
+  echo "::warning::playwright ${command[*]} failed or exceeded ${attempt_timeout}s (attempt ${attempt}/${attempts})"
+
+  # timeout only signals pnpm; a stalled apt-get is a grandchild and survives it.
+  # Match on the process name rather than the full command line, or pkill would
+  # match the sudo that is running it and take out this script instead.
+  for process in apt-get apt dpkg unattended-upgr; do
+    sudo pkill -9 -x "$process" || true
+  done
+
+  # A killed apt leaves its locks behind and the retry would fail instantly.
+  sudo rm -f \
+    /var/lib/apt/lists/lock \
+    /var/cache/apt/archives/lock \
+    /var/lib/dpkg/lock \
+    /var/lib/dpkg/lock-frontend
+  sudo dpkg --configure -a || true
+
+  sleep 10
+done
+
+echo "::error::playwright ${command[*]} failed after ${attempts} attempts"
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,29 +6,29 @@ on:
   pull_request:
     branches: [main, master]
 
+# A pull request that gets a new push has nothing to learn from the run for the
+# superseded commit, and every one of those runs holds a Playwright job for
+# minutes. Pushes to main are never cancelled: each one is the commit a deploy
+# and the production smoke are about to be judged on.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint and Validate
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: "lts/*"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Set up the toolchain
+        uses: ./.github/actions/setup
 
       - name: Check formatting
         run: pnpm run format:check
@@ -52,27 +52,16 @@ jobs:
     name: E2E
     runs-on: ubuntu-latest
     needs: lint
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
-        name: Install pnpm
+      - name: Set up the toolchain
+        uses: ./.github/actions/setup
         with:
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: "lts/*"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+          browsers: chromium
 
       - name: Run E2E tests
         run: pnpm run test:e2e
@@ -93,27 +82,18 @@ jobs:
     name: E2E (Cloudflare Pages semantics)
     runs-on: ubuntu-latest
     needs: lint
+    # The slowest of the three: wrangler is served by a single worker on
+    # purpose (see playwright.pages.config.ts), so ~20 minutes is normal.
+    timeout-minutes: 45
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
-        name: Install pnpm
+      - name: Set up the toolchain
+        uses: ./.github/actions/setup
         with:
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: "lts/*"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+          browsers: chromium
 
       - name: Run E2E against wrangler pages dev
         run: pnpm exec playwright test -c playwright.pages.config.ts
@@ -135,27 +115,16 @@ jobs:
     name: E2E (Docker image)
     runs-on: ubuntu-latest
     needs: lint
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
-        name: Install pnpm
+      - name: Set up the toolchain
+        uses: ./.github/actions/setup
         with:
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: "lts/*"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+          browsers: chromium
 
       - name: Run E2E tests against the Docker image
         run: pnpm run test:e2e:docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/nightly-corpus.yml
+++ b/.github/workflows/nightly-corpus.yml
@@ -29,22 +29,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
-        name: Install pnpm
+      - name: Set up the toolchain
+        uses: ./.github/actions/setup
         with:
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: "lts/*"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+          browsers: chromium
 
       # Apache POI's test-data tree (Apache-2.0) is the largest curated pile of
       # real-world .doc/.docx/.xls/.xlsx/.ppt/.pptx around, including many
@@ -94,22 +82,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
-        name: Install pnpm
+      - name: Set up the toolchain
+        uses: ./.github/actions/setup
         with:
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: "lts/*"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps webkit firefox
+          browsers: webkit firefox
 
       # The same PR-time suites (minus the opt-in sweeps) on the two engines
       # the gate does not cover. Same-realm/L0 rules apply unchanged.
@@ -133,22 +109,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
-        name: Install pnpm
+      - name: Set up the toolchain
+        uses: ./.github/actions/setup
         with:
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: "lts/*"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+          browsers: chromium
 
       # Roadmap direction 9 (L3): flag when the ecosystem packages on npm have
       # moved past what this repo pins. Informational -- the bump itself is a

--- a/.github/workflows/pages-build-site.yml
+++ b/.github/workflows/pages-build-site.yml
@@ -25,6 +25,7 @@ jobs:
   build:
     name: Publish redirector
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -43,6 +44,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -29,22 +29,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
-        name: Install pnpm
+      - name: Set up the toolchain
+        uses: ./.github/actions/setup
         with:
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: "lts/*"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+          browsers: chromium
 
       - name: Wait for the Cloudflare Pages preview of this commit
         id: preview

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -32,22 +32,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
-        name: Install pnpm
+      - name: Set up the toolchain
+        uses: ./.github/actions/setup
         with:
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: "lts/*"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+          browsers: chromium
 
       # On push: build the same commit and wait until production serves its
       # hashed entry asset (Vite hashes are content-derived, so an identical

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,17 +15,13 @@ on:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install
+      - name: Set up the toolchain
+        uses: ./.github/actions/setup
 
       - name: Build project
         run: bash bin/build.sh

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -16,6 +16,7 @@ jobs:
     if: github.repository == 'ranuts/document'
     runs-on: ubuntu-latest
     name: Semantic Pull Request
+    timeout-minutes: 5
     steps:
       - name: Validate PR title
         uses: amannn/action-semantic-pull-request@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,31 +261,41 @@ E2E 在 CI 中依赖 `lint` job 成功后才运行（`needs: lint`）。
 
 ## CI 流程（.github/workflows/ci.yml）
 
-三个 job，触发条件：push/PR 到 main/master。
+**四个 job**，触发条件：push/PR 到 main/master。`lint` 先跑，三个 e2e job
+在它之后并行。
 
-**lint job（串行步骤）：**
+| job          | 名称（分支保护里的必需检查名）   | 正常耗时                   | timeout |
+| ------------ | -------------------------------- | -------------------------- | ------- |
+| `lint`       | Lint and Validate                | ~1.5 min                   | 15 min  |
+| `e2e`        | E2E                              | ~9 min                     | 30 min  |
+| `e2e-docker` | E2E (Docker image)               | ~8 min（镜像构建仅占 46s） | 30 min  |
+| `e2e-pages`  | E2E (Cloudflare Pages semantics) | ~18 min                    | 45 min  |
 
-1. `pnpm/action-setup@v6 version: latest` — 不锁定 pnpm 版本
-2. `actions/setup-node@v6 node-version: lts/*` — 不锁定 Node 版本
-3. `pnpm install --frozen-lockfile`
-4. `pnpm run format:check`
-5. `pnpm run lint:ts`
-6. `pnpm run test:coverage`
-7. `docker compose config --quiet`（验证 Docker Compose 文件）
-8. `hadolint/hadolint-action@v3.3.0`（Dockerfile 检查）
+**lint job（串行步骤）：** setup（见下）→ `format:check` → `lint:ts` →
+`test:coverage` → `docker compose config --quiet` → hadolint。
+**三个 e2e job：** setup（含 chromium）→ 各自的测试命令 → 失败时上传
+`playwright-report*/` artifact。
 
-**e2e job（需 lint 通过）：**
+**共用 setup（`.github/actions/setup`）**：pnpm + Node `lts/*` + pnpm 缓存 +
+`pnpm install --frozen-lockfile`，`browsers:` 入参非空时再装 Playwright 浏览器。
+全部 8 个 workflow 共用它，别在 workflow 里重新内联这几步——
+`test/unit/workflow-contract.test.ts` 会拦下来。
 
-1. 同上安装步骤
-2. `playwright install --with-deps chromium`
-3. `pnpm run test:e2e`
-4. 失败时上传 `playwright-report/` artifact
+**为什么浏览器安装要包一层脚本**：`playwright install --with-deps` 会调
+apt-get，而 hosted runner 上的 apt 有过**拉完 release 索引后彻底停住、一个字节
+不动**的表现——2026-08-18 一天之内四次 CI 被 GitHub 的 6 小时 job 上限杀掉，
+每次挂在不同的 job（三个 e2e job 跑的是同一步，谁中枪是随机的），每次都要人工
+重跑。apt 自身没有总时长上限，所以 `.github/scripts/install-playwright.sh` 给
+每次尝试套 `timeout` 并重试 3 次，重试前清掉被杀的 apt 留下的锁；浏览器二进制
+按 Playwright 版本号进 `actions/cache`，命中时只跑 `install-deps`。
 
-**e2e-docker job（需 lint 通过，与 e2e 并行）：**
+**并发**：PR 收到新 push 时旧 run 直接取消（`cancel-in-progress` 只对
+`pull_request` 生效）；push 到 main 的 run 永不取消——那是部署和线上冒烟要判定
+的提交。
 
-1. 同上安装步骤 + `playwright install --with-deps chromium`
-2. `pnpm run test:e2e:docker`（构建生产镜像 + 同套 E2E 打容器）
-3. 失败时上传 `playwright-report-docker/` artifact
+**约定**：新增 workflow / job 必须带 `timeout-minutes`，浏览器安装必须走共用
+action。两条都由 `test/unit/workflow-contract.test.ts` 钉死。
+详见 docs/explorations/2026-08-19-ci-workflow-hardening.md。
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,8 +293,16 @@ apt-get，而 hosted runner 上的 apt 有过**拉完 release 索引后彻底停
 `pull_request` 生效）；push 到 main 的 run 永不取消——那是部署和线上冒烟要判定
 的提交。
 
+**`e2e-pages` 的 wrangler 由 `bin/serve-pages-dev.sh` 起**：它固定
+`--compatibility-date`（不传的话 wrangler 取**今天**，而随附的 workerd 只支持到
+它自己的发布日——2026-08-19 当天所有分支连同 main 全线变红），并且重启循环会
+放弃（活不过 10s 视为没起来，连续 3 次带真实错误退出，否则启动错误会被无限
+重试成一句无用的 `Timed out waiting 300000ms from config.webServer`）。见
+docs/explorations/2026-08-19-wrangler-compat-date-timebomb.md。
+
 **约定**：新增 workflow / job 必须带 `timeout-minutes`，浏览器安装必须走共用
-action。两条都由 `test/unit/workflow-contract.test.ts` 钉死。
+action，wrangler 必须经 `bin/serve-pages-dev.sh` 起。三条都由
+`test/unit/workflow-contract.test.ts` 钉死。
 详见 docs/explorations/2026-08-19-ci-workflow-hardening.md。
 
 ---

--- a/bin/serve-pages-dev.sh
+++ b/bin/serve-pages-dev.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# Serve dist/ with Cloudflare Pages' own semantics for the e2e-pages suite.
+#
+# Two things this wrapper exists for:
+#
+# 1. A pinned compatibility date. Given none, wrangler defaults to *today*,
+#    and the workerd binary it ships only supports dates up to its own release
+#    -- so on 2026-08-19 every run, on every branch, died with "This Worker
+#    requires compatibility date 2026-08-19, but the newest date supported by
+#    this server binary is 2026-08-18". A date that arrives on a calendar and
+#    not in a commit is a time bomb; pin it. Any date the installed workerd
+#    knows about will do (old dates are supported forever, and this project
+#    serves static assets with no Functions), so bump it deliberately or not
+#    at all.
+#
+# 2. A restart loop that gives up. workerd has been seen to die mid-run on CI
+#    when a browser aborts a large download (sdk-all.js) while tests hammer it
+#    ("kj/async-io-unix.c++ ... Connection reset by peer"), after which every
+#    test fails with ECONNREFUSED -- so a crash should cost one retried test,
+#    not the job. But an unconditional loop also retries a startup error
+#    forever, which is how the compatibility-date failure above surfaced: not
+#    as its own clear message but as Playwright's "Timed out waiting 300000ms
+#    from config.webServer", with the real cause fifteen repetitions upstream.
+#    Restart a server that had been running; give up on one that never starts.
+set -eu
+
+PORT=${1:-8788}
+COMPATIBILITY_DATE=2026-08-01
+
+# A server that dies this soon never came up; it failed to start.
+STARTUP_SECONDS=10
+MAX_STARTUP_FAILURES=3
+
+failures=0
+while true; do
+  started=$(date +%s)
+
+  if pnpm dlx wrangler@latest pages dev dist \
+    --port "$PORT" \
+    --ip 127.0.0.1 \
+    --compatibility-date "$COMPATIBILITY_DATE"; then
+    exit 0
+  fi
+
+  elapsed=$(($(date +%s) - started))
+
+  if [ "$elapsed" -lt "$STARTUP_SECONDS" ]; then
+    failures=$((failures + 1))
+    if [ "$failures" -ge "$MAX_STARTUP_FAILURES" ]; then
+      echo "wrangler pages dev failed to start ${failures} times in a row; the error is above" >&2
+      exit 1
+    fi
+  else
+    failures=0
+  fi
+
+  echo "wrangler pages dev exited after ${elapsed}s, restarting"
+  sleep 1
+done

--- a/docs/explorations/2026-08-19-ci-workflow-hardening.md
+++ b/docs/explorations/2026-08-19-ci-workflow-hardening.md
@@ -1,0 +1,140 @@
+# CI 加固：六小时挂死、缺失的 timeout，与一份共用 setup
+
+2026-08-19
+
+## 起因
+
+PR #152 的六个必需检查里五个绿，`E2E (Docker image)` 显示 `CANCELLED`，
+`mergeStateStatus` 卡在 `BLOCKED`，PR 挂了一整晚没合进去。
+
+翻日志发现它不是失败，是**挂死**：
+
+```
+16:53:49  job 开始
+16:55:01  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
+          （此后 5 小时 59 分钟，零输出）
+22:54:02  ##[error]The operation was canceled.
+```
+
+`22:54 - 16:53 = 6h01m`，正是 GitHub 对单个 job 的硬上限。没有任何一方主动
+取消，是被平台掐掉的。
+
+## 这不是孤例
+
+查最近 40 次 CI run：26 成功 / 7 失败 / 6 取消，**其中 4 次是 361 分钟的同一处
+挂死**（另加 #152 这次 466 分钟）。而且挂的 job 每次都不一样：
+
+| run         | 挂住的 job         | 时长    |
+| ----------- | ------------------ | ------- |
+| 32154679924 | E2E (Docker image) | 360 min |
+| 32157110583 | E2E                | 360 min |
+| 32162464632 | E2E                | 360 min |
+| 32162614979 | E2E (Docker image) | 361 min |
+
+对每一次取消的 job 抓最后几行日志，签名完全一致——都停在
+`playwright install --with-deps chromium` 里 apt 拉完 `noble-security InRelease`
+之后。三个 e2e job 跑的是同一个 install 步骤，所以谁中枪纯随机，看起来像"到处
+都在坏"，实际是同一个点。
+
+`--with-deps` 会 shell out 到 `apt-get`。runner 的 sources 里
+`azure.archive.ubuntu.com`（内网镜像）全部 `Ign:`，回落到
+`archive.ubuntu.com`，然后连接停住不动。apt 的 `Acquire::http::Timeout` 管的是
+单次连接/读取，一个"连上了但不给字节"的镜像可以让它永远等下去，而 apt **没有
+任何总时长上限**。
+
+## 三层问题
+
+1. **没有 timeout**：`ci.yml` 的四个 job 一个都没写 `timeout-minutes`。
+   较新的 `preview-smoke` / `prod-smoke` / `nightly-corpus` 都写了，最老、
+   却承载 6 个必需检查里 4 个的 `ci.yml` 反而没有。于是一次网络停滞的代价是
+   6 小时 runner 额度 + 一个通宵堵住的 PR + 一次人工重跑。
+2. **没有重试**：即便 apt 偶发失败，也只能靠人回来点 re-run。
+3. **同一段 setup 抄了 9 遍**：8 个 workflow 里 9 处重复
+   `pnpm/action-setup` + `setup-node` + `pnpm install`，其中 8 处各自内联
+   `playwright install --with-deps`。任何加固都得改 8 个地方，下一个新
+   workflow 还会再漏一次。
+
+## 做法
+
+### 1. `.github/scripts/install-playwright.sh`——把安装限时并重试
+
+每次尝试用 `timeout --kill-after=30s 300s` 包住，失败或超时就重试，最多 3 次。
+两个细节不能省：
+
+- `timeout` 只对 `pnpm` 发信号，**停住的 `apt-get` 是孙进程会活下来**，所以
+  重试前要 `pkill`。用 `pkill -9 -x <名字>` 按进程名精确匹配，**不能用
+  `pkill -f 'apt-get|dpkg'`**——那样模式串会匹配到正在执行它的 `sudo` 自己的
+  命令行，把脚本自己杀掉。
+- 被杀的 apt 会留下 `/var/lib/dpkg/lock-frontend` 等锁，不清掉的话重试会秒失败
+  在 `Could not get lock`，重试逻辑就成了纯装饰。清完再 `dpkg --configure -a`。
+
+顺带写死 `Acquire::Retries` / `Acquire::http(s)::Timeout` —— 这一条**救不了**
+这次的挂死（那是零字节的静默停滞），但能让"慢镜像"也快速失败。
+
+最坏情况：3 × 5 min = 15 min 后 job 红掉，而不是 6 小时后被平台杀掉。
+
+### 2. `.github/actions/setup`——一份共用的 composite action
+
+pnpm + Node `lts/*` + pnpm 缓存 + `pnpm install --frozen-lockfile`，
+`browsers:` 非空时再走上面的脚本装浏览器。9 处重复收敛成一处，
+`release.yml` 除外的所有 workflow 都改用它。
+
+浏览器二进制额外进 `actions/cache`，key 是 **Playwright 版本号**而不是
+lockfile——按 lockfile 会在每次依赖升级时白白失效重下。命中时只需要跑
+`install-deps`（系统库永远不在缓存里）。正常 install 步骤耗时 44～108s，
+命中后省掉其中的下载部分。
+
+### 3. 全部 8 个 workflow、14 个 job 补 `timeout-minutes`
+
+按实测耗时留 2～3 倍余量（e2e 9 min → 30；e2e-pages 18 min → 45；
+docker 8 min → 30；lint 1.5 min → 15）。
+
+### 4. `ci.yml` 加 concurrency
+
+PR 收到新 push 时取消旧 run；push 到 main 的 run **不取消**——那是部署和线上
+冒烟要判定的提交：
+
+```yaml
+cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+```
+
+### 5. 顺手修掉 `release.yml`
+
+它用 `npm install` 装一个 pnpm workspace 仓库，而根 `package.json` 里有四个
+`"workspace:*"` 依赖——npm 不认 `workspace:` 协议，这个手动 release 流程在
+install 那步就不可能成功。改走共用 setup。
+
+## 用例固化
+
+`test/unit/workflow-contract.test.ts`（28 个断言）钉死四条不变量：
+
+1. 每个 workflow 的每个 job 都有 `timeout-minutes`，且 ≤ 300；
+2. 任何 workflow 都不许再内联 `playwright install`，必须走共用 action；
+3. 共用 action 走的是重试脚本，缓存 key 按版本号而非 lockfile；
+4. 脚本里 `timeout` 包裹与 apt 锁清理都在；`ci.yml` 的 concurrency 只对 PR 取消。
+
+反向验证（逐条撤掉修复，确认变红）：
+
+| 撤掉的东西                    | 结果      |
+| ----------------------------- | --------- |
+| e2e job 的 `timeout-minutes`  | 1 failed  |
+| 改回内联 `playwright install` | 1 failed  |
+| 删掉 `concurrency` 段         | 1 failed  |
+| 去掉 `timeout` 包裹 + 锁清理  | 2 failed  |
+| 全部恢复                      | 28 passed |
+
+安装脚本本身在本地用打桩（`sudo` / `pnpm` / `timeout` / `sleep`）跑过五个分支：
+缓存未命中走 `install --with-deps`、命中走 `install-deps`、多浏览器参数、
+无参数默认 chromium、持续失败重试到上限后 `exit 1`。
+
+## 没有做的
+
+- **给 `e2e-pages` 分片**（它 18 min，是最长的一条）：分片会改变 check 名字，
+  而分支保护里必需检查是按名字匹配的，改名会让 PR 永久卡在"等待缺失的检查"。
+  要做得先改分支保护，属于另一件事。
+- **给 Docker 构建加 buildx 缓存**：实测镜像构建只占 46s（16:50:21 → 16:51:07），
+  该 job 的 8 分钟基本都是测试本身，缓存省不下什么。
+- **提高 Playwright worker 数**：runner 4 核，默认 2 worker。这些用例每个都要
+  拉起真实编辑器 + x2t.wasm，是内存敏感型；为了省几分钟去换新的偶发失败，
+  和这次要解决的问题正好相反。`playwright.pages.config.ts` 的 `workers: 1`
+  是有意为之（多 worker 会让 wrangler 中断 sdk-all.js 这种大文件下载）。

--- a/docs/explorations/2026-08-19-wrangler-compat-date-timebomb.md
+++ b/docs/explorations/2026-08-19-wrangler-compat-date-timebomb.md
@@ -1,0 +1,105 @@
+# wrangler 的默认 compatibility date 是个定时炸弹
+
+2026-08-19
+
+## 症状
+
+2026-08-19 00:47 UTC 起，`E2E (Cloudflare Pages semantics)` 在**每个分支**上都红，
+main 也不例外（PR #152 合并后 main 的那次 CI 就是这么挂的）。Playwright 报的是：
+
+```
+Error: Timed out waiting 300000ms from config.webServer.
+```
+
+这条信息毫无用处。真正的原因在它上面两百行，而且重复了十五遍：
+
+```
+✘ [ERROR] service core:user:<uuid>: This Worker requires compatibility date
+  "2026-08-19", but the newest date supported by this server binary is
+  "2026-08-18".
+```
+
+## 根因
+
+`playwright.pages.config.ts` 里是 `pnpm dlx wrangler@latest pages dev dist ...`，
+仓库里没有任何 wrangler 配置文件，也没传 `--compatibility-date`。wrangler 本人
+把这件事说得很清楚：
+
+```
+▲ [WARNING] No compatibility_date was specified. Using today's date: 2026-08-19.
+```
+
+而它自带的 workerd 二进制只支持到**它自己发布那天**为止的日期。于是每当日期
+翻到一个比当前 workerd 发布日更新的一天，"今天"这个默认值就越界，workerd 直接
+拒绝启动。这不是抖动：它跟代码无关、跟分支无关，只跟日历有关，而且当天之内
+必然 100% 复现。
+
+本地一条命令即可复现（wrangler 4.123.0）：
+
+```
+$ pnpm dlx wrangler@latest pages dev <任意目录> --port 8791 --ip 127.0.0.1
+▲ [WARNING] No compatibility_date was specified. Using today's date: 2026-08-19.
+✘ [ERROR] ... but the newest date supported by this server binary is "2026-08-18".
+```
+
+加上固定日期就正常：
+
+```
+$ pnpm dlx wrangler@latest pages dev <任意目录> --port 8792 --ip 127.0.0.1 \
+    --compatibility-date=2026-08-01
+[wrangler:info] Ready on http://127.0.0.1:8792
+$ curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8792/   # 200
+```
+
+## 为什么它伪装成超时
+
+原来的 serve 命令是个无条件重启循环：
+
+```sh
+until pnpm dlx wrangler@latest pages dev dist --port $PORT --ip 127.0.0.1; do
+  echo "wrangler pages dev exited, restarting"; sleep 1
+done
+```
+
+这个循环本身有正当理由：workerd 在 CI 上会在浏览器中断 sdk-all.js 这种大文件
+下载时**跑到一半崩掉**，崩了之后所有用例 ECONNREFUSED；重启循环让一次崩溃只
+损失一个重试的用例，而不是整个 job。
+
+但它不区分"跑着跑着崩了"和"压根没起来"。启动错误被它每秒重试一次，直到
+Playwright 的 300 秒 webServer 超时，最后呈现给人的就是一句和真实原因毫无关系的
+`Timed out waiting 300000ms`。调查成本几乎全花在这上面。
+
+## 修法
+
+新增 `bin/serve-pages-dev.sh`，两件事：
+
+1. **固定 compatibility date**（`COMPATIBILITY_DATE=2026-08-01`）。老日期永远
+   被支持，且本项目是纯静态资源、没有 Pages Functions，所以具体取哪天不影响
+   行为，重要的是它写在提交里而不是由日历决定。
+2. **重启循环会放弃**。活不过 10 秒的进程算"没起来"，连续 3 次就带着真实错误
+   退出；活过 10 秒才崩的按原意重启，并把计数清零。
+
+顺带把这段 shell 从 TS 模板字符串里搬进 `bin/`——模板字符串里写 `${}` 的 shell
+变量要转义，是纯粹的雷区，而且 `bin/` 本来就是这个仓库放脚本的地方。
+
+## 用例固化
+
+`test/unit/workflow-contract.test.ts` 增三条：脚本必须传 `--compatibility-date`
+且日期写死、必须有放弃阈值、`playwright.pages.config.ts` 不许再内联
+`wrangler@latest pages dev`。反向验证：三条各自撤掉都会变红，恢复后 31 绿。
+
+脚本本身在本地验证过四种情形：真实 wrangler 起得来并返回 200、日志里不再出现
+`Using today's date`、启动即失败时 3 次后 `exit 1`、跑够 10 秒才崩时只重启不放弃。
+
+## 教训
+
+CI 里任何"默认取今天"的东西都是定时炸弹，而且引爆时间和改动无关，所以第一反应
+一定是"谁动了代码"——这次它同时点着了 main 和所有在飞的 PR。相关的一条：
+`pnpm dlx wrangler@latest` 每次拉最新版，是同一类不确定性的另一半。仓库约定
+不锁工具版本（见 CLAUDE.md），那就更要把**行为契约**（compatibility date）钉死。
+
+另一条：容错重试必须能区分"运行中失败"和"启动失败"，否则它会把一个清晰的错误
+熬成一个超时。
+
+同批的 CI 加固见
+[2026-08-19-ci-workflow-hardening.md](2026-08-19-ci-workflow-hardening.md)。

--- a/playwright.pages.config.ts
+++ b/playwright.pages.config.ts
@@ -17,8 +17,9 @@ const PORT = Number(process.env.PAGES_PORT || 8788);
 // ("kj/async-io-unix.c++ ... Connection reset by peer"), after which every
 // test fails with ECONNREFUSED. Two mitigations: run the suites serially so
 // concurrent aborts don't pile up, and supervise the dev server in a restart
-// loop so a crash costs one retried test instead of the whole job.
-const SERVE = `until pnpm dlx wrangler@latest pages dev dist --port ${PORT} --ip 127.0.0.1; do echo "wrangler pages dev exited, restarting"; sleep 1; done`;
+// loop (bin/serve-pages-dev.sh, which also pins the compatibility date) so a
+// crash costs one retried test instead of the whole job.
+const SERVE = `sh ./bin/serve-pages-dev.sh ${PORT}`;
 
 export default defineConfig({
   ...base,

--- a/test/unit/workflow-contract.test.ts
+++ b/test/unit/workflow-contract.test.ts
@@ -1,0 +1,106 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * CI workflow contract. GitHub applies no default job timeout, and the apt-get
+ * that `playwright install --with-deps` shells out to has stalled outright on
+ * the hosted runners: four runs in a single day were killed at the six-hour
+ * limit, each one blocking a pull request until it was re-run by hand the next
+ * morning. Both guards -- a timeout on every job, and routing every browser
+ * install through the bounded retrying script -- are one line each and exactly
+ * the kind of thing a newly added workflow forgets, so pin them here.
+ */
+const ROOT = resolve(__dirname, '../..');
+const WORKFLOW_DIR = resolve(ROOT, '.github/workflows');
+
+const workflows = readdirSync(WORKFLOW_DIR)
+  .filter((file) => file.endsWith('.yml') || file.endsWith('.yaml'))
+  .map((file) => ({ file, src: readFileSync(resolve(WORKFLOW_DIR, file), 'utf8') }));
+
+/**
+ * Pull the top-level jobs out of a workflow. The repository has no YAML parser
+ * in its dependencies (see hosting-contract.test.ts for the same trade-off),
+ * and the shape needed here is narrow: job names sit at two spaces of indent
+ * under `jobs:`, and their own keys at four.
+ */
+function parseJobs(src: string): Array<{ name: string; body: string }> {
+  const lines = src.split('\n');
+  const start = lines.indexOf('jobs:');
+  if (start === -1) return [];
+
+  const jobs: Array<{ name: string; body: string }> = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^[A-Za-z0-9_-]+:/.test(line)) break; // back out to the next top-level key
+    const header = line.match(/^ {2}([A-Za-z0-9_-]+):\s*$/);
+    if (header) {
+      jobs.push({ name: header[1], body: '' });
+    } else if (jobs.length > 0) {
+      jobs[jobs.length - 1].body += `${line}\n`;
+    }
+  }
+  return jobs;
+}
+
+it('finds every workflow (a bad glob would make the checks below vacuous)', () => {
+  expect(workflows.length).toBeGreaterThanOrEqual(8);
+  expect(workflows.every(({ src }) => parseJobs(src).length > 0)).toBe(true);
+});
+
+describe.each(workflows)('$file', ({ src }) => {
+  const jobs = parseJobs(src);
+
+  it.each(jobs)('job $name is bounded by a timeout', ({ body }) => {
+    const timeout = body.match(/^ {4}timeout-minutes: (\d+)$/m);
+    expect(timeout).not.toBeNull();
+    // A job that wants longer than an hour is either the nightly corpus run or
+    // a hang; both should be a deliberate edit here rather than a default.
+    expect(Number(timeout?.[1])).toBeLessThanOrEqual(300);
+  });
+
+  it('installs Playwright browsers only through the shared setup action', () => {
+    expect(src).not.toMatch(/playwright install/);
+    if (/playwright test|test:e2e|browsers:/.test(src)) {
+      expect(src).toMatch(/uses: \.\/\.github\/actions\/setup/);
+    }
+  });
+});
+
+describe('the shared setup action', () => {
+  const action = readFileSync(resolve(ROOT, '.github/actions/setup/action.yml'), 'utf8');
+
+  it('routes the browser install through the retrying script', () => {
+    expect(action).toMatch(/\.github\/scripts\/install-playwright\.sh/);
+    expect(action).not.toMatch(/run: pnpm exec playwright install/);
+  });
+
+  it('caches the browsers against the Playwright version, not the lockfile', () => {
+    // Keying on the lockfile would evict the cache on every dependency bump
+    // and re-download the browsers for no reason.
+    expect(action).toMatch(/key: playwright-\$\{\{ runner\.os \}\}-\$\{\{ steps\.playwright\.outputs\.version \}\}/);
+  });
+});
+
+describe('the Playwright install script', () => {
+  const script = readFileSync(resolve(ROOT, '.github/scripts/install-playwright.sh'), 'utf8');
+
+  it('bounds each attempt and retries', () => {
+    expect(script).toMatch(/timeout --kill-after=\d+s "\$\{attempt_timeout\}s"/);
+    expect(script).toMatch(/for attempt in \$\(seq 1 "\$attempts"\)/);
+  });
+
+  it('clears the apt locks a killed attempt leaves behind', () => {
+    // Without this the retry fails instantly on "Could not get lock", which
+    // would make the retry loop pure decoration.
+    expect(script).toMatch(/\/var\/lib\/dpkg\/lock-frontend/);
+  });
+});
+
+describe('.github/workflows/ci.yml', () => {
+  const ci = workflows.find(({ file }) => file === 'ci.yml')!.src;
+
+  it('drops the run for a superseded pull request commit, but never for main', () => {
+    expect(ci).toMatch(/^concurrency:$/m);
+    expect(ci).toMatch(/cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/);
+  });
+});

--- a/test/unit/workflow-contract.test.ts
+++ b/test/unit/workflow-contract.test.ts
@@ -96,6 +96,33 @@ describe('the Playwright install script', () => {
   });
 });
 
+describe('bin/serve-pages-dev.sh', () => {
+  const script = readFileSync(resolve(ROOT, 'bin/serve-pages-dev.sh'), 'utf8');
+  const config = readFileSync(resolve(ROOT, 'playwright.pages.config.ts'), 'utf8');
+
+  it('pins the compatibility date instead of letting wrangler default to today', () => {
+    // wrangler defaults to the current date, and its workerd only supports
+    // dates up to its own release: on 2026-08-19 that default broke the
+    // e2e-pages job on every branch at once, main included. A date that
+    // arrives on a calendar rather than in a commit is a time bomb.
+    expect(script).toMatch(/--compatibility-date/);
+    expect(script).toMatch(/^COMPATIBILITY_DATE=\d{4}-\d{2}-\d{2}$/m);
+  });
+
+  it('gives up on a server that never starts', () => {
+    // The restart loop is there for a mid-run workerd crash, but retrying a
+    // startup error forever is what buried the real message under Playwright's
+    // "Timed out waiting 300000ms from config.webServer".
+    expect(script).toMatch(/MAX_STARTUP_FAILURES=\d+/);
+    expect(script).toMatch(/failed to start/);
+  });
+
+  it('is the only way the suite starts wrangler', () => {
+    expect(config).toMatch(/bin\/serve-pages-dev\.sh/);
+    expect(config).not.toMatch(/wrangler@latest pages dev/);
+  });
+});
+
 describe('.github/workflows/ci.yml', () => {
   const ci = workflows.find(({ file }) => file === 'ci.yml')!.src;
 


### PR DESCRIPTION
两个互不相关的 CI 缺陷，都是"红得跟改动无关"那一类。第二个是在验证第一个的过程中撞出来的，且它此刻正让 **main 和所有在飞的 PR 全线变红**，所以放在一起修。

---

## 一、六小时挂死 + 缺失的 timeout

#152 的六个必需检查五绿一 `CANCELLED`，PR 挂了一晚。它不是失败，是挂死：

```
16:55:01  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
          （此后 5 小时 59 分钟，零输出）
22:54:02  ##[error]The operation was canceled.
```

6h01m —— GitHub 对单个 job 的硬上限。

最近 40 次 CI：26 成功 / 7 失败 / **6 取消，其中 4 次是 361 分钟的同一处挂死**。挂住的 job 每次不同（E2E ×2、E2E Docker ×2），看着像"到处都在坏"，但每次取消 job 的最后几行日志签名一模一样——三个 e2e job 跑的是同一个 `playwright install --with-deps chromium`，谁中枪是随机的。apt 连上镜像后一个字节不给，而它自身没有任何总时长上限。

| | |
| --- | --- |
| `.github/scripts/install-playwright.sh` | 每次尝试套 `timeout`，重试 3 次。两个坑：停住的 `apt-get` 是孙进程，`timeout` 杀不到，重试前按**进程名**清（不能 `pkill -f 'apt-get\|dpkg'`——模式串会匹配到执行它的 sudo 自己，把脚本自己杀掉）；被杀的 apt 留下 dpkg 锁，不清掉重试会秒失败在 `Could not get lock`，重试就成了纯装饰。 |
| `.github/actions/setup` | 9 处重复的 pnpm/Node/install 收敛成一处（其中 8 处原本各自内联浏览器安装）。浏览器按 **Playwright 版本号**进缓存而非 lockfile——按 lockfile 会在每次依赖升级时白白失效重下。 |
| 8 个 workflow / 14 个 job | 全部补 `timeout-minutes`，按实测耗时留 2～3 倍余量。挂死代价从一晚上变 15 分钟。 |
| `ci.yml` | 加 concurrency：PR 收到新 push 取消旧 run；**push 到 main 不取消**，那是部署和线上冒烟要判定的提交。 |
| `release.yml` | 顺手修：它用 `npm install` 装 pnpm workspace，而根 manifest 有四个 `workspace:*` 依赖，npm 不认这个协议——这个手动 release 在 install 那步就不可能成功。 |

## 二、wrangler 的默认 compatibility date

今天 00:47 UTC 起 `E2E (Cloudflare Pages semantics)` 在每个分支上都红，main 也一样。Playwright 只报 `Timed out waiting 300000ms from config.webServer`，真因在它上面两百行、重复了十五遍：

```
✘ [ERROR] This Worker requires compatibility date "2026-08-19",
  but the newest date supported by this server binary is "2026-08-18".
```

仓库里没有 wrangler 配置也没传 `--compatibility-date`，wrangler 就取**今天**（它自己会 WARNING 说明），而随附的 workerd 只支持到它自己的发布日。跟代码无关、跟分支无关，只跟日历有关。

修法在新增的 `bin/serve-pages-dev.sh`：

1. **固定 compatibility date**。老日期永远被支持，且本项目纯静态资源、没有 Pages Functions，取哪天不影响行为——重要的是它写在提交里而不是由日历决定。
2. **重启循环会放弃**。原循环有正当理由（workerd 会在浏览器中断 sdk-all.js 时跑到一半崩，重启让一次崩溃只损失一个重试用例），但它分不清"跑着崩了"和"压根没起来"，于是把启动错误每秒重试到 Playwright 超时，把清晰的错误熬成了一句无用的超时。现在活不过 10s 视为没起来，连续 3 次带真实错误退出；活过 10s 才崩的照旧重启并清零计数。

顺带把这段 shell 从 TS 模板字符串搬进 `bin/`——模板字符串里写 `${}` 的 shell 变量要转义，纯雷区。

## 用例固化

`test/unit/workflow-contract.test.ts`（31 断言）钉住：每个 job 都有 timeout、没有 workflow 再内联浏览器安装、脚本的 `timeout` 包裹与锁清理都在、concurrency 只对 PR 取消、wrangler 的 compatibility date 写死、重启循环有放弃阈值、配置不许再内联 `wrangler@latest pages dev`。

反向验证（逐条撤掉修复）：去掉 e2e timeout → 红｜改回内联 install → 红｜删 concurrency → 红｜去掉 timeout 包裹+锁清理 → 红 2 条｜拿掉固定日期 → 红｜拿掉放弃逻辑 → 红｜配置改回内联 wrangler → 红｜全部恢复 → 31 绿。

脚本另有本地实测：安装脚本打桩跑过五个分支（缓存命中/未命中、多浏览器、无参数默认、失败重试到上限）；serve 脚本用**真实 wrangler** 复现了失败、验证固定日期后 `Ready on` + HTTP 200 且不再有 `Using today's date` 警告、启动即失败 3 次后 `exit 1`、跑够 10s 才崩只重启不放弃；并用真实 `bin/build.sh` + 新脚本跑通了一条完整 pages 用例（4 passed）。

## 没有做

- **给 `e2e-pages` 分片**（18 min，最长一条）：会改变 check 名字，而分支保护按名字匹配必需检查，改名会让 PR 永久卡在等一个不存在的检查。得先改分支保护，属于另一件事。
- **Docker 构建缓存**：实测镜像构建只占 46s，那 8 分钟都是测试本身。
- **提高 worker 数**：runner 4 核默认 2 worker，这些用例每个都拉真实编辑器 + x2t.wasm，内存敏感；为省几分钟换新的偶发失败，和本 PR 目的相反。

本地：`format:check`、`lint:ts`、`test:coverage`（32 文件 / 608 用例全绿）。

详见 docs/explorations/2026-08-19-ci-workflow-hardening.md 与 docs/explorations/2026-08-19-wrangler-compat-date-timebomb.md。

🤖 Generated with [Claude Code](https://claude.com/claude-code)