### PR TITLE
fix(docker): ship a cache contract so a pulled image actually reaches the browser (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,17 @@ notes. Entries describe what users experience, not internal refactors.
 
 ### Fixed
 
+- Self-hosted (Docker) installs now pick up a new image immediately. The
+  bundled server was caching pages for a day and its JavaScript for a year
+  without ever asking the server again, so pulling a new image could change
+  nothing in the browser -- a fix released weeks earlier was simply not
+  running, while a freshly installed browser on the same machine got it
+  (GitHub #144). Pages and unhashed files now revalidate; only
+  content-addressed files stay cached long-term.
+- When the editor reports "code -82" for a document that failed to open, the
+  message now names the underlying cause instead of the number alone, and a
+  save attempted after such a failure is refused immediately instead of
+  waiting out its timeout.
 - Documents on a phone now use the screen: the right panel, the rulers and the
   notes pane are folded away on narrow viewports, presentations also fold away
   the slide thumbnails, and the document starts fitted to the width -- so it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,12 @@ index.html）的 canonical/hreflang/JSON-LD/sitemap/双语互指契约——新�
 跑在容器（static-web-server）上，证明镜像端到端可用——正是这条链路抓出了
 "Dockerfile 缺 workspace manifest、安装必挂"的问题（CI 原本只查 compose
 config 和 hadolint，从不真正 build）。容器由 `bin/test-e2e-docker.sh` 前后
-强制清理，绝不复用（残留容器会静默服务陈旧镜像）。
+强制清理，绝不复用（残留容器会静默服务陈旧镜像）。镜像的缓存契约在根目录
+`sws.toml`（static-web-server 不读 `_headers`，默认按扩展名给 HTML 1 天、
+`.js/.css` 1 年且都不校验——自托管用户重拉镜像后浏览器仍跑旧 bundle，
+issue #144 第二轮就栽在这里）；改 `_headers` 时必须同步改它，
+`test/unit/hosting-contract.test.ts` + `test/e2e/docker-cache-headers.spec.ts`
+（`E2E_DOCKER=1`）钉死两边。
 
 E2E 在 CI 中依赖 `lint` job 成功后才运行（`needs: lint`）。
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,3 +31,10 @@ RUN pnpm -r run prepare && pnpm run build
 
 FROM joseluisq/static-web-server:2.42.0
 COPY --from=builder /app/dist /public
+# static-web-server does not read dist/_headers (that is Cloudflare Pages'
+# format), and its extension-based defaults cache HTML for a day and every
+# stable-named .js/.css for a year -- so a pulled image can keep serving the
+# previous front end out of the browser cache. sws.toml is the Docker twin of
+# public/_headers; test/unit/hosting-contract.test.ts keeps the two in sync.
+COPY sws.toml /sws.toml
+ENV SERVER_CONFIG_FILE=/sws.toml

--- a/bin/test-e2e-docker.sh
+++ b/bin/test-e2e-docker.sh
@@ -11,7 +11,7 @@ docker build -t document:e2e .
 docker rm -f document-e2e-docker >/dev/null 2>&1 || true
 
 set +e
-./node_modules/.bin/playwright test --config playwright.docker.config.ts
+E2E_DOCKER=1 ./node_modules/.bin/playwright test --config playwright.docker.config.ts
 status=$?
 set -e
 

--- a/docs/explorations/2026-08-19-issue-144-docker-cache-contract.md
+++ b/docs/explorations/2026-08-19-issue-144-docker-cache-contract.md
@@ -1,0 +1,137 @@
+# issue #144 续：为什么"重拉镜像"之后错误一模一样 —— 自托管镜像的缓存契约
+
+日期：2026-08-19
+相关 issue：[#144](https://github.com/ranuts/document/issues/144)
+前一轮：[2026-08-18-issue-144-open-conversion-environment-retry.md](2026-08-18-issue-144-open-conversion-environment-retry.md)
+
+## 一、新的事实
+
+08-18 我们改了三处（字体系统就绪后再转换 / 环境类失败自动重开一次 / toast 带上真实
+原因），并在 issue 里请报告者刷新重试。08-19 回复：
+
+> 我已重拉Docker镜像，但错误依旧，提示出错信息也是一样的。
+
+"**一模一样**"这四个字是本轮唯一的硬证据。上一轮的改动只要真跑起来，界面就必然不同：
+
+| 上一轮改动         | 用户可见的差异                         |
+| ------------------ | -------------------------------------- |
+| 环境类失败自动重开 | 先弹一条 info toast（"正在重试打开…"） |
+| toast 带上真实原因 | 错误 toast 末尾多一段 `[TypeError: …]` |
+
+两者都没出现 → **报告者的浏览器压根没在跑新代码**（或者跑到了、但失败走的是另一条
+根本不经过我们那条 guard 的路径 —— 见第四节，两件事都要修）。
+
+## 二、镜像换了，浏览器没换：static-web-server 的默认缓存头
+
+`Dockerfile` 的运行阶段是 `joseluisq/static-web-server`，它**不读 `dist/_headers`**
+（那是 Cloudflare Pages 的格式，只对线上生效）。它按扩展名给默认值。实测（2.42.0，
+挂一个样本目录）：
+
+```
+/                    cache-control: max-age=86400
+/editor.html         cache-control: max-age=86400
+/assets/app.*.js     cache-control: max-age=31536000
+/sdkjs/sdk-all-min.js cache-control: max-age=31536000
+/sw.js               cache-control: max-age=31536000
+/fonts/000           cache-control: max-age=86400
+```
+
+注意全部**没有 `no-cache` / `must-revalidate`**：在有效期内浏览器根本不会问服务器。
+于是自托管链路上出现一个致命组合：
+
+- `editor.html` 缓存 **1 天**，而它引用的是**哈希化**的 bundle
+  （`./assets/editor-C4gAPO3j.js`）；
+- 只要浏览器手上还有昨天的 `editor.html`，它就会去加载**昨天那个哈希名**的 bundle；
+  而 `/assets/*.js` 被服务器标了 **1 年**，那份旧 bundle 也正躺在同一个浏览器缓存里
+  —— 于是**两个文件都不经过服务器**，页面完整跑起来，跑的却是旧代码。新镜像里
+  根本没有那个哈希名的文件，但浏览器压根没去问；
+  （另一半概率是旧 bundle 已被浏览器淘汰：那就变成 404 + 白页，也是这条链路的
+  经典症状，`public/_headers` 开头那段注释记的就是它。）
+- `Ctrl+F5` 只对**当次导航**绕过缓存。报告者从落地页 `/` 强刷，再点进 `/editor`
+  是**一次新的导航**，仍然吃那 1 天的缓存 —— 强刷了，也还是旧的。
+- `sw.js` 被标了 1 年（浏览器规范把 SW 脚本的缓存上限压到 24 小时，所以没有更糟，
+  但新 SW 最长也要一天才被发现）。
+- 厂商 JS（`sdkjs/**`、`web-apps/**`，其中 `x2t_helper.js` 带着我们自己的补丁）标 1 年
+  且不校验 —— 一旦哪次升级动了它，自托管用户可以抱着旧文件跑一年，还会和新的
+  `AllFonts.js` / 字体目录混搭，正是"半初始化 → -82"的温床。
+
+线上没这个问题（`public/_headers` 把契约钉死了），**只有自托管中招**，而报告者正是
+自托管。这一条足以解释"重拉镜像 + 强刷 = 完全一样的报错"。
+
+## 三、修法：给镜像一份和 `_headers` 对等的契约
+
+新增仓库根目录 `sws.toml`（static-web-server 的 `[[advanced.headers]]`），
+`Dockerfile` 里 `COPY sws.toml /sws.toml` + `ENV SERVER_CONFIG_FILE=/sws.toml`。
+规则按"后面的覆盖前面的、按 header 合并"的语义写：
+
+| source                            | Cache-Control                              |
+| --------------------------------- | ------------------------------------------ |
+| `**`（兜底）                      | `no-cache`（每次校验，命中就是 304）       |
+| `/assets/**`、`/ran-tokens.*.css` | `max-age=31536000, immutable`（内容寻址）  |
+| `/fonts/*`、`x2t.wasm.gz`         | `max-age=31536000, immutable`（随 vendor） |
+| `/ran-fonts/**`                   | `max-age=604800, must-revalidate`          |
+
+即：**默认全部校验，只有名字里带内容哈希、或随 vendor 整体更换的大文件才长缓存** ——
+和 `public/_headers` 一字不差的取舍。实测 static-web-server 支持 `Last-Modified`
+条件请求，校验的代价是一个 304，不是重新下载。
+
+## 四、-82 这张截图本身信息量为零
+
+顺带钉死上一轮没覆盖到的一条：厂商在编辑器 frame 里**自己装了**全局错误钩子
+（`sdkjs/*/sdk-all-min.js`，`asc_docs_api._init`）：
+
+```js
+u = function (msg, script, ...) {
+  ...
+  r.isLoadFullApi &&
+    (r.isDocumentLoadComplete
+      ? r.sendEvent('asc_onError', EditingError, NoCritical)
+      : r.sendEvent('asc_onError', ConvertationOpenError /* -82 */, Critical));
+};
+a.onunhandledrejection = ...; a.onerror = ...;
+```
+
+也就是说：**文档加载完成之前，frame 里任何一个没被接住的错误 —— 不管来自哪 ——
+都会变成同一个 -82 + 同一个"打开文件时发生错误"对话框**。我们的
+`installOpenFailureGuard` 只认 `Document conversion failed|Conversion failed with code|X2T module`
+这几种 message，其它一律不记 `documentOpenError`，toast 里的 `[原因]` 就是空的 ——
+**和修复前逐字节相同**。所以"提示一样"也可能是"走了另一条路"，两种可能都得堵上：
+
+- `installOpenFailureGuard` 现在同时监听 frame 的 `error` 与全部
+  `unhandledrejection`，把**文档就绪前的第一条**错误记进 `lastFrameError`
+  （过滤扩展程序与跨域脚本，和厂商自己的过滤口径一致）；
+- toast 的 `[原因]` 优先用 guard 抓到的转换失败，没有就用 `lastFrameError`
+  （`describeOpenFailure`，纯函数，已单测）；
+- 厂商自己报的 -82（没经过我们的 guard）现在也会 `markDocumentOpenFailed`，
+  于是打开失败后的保存**立刻拒绝**，不再等满超时。
+
+## 五、用例与反向验证
+
+- `test/unit/hosting-contract.test.ts` 新增 `sws.toml` 一节：兜底必须是 `no-cache`、
+  immutable 集合必须与 `_headers` 一致、厂商目录不许 immutable、`Dockerfile` 必须真的
+  加载这份配置（"配置文件在仓库里但服务器不读"是最容易骗过评审的一种绿）。
+- `test/e2e/docker-cache-headers.spec.ts`（仅 `E2E_DOCKER=1`，由
+  `playwright.docker.config.ts` / `bin/test-e2e-docker.sh` 设置）：对**真容器**断言
+  `/`、`/editor`、`/sw.js`、`/home.css` 为 `no-cache`，哈希 bundle / 字体目录 /
+  x2t wasm 为 immutable，并验证一次校验换回 304。
+- **反向验证（已跑）**：`docker pull ghcr.io/ranuts/document:latest`（正是报告者拉到
+  的那个镜像）→ `docker tag ... document:e2e` → 同一条 spec 立刻变红：
+
+  ```
+  ✘ every unhashed path revalidates …   Expected: "no-cache"  Received: "max-age=86400"
+  ✘ hashed and vendor-versioned payloads stay immutable
+        Expected pattern: /max-age=31536000.*immutable/  Received: "max-age=31536000"
+  ✓ a revalidation costs a 304, not a re-download
+  ```
+
+  换成本次修复构建的镜像：3/3 全绿。也就是说，**报告者手上的镜像确实在用
+  `max-age=86400` 发 HTML** —— 浏览器一整天不会回来问一次。
+
+- `describeOpenFailure` / `noteFrameError` 的取舍（截断、只留第一条、跳过
+  `chrome-extension://` 与 `Script error.`）在 `test/unit/onlyoffice-editor.test.ts` 覆盖。
+
+## 六、给报告者的话
+
+镜像已修，但**已经中过招的浏览器需要一次真正的清理**才能跳出旧缓存：无痕窗口、
+或清掉该站点的缓存（DevTools → Application → Clear site data，含 Service Worker）。
+之后若仍报错，新 toast 会在方括号里写明真实原因，那才是可以继续查的输入。

--- a/lib/onlyoffice-editor.ts
+++ b/lib/onlyoffice-editor.ts
@@ -55,6 +55,48 @@ let contentReadyWaiters: Array<() => void> = [];
 // (see installOpenFailureGuard); pending and future saves reject with it
 // instead of waiting out the readiness timeout.
 let documentOpenError: string | null = null;
+// First error seen inside the editor frame before the document finished
+// loading. The vendor installs its own window.onerror/onunhandledrejection
+// (sdk-all-min, asc_docs_api._init) and turns ANY error that lands before
+// isDocumentLoadComplete into asc_onError(ConvertationOpenError = -82,
+// Critical) -- the same code our own conversion guard raises, and the same
+// dialog, with nothing about what actually threw. That is why every #144
+// report so far is a screenshot of an identical toast: the failures that do
+// not go through installOpenFailureGuard carry no cause at all. Keeping the
+// raw message here lets the toast name it.
+let lastFrameError: string | null = null;
+
+// Errors thrown by browser extensions and by cross-origin scripts are not
+// ours to report (the vendor's own handler skips them for the same reason).
+const FOREIGN_SCRIPT = /^(?:chrome|moz|safari|ms-browser)-extension:\/\//;
+
+/**
+ * Record an error seen inside the editor frame while a document is opening.
+ * First one wins: later errors are usually fallout from the first. Returns
+ * whether this call is the one that stuck.
+ */
+export function noteFrameError(message: string, source?: string): boolean {
+  if (documentContentReady || documentOpenError || lastFrameError) return false;
+  if (!message || message === 'Script error.') return false;
+  if (source && FOREIGN_SCRIPT.test(source)) return false;
+  lastFrameError = message;
+  return true;
+}
+
+/**
+ * The bracketed cause appended to the -82 toast. `documentOpenError` is the
+ * conversion rejection our own guard caught; `lastFrameError` covers the
+ * failures the vendor reported itself, which otherwise arrive as a bare code.
+ */
+export function describeOpenFailure(
+  code: number | undefined,
+  openError: string | null,
+  frameError: string | null,
+): string {
+  if (code !== -82) return '';
+  const reason = openError ?? frameError;
+  return reason ? ` [${reason.slice(0, 160)}]` : '';
+}
 
 function markDocumentContentReady(): void {
   if (documentContentReady) return;
@@ -69,6 +111,7 @@ function markDocumentContentReady(): void {
 function resetDocumentContentReady(): void {
   documentContentReady = false;
   documentOpenError = null;
+  lastFrameError = null;
   contentReadyWaiters = [];
 }
 
@@ -600,9 +643,18 @@ function installOpenFailureGuard(win: Window): void {
   // emitting the rejections of its own failed open for a while; those must not
   // be charged to the document that took its place.
   const generation = openGeneration;
+  // Everything that throws in this frame before the document is ready ends up
+  // as the vendor's own -82, so keep the first message whether or not it looks
+  // like a conversion failure (see noteFrameError).
+  win.addEventListener('error', (event) => {
+    const error = event as ErrorEvent;
+    if (generation !== openGeneration) return;
+    noteFrameError(String(error.message ?? ''), error.filename);
+  });
   win.addEventListener('unhandledrejection', (event) => {
     const reason = (event as PromiseRejectionEvent).reason as { message?: unknown } | undefined;
     const message = String(reason && typeof reason === 'object' ? (reason.message ?? reason) : reason);
+    if (generation === openGeneration) noteFrameError(message);
     if (!OPEN_FAILURE_PATTERN.test(message)) return;
     if (documentContentReady) {
       // The document is loaded, so this is a failed export (convertFromBin);
@@ -1488,7 +1540,13 @@ function createPersonalEditorInstance(config: {
         // arrived as a screenshot of this toast (#113, #144). When the open
         // conversion is what failed we know exactly why, so put that reason in
         // the toast too -- truncated, since it is vendor text.
-        const cause = code === -82 && documentOpenError ? ` [${documentOpenError.slice(0, 160)}]` : '';
+        const cause = describeOpenFailure(code, documentOpenError, lastFrameError);
+        // A -82 the vendor raised itself (its window.onerror path) never went
+        // through installOpenFailureGuard, so nothing has marked the document
+        // as failed yet and every save would wait out its full timeout.
+        if (code === -82 && !documentContentReady) {
+          markDocumentOpenFailed(documentOpenError ?? lastFrameError ?? `editor reported error ${code}`);
+        }
         const detail = [code !== undefined ? `code ${code}` : '', data?.errorDescription].filter(Boolean).join(', ');
         (window as unknown as { message?: { error?: (msg: string) => void } }).message?.error?.(
           `${t('editorErrorToast')}${detail ? ` (${detail})` : ''}${hint}${cause}`,

--- a/playwright.docker.config.ts
+++ b/playwright.docker.config.ts
@@ -8,6 +8,11 @@ import { defineConfig, devices } from '@playwright/test';
 // The image must exist as `document:e2e` before the run -- use
 // `pnpm run test:e2e:docker`, which builds it first, or build manually with
 // `pnpm run docker:build`.
+// Marks the run as the containerised one: docker-cache-headers.spec.ts checks
+// the image's own cache-control contract (sws.toml) and must not run against
+// the vite preview server, which serves different headers.
+process.env.E2E_DOCKER = '1';
+
 export default defineConfig({
   testDir: 'test/e2e',
   timeout: 120_000,

--- a/sws.toml
+++ b/sws.toml
@@ -1,0 +1,70 @@
+# Caching contract for the self-hosted Docker image (static-web-server).
+#
+# This file is the Docker twin of public/_headers: the Cloudflare Pages
+# deployment gets its cache rules from _headers, which static-web-server does
+# not read. Without it the server falls back to its extension-based defaults --
+# `max-age=86400` for HTML and `max-age=31536000` for every .js/.css -- and the
+# stable-named files then outlive the image they came from. A self-hoster who
+# pulls a new image keeps serving the previous editor.html (and with it the
+# previous hashed bundle) out of the browser cache for a day, and the previous
+# vendor JS for a year, which is how a fix that shipped weeks ago can still be
+# missing from a freshly pulled container (GitHub #144).
+#
+# Rules are applied in order and merged per header, so the catch-all below sets
+# the safe default and the specific rules that follow relax it.
+
+[advanced]
+
+# Default: revalidate. Same semantics as the Pages default, and what every
+# stable-named file needs -- HTML, sw.js, the deploy-coupled shell files
+# (home.css, landing.css, lang-switch.js, ranui-iife/) and the vendor trees,
+# whose JS carries our own runtime patch (x2t_helper.js). Revalidation is a
+# conditional request answered with 304, not a re-download.
+[[advanced.headers]]
+source = "**"
+[advanced.headers.headers]
+Cache-Control = "no-cache"
+
+# Keep the vendored editor trees out of search indexes (mirrors _headers).
+[[advanced.headers]]
+source = "/sdkjs/**"
+[advanced.headers.headers]
+X-Robots-Tag = "noindex"
+
+[[advanced.headers]]
+source = "/web-apps/**"
+[advanced.headers.headers]
+X-Robots-Tag = "noindex"
+
+# Hashed build outputs: the filename changes with the content.
+[[advanced.headers]]
+source = "/assets/**"
+[advanced.headers.headers]
+Cache-Control = "public, max-age=31536000, immutable"
+
+# Fingerprinted by bin/build.sh, same reasoning.
+[[advanced.headers]]
+source = "/ran-tokens.*.css"
+[advanced.headers.headers]
+Cache-Control = "public, max-age=31536000, immutable"
+
+# Self-hosted webfonts: unhashed, but they only change with a ranui release.
+[[advanced.headers]]
+source = "/ran-fonts/**"
+[advanced.headers.headers]
+Cache-Control = "public, max-age=604800, must-revalidate"
+
+# The editor's indexed font catalog (000..266, 200 KB - 5 MB each): replaced
+# only together with the vendor build, and revalidating them per open is what
+# put a CJK deck on "Loading presentation" for minutes on production.
+[[advanced.headers]]
+source = "/fonts/*"
+[advanced.headers.headers]
+Cache-Control = "public, max-age=31536000, immutable"
+X-Robots-Tag = "noindex"
+
+# The x2t WASM (9.9 MB gz): the single largest download, vendor-versioned.
+[[advanced.headers]]
+source = "/sdkjs/common/wasm/x2t/x2t.wasm.gz"
+[advanced.headers.headers]
+Cache-Control = "public, max-age=31536000, immutable"

--- a/test/e2e/docker-cache-headers.spec.ts
+++ b/test/e2e/docker-cache-headers.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from './lib/l0';
+
+/**
+ * The caching contract of the self-hosted image (sws.toml), checked against
+ * the real container. Docker-only: the vite preview server used by the other
+ * configs serves its own headers, so the spec skips everywhere else --
+ * playwright.docker.config.ts sets E2E_DOCKER.
+ *
+ * What it guards: static-web-server does not read `_headers`, and its default
+ * is `max-age=86400` for HTML plus `max-age=31536000` for every .js/.css, all
+ * without revalidation. With those defaults a pulled image changes nothing for
+ * a day (the browser keeps the previous editor.html, which points at the
+ * previous hashed bundle) and vendor JS never changes at all -- which is how a
+ * reporter on GitHub #144 re-pulled the image and got a byte-identical error.
+ */
+const dockerOnly = !process.env.E2E_DOCKER;
+
+test.describe('self-hosted image cache headers', () => {
+  test.skip(dockerOnly, 'runs against the Docker image only (pnpm run test:e2e:docker)');
+
+  test('every unhashed path revalidates, so a new image reaches the browser', async ({ request }) => {
+    for (const path of ['/', '/editor', '/editor.html', '/sw.js', '/home.css', '/lang-switch.js']) {
+      const response = await request.get(path);
+      expect(response.status(), path).toBe(200);
+      expect(response.headers()['cache-control'], path).toBe('no-cache');
+    }
+  });
+
+  test('hashed and vendor-versioned payloads stay immutable', async ({ request }) => {
+    const editorHtml = await (await request.get('/editor.html')).text();
+    const bundle = /src="\.?\/?(assets\/[^"]+\.js)"/.exec(editorHtml)?.[1];
+    expect(bundle, 'editor.html must reference a hashed bundle').toBeTruthy();
+
+    for (const path of [`/${bundle}`, '/fonts/000', '/sdkjs/common/wasm/x2t/x2t.wasm.gz']) {
+      const response = await request.get(path);
+      expect(response.status(), path).toBe(200);
+      expect(response.headers()['cache-control'], path).toMatch(/max-age=31536000.*immutable/);
+    }
+  });
+
+  test('a revalidation costs a 304, not a re-download', async ({ request }) => {
+    const first = await request.get('/editor.html');
+    const lastModified = first.headers()['last-modified'];
+    expect(lastModified).toBeTruthy();
+    const second = await request.get('/editor.html', { headers: { 'If-Modified-Since': lastModified } });
+    expect(second.status()).toBe(304);
+  });
+});

--- a/test/unit/hosting-contract.test.ts
+++ b/test/unit/hosting-contract.test.ts
@@ -64,6 +64,56 @@ describe('public/_headers', () => {
   });
 });
 
+/**
+ * Docker twin of the same contract. static-web-server never reads `_headers`,
+ * and its extension-based defaults are actively wrong for this app: HTML for a
+ * day and every stable-named .js/.css for a year, both without revalidation.
+ * A self-hoster who pulled a new image therefore kept serving the previous
+ * editor.html -- and with it the previous hashed bundle -- so a shipped fix
+ * was simply not there (GitHub #144, "re-pulled the image, same error").
+ */
+describe('sws.toml (self-hosted Docker)', () => {
+  /** Parse the `[[advanced.headers]]` blocks into { source, headers }. */
+  const rules = read('sws.toml')
+    .split(/^\[\[advanced\.headers\]\]$/m)
+    .slice(1)
+    .map((block) => {
+      const source = /source\s*=\s*"([^"]+)"/.exec(block)?.[1] ?? '';
+      const headers: Record<string, string> = {};
+      for (const line of block.split('\n')) {
+        const match = /^([A-Za-z-]+)\s*=\s*"([^"]*)"$/.exec(line.trim());
+        if (match && match[1] !== 'source') headers[match[1].toLowerCase()] = match[2];
+      }
+      return { source, headers };
+    });
+  const cc = (source: string) => rules.find((rule) => rule.source === source)?.headers['cache-control'];
+
+  it('defaults every path to revalidation, so a new image is actually served', () => {
+    expect(rules[0]?.source).toBe('**');
+    expect(cc('**')).toBe('no-cache');
+  });
+
+  it('pins the same immutable set as _headers (hashed assets, font catalog, x2t wasm)', () => {
+    for (const source of ['/assets/**', '/fonts/*', '/sdkjs/common/wasm/x2t/x2t.wasm.gz', '/ran-tokens.*.css']) {
+      expect(cc(source), source).toMatch(/max-age=31536000.*immutable/);
+    }
+  });
+
+  it('never makes the patched vendor trees immutable', () => {
+    for (const rule of rules) {
+      if (/^\/(sdkjs|web-apps)\/\*\*$/.test(rule.source)) {
+        expect(rule.headers['cache-control'] ?? '', rule.source).not.toMatch(/immutable|max-age=[1-9]/);
+      }
+    }
+  });
+
+  it('is wired into the image (a config the server never loads pins nothing)', () => {
+    const dockerfile = read('Dockerfile');
+    expect(dockerfile).toMatch(/COPY sws\.toml \/sws\.toml/);
+    expect(dockerfile).toMatch(/ENV SERVER_CONFIG_FILE=\/sws\.toml/);
+  });
+});
+
 describe('public/_redirects', () => {
   it('canonicalizes the localized landing directory', () => {
     expect(read('public/_redirects')).toMatch(/^\/zh-CN\s+\/zh-CN\/\s+308/m);

--- a/test/unit/onlyoffice-editor.test.ts
+++ b/test/unit/onlyoffice-editor.test.ts
@@ -19,6 +19,8 @@ vi.mock(import('@ranuts/shared/document-utils'), async (importOriginal) => {
 import {
   awaitFontSystem,
   classifyOpenFailure,
+  describeOpenFailure,
+  noteFrameError,
   compactViewportCustomization,
   createEditorInstance,
   isCompactViewport,
@@ -515,6 +517,40 @@ describe('open-conversion readiness and failure classification', () => {
     ).toBe('environment');
     expect(classifyOpenFailure('X2T module not found after script loading')).toBe('environment');
     expect(classifyOpenFailure('Document conversion failed: TypeError: Failed to fetch')).toBe('environment');
+  });
+
+  // The vendor's own window.onerror turns any pre-load error into the same
+  // -82 our conversion guard raises, so a report of "code -82" alone says
+  // nothing about the cause (GitHub #144 arrived twice as the same
+  // screenshot). The toast has to carry whatever the frame actually threw.
+  it('names the conversion rejection in the -82 toast when the guard caught it', () => {
+    expect(describeOpenFailure(-82, 'Document conversion failed: Conversion failed with code: 88', null)).toBe(
+      ' [Document conversion failed: Conversion failed with code: 88]',
+    );
+  });
+
+  it('falls back to the frame error for a -82 the vendor raised itself', () => {
+    expect(describeOpenFailure(-82, null, "TypeError: Cannot read properties of undefined (reading 'Id')")).toBe(
+      " [TypeError: Cannot read properties of undefined (reading 'Id')]",
+    );
+  });
+
+  it('adds nothing when there is no cause, and never to another error code', () => {
+    expect(describeOpenFailure(-82, null, null)).toBe('');
+    expect(describeOpenFailure(-85, null, 'some frame error')).toBe('');
+    expect(describeOpenFailure(undefined, null, 'some frame error')).toBe('');
+  });
+
+  it('truncates the vendor text so the toast stays readable', () => {
+    expect(describeOpenFailure(-82, 'x'.repeat(300), null)).toBe(` [${'x'.repeat(160)}]`);
+  });
+
+  it('keeps the first frame error and ignores noise and foreign scripts', () => {
+    expect(noteFrameError('', undefined)).toBe(false);
+    expect(noteFrameError('Script error.')).toBe(false);
+    expect(noteFrameError('boom in an add-on', 'chrome-extension://abc/inject.js')).toBe(false);
+    expect(noteFrameError('the real first failure')).toBe(true);
+    expect(noteFrameError('later fallout')).toBe(false);
   });
 });
 


### PR DESCRIPTION
Follow-up to #146 / #148. The reporter on #144 pulled a new image and got a
**byte-identical** error — which is itself the evidence: the previous round adds a
retry toast and a bracketed cause to the -82 message, so an unchanged UI means the
browser never ran the new code.

## Why a pulled image changed nothing

`static-web-server` does not read `dist/_headers` (that is Cloudflare Pages' format,
so only production was pinned). It falls back to extension-based defaults — measured
against a real container:

```
/  /editor.html          cache-control: max-age=86400      <- a day, never revalidated
/assets/app.<hash>.js    cache-control: max-age=31536000
/sdkjs/**.js  /sw.js     cache-control: max-age=31536000
/fonts/000               cache-control: max-age=86400
```

`editor.html` is cached for a day and the hashed bundle it points at for a year, so
**neither file touches the server**: the page runs entirely on the previous build.
`Ctrl+F5` only bypasses the cache for that one navigation — hard-refreshing the
landing page and then clicking through to `/editor` is a fresh navigation that hits
the cache again. (The other half of the coin: if the old bundle has been evicted, the
stale HTML 404s instead — the failure `public/_headers` was written to prevent.)

`sws.toml` is the Docker twin of `public/_headers`: revalidate by default (a 304, not
a re-download — the server answers conditional requests), long-lived only for
content-addressed names and the vendor-versioned binaries.

## Second gap: a -82 screenshot carries no information

The vendor installs its own `window.onerror` / `onunhandledrejection` in the editor
frame (`sdk-all-min.js`, `asc_docs_api._init`) and turns **any** error landing before
the document is loaded into `asc_onError(ConvertationOpenError = -82, Critical)` —
the same code and dialog our own conversion guard raises. `installOpenFailureGuard`
only recorded messages matching the conversion pattern, so everything else produced a
toast with a bare number, identical before and after a fix.

It now keeps the first pre-ready frame error (skipping extension and cross-origin
scripts, matching the vendor's own filter), names it in the -82 toast, and marks the
document as failed so a save after a vendor-reported open failure is refused
immediately instead of waiting out its timeout.

## Tests

- `test/unit/hosting-contract.test.ts`: pins `sws.toml` against `_headers` and checks
  the Dockerfile actually loads it (a config file the server never reads pins nothing).
- `test/e2e/docker-cache-headers.spec.ts`: asserts the headers on the real container
  and that a revalidation costs a 304 (`E2E_DOCKER=1`, set by the docker config and
  `bin/test-e2e-docker.sh`).
- `describeOpenFailure` / `noteFrameError` unit-tested (truncation, first-error-wins,
  `chrome-extension://` and `Script error.` filtered).

**Reverse validation**: the same spec run against the published pre-fix image
(`ghcr.io/ranuts/document:latest` — the one the reporter pulled) goes red on the first
assertion, `Expected: "no-cache"  Received: "max-age=86400"`; against this branch's
image 3/3 pass. Full docker suite on this branch: 85 passed, 13 skipped.

Write-up: `docs/explorations/2026-08-19-issue-144-docker-cache-contract.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)