### PR TITLE
ci: shard the three E2E suites and stop them waiting on lint

### DIFF
--- a/.github/scripts/install-playwright.sh
+++ b/.github/scripts/install-playwright.sh
@@ -17,22 +17,39 @@ if [ ${#browsers[@]} -eq 0 ]; then
   browsers=(chromium)
 fi
 
-# Stop apt from trickling along on a half-dead mirror indefinitely. This alone
-# would not have saved the six-hour runs (the stall happens with no bytes
-# moving at all), but it turns a slow mirror into a fast failure too.
-sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'CONF'
-Acquire::Retries "3";
-Acquire::http::Timeout "30";
-Acquire::https::Timeout "30";
-CONF
-
-# A cache hit restores the browser binaries but never the system libraries, so
-# the apt half still has to run -- but it is allowed to lose, and it is not
-# allowed to take long about it (see the note on the exit below). A healthy
-# install-deps finishes well inside a minute; a stalled one costs two and the
-# suite carries on. A cold cache has no browsers to run without, so it keeps
-# the patient settings.
+# On a cache hit, skip apt entirely.
+#
+# What `install-deps` actually does on a hosted runner, read off a healthy run:
+# every library Chromium needs -- libnss3, libgbm1, libasound2t64, libcairo2,
+# the lot -- reports "is already the newest version". The runner image ships
+# them. The only thing apt installs is 21.1 MB of fonts (fonts-wqy-zenhei,
+# fonts-ipafont-gothic, fonts-unifont, fonts-freefont-ttf, fonts-tlwg-loma-otf,
+# xfonts-encodings), for rendering scripts a screenshot might contain.
+#
+# This suite does not render through them. The editor draws with its own
+# vendored XOR font catalog (public/fonts/), PDF export injects
+# PDF_FONT_MANIFEST, and the landing pages load vendored Geist woff2 -- system
+# fonts reach nothing but DOM fallback text. The visual specs compare two
+# renders from the same browser (original against saved-and-reopened), so a
+# missing glyph would be missing identically on both sides.
+#
+# So each job was making a network call to Ubuntu's mirrors, on a fresh VM,
+# for fonts nothing reads. Eleven jobs, eleven rolls of the dice per run -- and
+# the dice are loaded: the runner's preferred azure.archive.ubuntu.com comes
+# back `Ign:`, apt falls through to the public archive, and that stalls dead
+# with no bytes moving. Four jobs were killed at GitHub's six-hour limit this
+# week before the attempts were bounded; two more burned 17 minutes each on a
+# single pull request after that.
+#
+# A cold cache still installs, deps and all: there are no browsers to run
+# without it, and that path downloads from Playwright's CDN anyway.
 if [ "${BROWSERS_CACHED:-}" = "true" ]; then
+  if [ "${PLAYWRIGHT_INSTALL_DEPS:-}" != "true" ]; then
+    echo "Browsers restored from the cache; skipping the apt font install."
+    exit 0
+  fi
+  # Escape hatch: PLAYWRIGHT_INSTALL_DEPS=true puts apt back, bounded and
+  # advisory, for the day a runner image stops shipping one of the libraries.
   command=(install-deps "${browsers[@]}")
   deps_are_advisory=true
   default_attempts=1
@@ -43,6 +60,15 @@ else
   default_attempts=3
   default_timeout=300
 fi
+
+# Stop apt from trickling along on a half-dead mirror indefinitely. This alone
+# would not have saved the six-hour runs (the stall happens with no bytes
+# moving at all), but it turns a slow mirror into a fast failure too.
+sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'CONF'
+Acquire::Retries "3";
+Acquire::http::Timeout "30";
+Acquire::https::Timeout "30";
+CONF
 
 attempts=${PLAYWRIGHT_INSTALL_ATTEMPTS:-$default_attempts}
 attempt_timeout=${PLAYWRIGHT_INSTALL_TIMEOUT:-$default_timeout}

--- a/.github/scripts/install-playwright.sh
+++ b/.github/scripts/install-playwright.sh
@@ -17,9 +17,6 @@ if [ ${#browsers[@]} -eq 0 ]; then
   browsers=(chromium)
 fi
 
-attempts=${PLAYWRIGHT_INSTALL_ATTEMPTS:-3}
-attempt_timeout=${PLAYWRIGHT_INSTALL_TIMEOUT:-300}
-
 # Stop apt from trickling along on a half-dead mirror indefinitely. This alone
 # would not have saved the six-hour runs (the stall happens with no bytes
 # moving at all), but it turns a slow mirror into a fast failure too.
@@ -29,13 +26,26 @@ Acquire::http::Timeout "30";
 Acquire::https::Timeout "30";
 CONF
 
-# A cache hit restores the browser binaries but never the system libraries,
-# so the apt half still has to run.
+# A cache hit restores the browser binaries but never the system libraries, so
+# the apt half still has to run -- but it is allowed to lose, and it is not
+# allowed to take long about it (see the note on the exit below). A healthy
+# install-deps finishes well inside a minute; a stalled one costs two and the
+# suite carries on. A cold cache has no browsers to run without, so it keeps
+# the patient settings.
 if [ "${BROWSERS_CACHED:-}" = "true" ]; then
   command=(install-deps "${browsers[@]}")
+  deps_are_advisory=true
+  default_attempts=1
+  default_timeout=120
 else
   command=(install --with-deps "${browsers[@]}")
+  deps_are_advisory=false
+  default_attempts=3
+  default_timeout=300
 fi
+
+attempts=${PLAYWRIGHT_INSTALL_ATTEMPTS:-$default_attempts}
+attempt_timeout=${PLAYWRIGHT_INSTALL_TIMEOUT:-$default_timeout}
 
 for attempt in $(seq 1 "$attempts"); do
   if timeout --kill-after=30s "${attempt_timeout}s" pnpm exec playwright "${command[@]}"; then
@@ -61,6 +71,23 @@ for attempt in $(seq 1 "$attempts"); do
 
   sleep 10
 done
+
+# With the binaries already restored from the cache, the only thing apt could
+# still be adding is system libraries -- and the hosted runner image ships
+# chromium's. Failing the job here means a stalled Ubuntu mirror is a red pull
+# request, which is what actually happened: `noble-security InRelease` followed
+# by four and a half minutes of total silence, three attempts in a row, twice on
+# the same run. Sharding multiplied the number of jobs exposed to it.
+#
+# So on a cache hit the suite runs anyway. If a library really is missing,
+# Playwright says so in as many words when it launches the browser, and the
+# test step fails with that message instead of this one -- the information is
+# not lost, it just no longer costs a run. A cold cache still has to succeed:
+# there are no browsers to run without it.
+if [ "$deps_are_advisory" = "true" ]; then
+  echo "::warning::playwright ${command[*]} failed after ${attempts} attempts; continuing on the cached browsers"
+  exit 0
+fi
 
 echo "::error::playwright ${command[*]} failed after ${attempts} attempts"
 exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,20 @@ concurrency:
 permissions:
   contents: read
 
+# The three E2E suites run the same ~95 specs against three different servers
+# (vite preview, the production container, wrangler pages dev), which is the
+# whole cost of this workflow -- install, vite build and docker build together
+# are under two minutes. Each suite is therefore split across three runners,
+# and a summary job carries the name the branch protection requires.
+#
+# Sharding, not more workers: the runner has 4 cores, the editor is a WASM
+# process per worker, and the Pages suite deliberately runs single-worker
+# (playwright.pages.config.ts explains why workerd dies under concurrent
+# aborts). Shards keep every suite's own concurrency semantics untouched.
+#
+# Changing the shard count means editing both the matrix and the /N in the
+# --shard argument of that job.
+
 jobs:
   lint:
     name: Lint and Validate
@@ -48,11 +62,21 @@ jobs:
           dockerfile: Dockerfile
           failure-threshold: error
 
-  e2e:
-    name: E2E
+  # The E2E jobs deliberately do NOT wait for lint. Lint is a one-minute job,
+  # but waiting for it put ~90 seconds of pure latency on the critical path of
+  # every PR. On a public repository the runners are free, so the only cost of
+  # starting E2E early is a wasted run on the commits where lint is red -- and
+  # those commits get their E2E answer for free instead of after a second push.
+  e2e-shard:
+    name: E2E shard ${{ matrix.shard }}
     runs-on: ubuntu-latest
-    needs: lint
-    timeout-minutes: 30
+    timeout-minutes: 20
+    strategy:
+      # One shard failing must not hide the verdict of the other two: a red
+      # suite should report every failure it has in a single run.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
 
     steps:
       - name: Checkout code
@@ -64,27 +88,48 @@ jobs:
           browsers: chromium
 
       - name: Run E2E tests
-        run: pnpm run test:e2e
+        run: pnpm exec playwright test --shard=${{ matrix.shard }}/3
 
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.shard }}
           path: playwright-report/
           retention-days: 7
+
+  # Summary jobs. Branch protection matches required checks by name, so the
+  # three names below must stay exactly as they are -- the sharded jobs are
+  # named "... shard N" precisely so these can keep the original names.
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+    needs: e2e-shard
+    if: always()
+    timeout-minutes: 5
+    steps:
+      - name: Report the shard verdict
+        env:
+          RESULT: ${{ needs.e2e-shard.result }}
+        run: |
+          echo "shards: $RESULT"
+          [ "$RESULT" = "success" ] || exit 1
 
   # Deploy artifact + host semantics: bin/build.sh output served by
   # `wrangler pages dev`, which reproduces Cloudflare Pages' index.html -> 308
   # redirects, _headers and _redirects. Catches "works on vite preview, broken
   # on the live site" (PDF loader stuck behind the 308; font cache headers).
-  e2e-pages:
-    name: E2E (Cloudflare Pages semantics)
+  e2e-pages-shard:
+    name: E2E (Cloudflare Pages semantics) shard ${{ matrix.shard }}
     runs-on: ubuntu-latest
-    needs: lint
-    # The slowest of the three: wrangler is served by a single worker on
-    # purpose (see playwright.pages.config.ts), so ~20 minutes is normal.
-    timeout-minutes: 45
+    # Each shard still serves wrangler with a single worker on purpose (see
+    # playwright.pages.config.ts), so a shard is roughly a third of the old
+    # ~20 minute job plus its own build.
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
 
     steps:
       - name: Checkout code
@@ -96,26 +141,44 @@ jobs:
           browsers: chromium
 
       - name: Run E2E against wrangler pages dev
-        run: pnpm exec playwright test -c playwright.pages.config.ts
+        run: pnpm exec playwright test -c playwright.pages.config.ts --shard=${{ matrix.shard }}/3
 
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-report-pages
+          name: playwright-report-pages-${{ matrix.shard }}
           path: playwright-report-pages/
           retention-days: 7
+
+  e2e-pages:
+    name: E2E (Cloudflare Pages semantics)
+    runs-on: ubuntu-latest
+    needs: e2e-pages-shard
+    if: always()
+    timeout-minutes: 5
+    steps:
+      - name: Report the shard verdict
+        env:
+          RESULT: ${{ needs.e2e-pages-shard.result }}
+        run: |
+          echo "shards: $RESULT"
+          [ "$RESULT" = "success" ] || exit 1
 
   # The lint job only validates compose config and Dockerfile style; this job
   # actually builds the image and runs the full e2e suite against the running
   # container, proving the production image serves the editor correctly (this
-  # is what caught the workspace-manifest install breakage). Runs in parallel
-  # with the main e2e job.
-  e2e-docker:
-    name: E2E (Docker image)
+  # is what caught the workspace-manifest install breakage). Every shard builds
+  # the image itself -- that build is 45 seconds, far cheaper than shipping the
+  # image between jobs as an artifact.
+  e2e-docker-shard:
+    name: E2E (Docker image) shard ${{ matrix.shard }}
     runs-on: ubuntu-latest
-    needs: lint
-    timeout-minutes: 30
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
 
     steps:
       - name: Checkout code
@@ -127,12 +190,28 @@ jobs:
           browsers: chromium
 
       - name: Run E2E tests against the Docker image
-        run: pnpm run test:e2e:docker
+        # Called directly, not through `pnpm run`: pnpm swallows the extra
+        # arguments, which would silently run the whole suite in every shard.
+        run: sh ./bin/test-e2e-docker.sh --shard=${{ matrix.shard }}/3
 
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-report-docker
+          name: playwright-report-docker-${{ matrix.shard }}
           path: playwright-report-docker/
           retention-days: 7
+
+  e2e-docker:
+    name: E2E (Docker image)
+    runs-on: ubuntu-latest
+    needs: e2e-docker-shard
+    if: always()
+    timeout-minutes: 5
+    steps:
+      - name: Report the shard verdict
+        env:
+          RESULT: ${{ needs.e2e-docker-shard.result }}
+        run: |
+          echo "shards: $RESULT"
+          [ "$RESULT" = "success" ] || exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,14 +122,16 @@ jobs:
   e2e-pages-shard:
     name: E2E (Cloudflare Pages semantics) shard ${{ matrix.shard }}
     runs-on: ubuntu-latest
-    # Each shard still serves wrangler with a single worker on purpose (see
-    # playwright.pages.config.ts), so a shard is roughly a third of the old
-    # ~20 minute job plus its own build.
+    # Five shards rather than three: this suite still serves wrangler with a
+    # single worker on purpose (see playwright.pages.config.ts), so it is the
+    # slowest of the three and sets the critical path. Every shard also pays a
+    # fixed ~2 minutes for its own bin/build.sh and wrangler start, which is
+    # what stops the split from paying off much beyond this.
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4, 5]
 
     steps:
       - name: Checkout code
@@ -141,7 +143,7 @@ jobs:
           browsers: chromium
 
       - name: Run E2E against wrangler pages dev
-        run: pnpm exec playwright test -c playwright.pages.config.ts --shard=${{ matrix.shard }}/3
+        run: pnpm exec playwright test -c playwright.pages.config.ts --shard=${{ matrix.shard }}/5
 
       - name: Upload Playwright report
         if: failure()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,20 +266,39 @@ E2E 在 CI 中依赖 `lint` job 成功后才运行（`needs: lint`）。
 
 ## CI 流程（.github/workflows/ci.yml）
 
-**四个 job**，触发条件：push/PR 到 main/master。`lint` 先跑，三个 e2e job
-在它之后并行。
+触发条件：push/PR 到 main/master。**所有 job 一起起跑，e2e 不等 lint**——lint
+只有 1 min，但等它整个 job 结束会在每个 PR 的关键路径上白加 ~90s；仓库是公开
+的，runner 免费，lint 红的那次多跑一轮 e2e 比多推一次 commit 划算。
 
-| job          | 名称（分支保护里的必需检查名）   | 正常耗时                   | timeout |
-| ------------ | -------------------------------- | -------------------------- | ------- |
-| `lint`       | Lint and Validate                | ~1.5 min                   | 15 min  |
-| `e2e`        | E2E                              | ~9 min                     | 30 min  |
-| `e2e-docker` | E2E (Docker image)               | ~8 min（镜像构建仅占 46s） | 30 min  |
-| `e2e-pages`  | E2E (Cloudflare Pages semantics) | ~18 min                    | 45 min  |
+三套 E2E 跑的是**同一批 ~95 个用例**，只是服务器不同（vite preview / 生产镜像 /
+wrangler pages dev），这是整个 workflow 的全部成本（install + vite build +
+docker build 加起来不到 2 min）。所以每套都用 matrix 切成 **3 个分片**，再由一个
+汇总 job 顶着分支保护要求的检查名：
+
+| 分片 job（matrix ×3） | 汇总 job（= 必需检查名）                       | 分片耗时 | timeout |
+| --------------------- | ---------------------------------------------- | -------- | ------- |
+| `lint`（不分片）      | `lint` → Lint and Validate                     | ~1.5 min | 15 min  |
+| `e2e-shard`           | `e2e` → E2E                                    | ~3 min   | 20 min  |
+| `e2e-docker-shard`    | `e2e-docker` → E2E (Docker image)              | ~4 min   | 25 min  |
+| `e2e-pages-shard`     | `e2e-pages` → E2E (Cloudflare Pages semantics) | ~5 min   | 30 min  |
+
+**分片而不是加 workers**：runner 只有 4 核、每个 worker 拖一个 WASM 编辑器进程，
+而 pages 那套是**故意**单 worker 的（并发下 workerd 会被大文件 abort 打崩，见
+`playwright.pages.config.ts`）。分片不动任何一套自己的并发语义。
+
+**改分片数要同时改两处**：matrix 的 `shard: [...]` 与命令里 `--shard=N/M` 的 M。
+对不上会静默少跑一批用例还报绿——`test/unit/workflow-contract.test.ts` 把两个
+数字钉在一起了。
+
+**docker 分片必须直接 `sh ./bin/test-e2e-docker.sh --shard=…`**，不能走
+`pnpm run test:e2e:docker -- --shard=…`：pnpm 会把参数吃掉，三个分片各自跑完整
+套件、全绿、分片等于没做（实测，见探索文档）。
 
 **lint job（串行步骤）：** setup（见下）→ `format:check` → `lint:ts` →
 `test:coverage` → `docker compose config --quiet` → hadolint。
-**三个 e2e job：** setup（含 chromium）→ 各自的测试命令 → 失败时上传
-`playwright-report*/` artifact。
+**e2e 分片 job：** setup（含 chromium）→ 各自带 `--shard` 的测试命令 → 失败时
+上传 `playwright-report*-<分片号>/` artifact。
+**汇总 job：** `if: always()`，`needs.<分片 job>.result != success` 就退 1。
 
 **共用 setup（`.github/actions/setup`）**：pnpm + Node `lts/*` + pnpm 缓存 +
 `pnpm install --frozen-lockfile`，`browsers:` 入参非空时再装 Playwright 浏览器。
@@ -306,9 +325,10 @@ apt-get，而 hosted runner 上的 apt 有过**拉完 release 索引后彻底停
 docs/explorations/2026-08-19-wrangler-compat-date-timebomb.md。
 
 **约定**：新增 workflow / job 必须带 `timeout-minutes`，浏览器安装必须走共用
-action，wrangler 必须经 `bin/serve-pages-dev.sh` 起。三条都由
-`test/unit/workflow-contract.test.ts` 钉死。
-详见 docs/explorations/2026-08-19-ci-workflow-hardening.md。
+action，wrangler 必须经 `bin/serve-pages-dev.sh` 起，分片数与 `--shard` 分母必须
+一致，三个汇总 job 的名字不能改。全部由 `test/unit/workflow-contract.test.ts`
+钉死。详见 docs/explorations/2026-08-19-ci-workflow-hardening.md 与
+docs/explorations/2026-08-19-ci-e2e-sharding.md。
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,12 +275,15 @@ wrangler pages dev），这是整个 workflow 的全部成本（install + vite b
 docker build 加起来不到 2 min）。所以每套都用 matrix 切成 **3 个分片**，再由一个
 汇总 job 顶着分支保护要求的检查名：
 
-| 分片 job（matrix ×3） | 汇总 job（= 必需检查名）                       | 分片耗时 | timeout |
-| --------------------- | ---------------------------------------------- | -------- | ------- |
-| `lint`（不分片）      | `lint` → Lint and Validate                     | ~1.5 min | 15 min  |
-| `e2e-shard`           | `e2e` → E2E                                    | ~3 min   | 20 min  |
-| `e2e-docker-shard`    | `e2e-docker` → E2E (Docker image)              | ~4 min   | 25 min  |
-| `e2e-pages-shard`     | `e2e-pages` → E2E (Cloudflare Pages semantics) | ~5 min   | 30 min  |
+| 分片 job              | 汇总 job（= 必需检查名）                       | 分片耗时    | timeout |
+| --------------------- | ---------------------------------------------- | ----------- | ------- |
+| `lint`（不分片）      | `lint` → Lint and Validate                     | ~1 min      | 15 min  |
+| `e2e-shard` ×3        | `e2e` → E2E                                    | 2.4~4 min   | 20 min  |
+| `e2e-docker-shard` ×3 | `e2e-docker` → E2E (Docker image)              | 3.3~4.6 min | 25 min  |
+| `e2e-pages-shard` ×5  | `e2e-pages` → E2E (Cloudflare Pages semantics) | ~4.5 min    | 30 min  |
+
+pages 切 5 片而不是 3 片：它单 worker、最慢，是关键路径；但每片还要付 ~2 min
+的 `build.sh` + wrangler 启动固定成本，再往上切收益就被这块吃掉了。
 
 **分片而不是加 workers**：runner 只有 4 核、每个 worker 拖一个 WASM 编辑器进程，
 而 pages 那套是**故意**单 worker 的（并发下 workerd 会被大文件 abort 打崩，见
@@ -310,8 +313,16 @@ apt-get，而 hosted runner 上的 apt 有过**拉完 release 索引后彻底停
 不动**的表现——2026-08-18 一天之内四次 CI 被 GitHub 的 6 小时 job 上限杀掉，
 每次挂在不同的 job（三个 e2e job 跑的是同一步，谁中枪是随机的），每次都要人工
 重跑。apt 自身没有总时长上限，所以 `.github/scripts/install-playwright.sh` 给
-每次尝试套 `timeout` 并重试 3 次，重试前清掉被杀的 apt 留下的锁；浏览器二进制
+每次尝试套 `timeout` 并重试，重试前清掉被杀的 apt 留下的锁；浏览器二进制
 按 Playwright 版本号进 `actions/cache`，命中时只跑 `install-deps`。
+
+**缓存命中时 `install-deps` 失败只警告、不判死**（2026-08-19 起）：缓存命中意味着
+浏览器二进制已就位，apt 只可能再补系统库，而 runner 镜像本来就带 chromium 的那套。
+把它当致命错误的结果是"Ubuntu 镜像源抽风 = PR 变红"——分片把跑 apt 的 job 从 3 个
+变成 11 个，撞上的概率同步放大，实测一轮里同一个分片连挂两次（每次
+`noble-security InRelease` 之后静默 4 分半 ×3）。所以命中缓存时只试 **1 次 120s**，
+失败就带 warning 继续跑用例：库真缺，Playwright 启动浏览器时会明说，红在测试步骤，
+信息一点不少。**冷缓存仍然必须成功**——那时候根本没有浏览器可跑。
 
 **并发**：PR 收到新 push 时旧 run 直接取消（`cancel-in-progress` 只对
 `pull_request` 生效）；push 到 main 的 run 永不取消——那是部署和线上冒烟要判定

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,13 +316,22 @@ apt-get，而 hosted runner 上的 apt 有过**拉完 release 索引后彻底停
 每次尝试套 `timeout` 并重试，重试前清掉被杀的 apt 留下的锁；浏览器二进制
 按 Playwright 版本号进 `actions/cache`，命中时只跑 `install-deps`。
 
-**缓存命中时 `install-deps` 失败只警告、不判死**（2026-08-19 起）：缓存命中意味着
-浏览器二进制已就位，apt 只可能再补系统库，而 runner 镜像本来就带 chromium 的那套。
-把它当致命错误的结果是"Ubuntu 镜像源抽风 = PR 变红"——分片把跑 apt 的 job 从 3 个
-变成 11 个，撞上的概率同步放大，实测一轮里同一个分片连挂两次（每次
-`noble-security InRelease` 之后静默 4 分半 ×3）。所以命中缓存时只试 **1 次 120s**，
-失败就带 warning 继续跑用例：库真缺，Playwright 启动浏览器时会明说，红在测试步骤，
-信息一点不少。**冷缓存仍然必须成功**——那时候根本没有浏览器可跑。
+**缓存命中时直接不跑 apt**（2026-08-19 起）。读健康 run 的日志才看清 `install-deps`
+到底在干什么：Chromium 要的库（libnss3 / libgbm1 / libasound2t64 / libcairo2 …）
+**全部 already the newest version**，runner 镜像本来就带；它真正装的只有 **21.1 MB
+字体**（fonts-wqy-zenhei / fonts-ipafont-gothic / fonts-unifont / fonts-freefont-ttf /
+fonts-tlwg-loma-otf / xfonts-encodings）。而本项目的渲染不经过系统字体——编辑器用自带的
+XOR 字体 catalog（`public/fonts/`）、PDF 走 `PDF_FONT_MANIFEST`、落地页用 vendored
+Geist woff2；视觉用例比的是"同一浏览器里的原始 vs 存回"，缺字形也是两侧同样缺。
+
+所以那是**每个 job 在全新 VM 上，为没人读的字体，向 Ubuntu 源发一次网络请求**。11 个
+job 就是一轮 run 掷 11 次骰子，而骰子是歪的：runner 首选的 `azure.archive.ubuntu.com`
+返回 `Ign:`，退回公网 archive 后整个停摆（`noble-security InRelease` 之后零字节）。
+本周四个 job 因此被 6 小时上限杀掉，加固之后又有两次各烧 17 分钟。
+
+现在缓存命中直接 `exit 0`（连 apt 配置都不写）；`PLAYWRIGHT_INSTALL_DEPS=true` 是逃生
+出口，会把 apt 放回来但只试 1 次 120s、失败仅告警。**冷缓存路径不变**（3 × 300s、失败
+判死）——那时候没有浏览器可跑，且它本来就要从 Playwright CDN 下载。
 
 **并发**：PR 收到新 push 时旧 run 直接取消（`cancel-in-progress` 只对
 `pull_request` 生效）；push 到 main 的 run 永不取消——那是部署和线上冒烟要判定

--- a/bin/test-e2e-docker.sh
+++ b/bin/test-e2e-docker.sh
@@ -10,8 +10,10 @@ set -e
 docker build -t document:e2e .
 docker rm -f document-e2e-docker >/dev/null 2>&1 || true
 
+# Extra arguments are forwarded to Playwright, which is how CI passes
+# --shard=N/M so the suite can be split across runners.
 set +e
-E2E_DOCKER=1 ./node_modules/.bin/playwright test --config playwright.docker.config.ts
+E2E_DOCKER=1 ./node_modules/.bin/playwright test --config playwright.docker.config.ts "$@"
 status=$?
 set -e
 

--- a/docs/explorations/2026-08-19-ci-e2e-sharding.md
+++ b/docs/explorations/2026-08-19-ci-e2e-sharding.md
@@ -131,7 +131,7 @@ run: sh ./bin/test-e2e-docker.sh --shard=${{ matrix.shard }}/3
 **它不是分片造成的，但分片把它放大了**：跑 apt 的 job 从 3 个变成 11 个，一轮
 run 撞上的概率同步翻倍。这条必须在同一个 PR 里处理，否则等于拿可靠性换速度。
 
-### 处理：缓存命中时，apt 的成败不再决定 job
+### 第一步（止血）：缓存命中时，apt 的成败不再决定 job
 
 `.github/scripts/install-playwright.sh` 分两条路：
 
@@ -146,6 +146,40 @@ runner 镜像本来就带 chromium 那套。库真的缺，Playwright 启动浏�
 浏览器，这步失败就是真的没法跑。
 
 顺带把 3×300s 压成 1×120s——一个"输了也无所谓"的尝试不该占用 15 分钟预算。
+
+### 第二步（根治）：缓存命中时根本不调 apt
+
+止血之后回头问"为什么老是它"，去读一次**健康** run 的日志，才看清 `install-deps`
+到底装了什么：
+
+```
+libasound2t64 is already the newest version ...
+libatk-bridge2.0-0t64 / libnss3 / libgbm1 / libcairo2 / libx11-6 ... 全部 already
+The following NEW packages will be installed:
+0 upgraded, 9 newly installed, 0 to remove
+Need to get 21.1 MB of archives.
+Setting up fonts-wqy-zenhei / fonts-ipafont-gothic / fonts-unifont /
+         fonts-freefont-ttf / fonts-tlwg-loma-otf / xfonts-encodings ...
+```
+
+**Chromium 需要的库一个都不用装——runner 镜像全带。apt 唯一真正在做的事是下载
+21.1 MB 字体。** 而这套用例不经过系统字体：编辑器用自带的 XOR 字体 catalog
+（`public/fonts/`），PDF 导出走 `PDF_FONT_MANIFEST`，落地页用 vendored Geist woff2；
+`visual-roundtrip` 和 corpus 视觉比对是"同一浏览器里的原始 vs 存回再打开"两侧对比，
+缺字形也是两侧同样缺。系统字体只够到 DOM 里的回退文本。
+
+于是问题的真身是：**每个 job 在全新 VM 上，为没人读的字体，向 Ubuntu 源发一次网络
+请求**。11 个 job = 一轮 run 掷 11 次骰子；而骰子是歪的（azure 镜像 `Ign:` → 退回公网
+archive → 停摆）。这不是偶发 flake，是结构。
+
+所以缓存命中直接 `exit 0`，连 apt 配置文件都不写（顺序也钉进用例了：一个还会
+`sudo` 写 apt 配置的"跳过"，仍然能因为 apt 的理由失败）。`PLAYWRIGHT_INSTALL_DEPS=true`
+留作逃生出口。冷缓存路径一个字没动。
+
+**顺带记一笔打脸**：这两条断言的第一版是**假保护**——反向验证时把跳过块整个删掉，
+用例照绿（正则里的 `PLAYWRIGHT_INSTALL_DEPS` 命中了逃生出口的注释，`exit 0` 命中了
+后面 advisory 分支的那句）。改成"取出 `BROWSERS_CACHED` 分支体、断言 `exit 0` 出现在
+第一个 `command=(` 之前"才真的红。反向验证不是走过场。
 
 ## 结果
 

--- a/docs/explorations/2026-08-19-ci-e2e-sharding.md
+++ b/docs/explorations/2026-08-19-ci-e2e-sharding.md
@@ -98,13 +98,65 @@ run: sh ./bin/test-e2e-docker.sh --shard=${{ matrix.shard }}/3
 | 三个汇总 job 的名字 == 必需检查名      | 改名 → PR 永远 pending                   |
 | 汇总 job 在分片红时必须退 1            | 换成 `echo ok` → 绿得毫无意义            |
 | docker 分片直接调脚本，不经 `pnpm run` | 换回 `pnpm run … -- --shard` → 分片失效  |
+| 缓存命中时 apt 失败不判死              | 去掉 advisory 分支 → 镜像源抽风就红      |
+| 冷缓存时 apt 失败必须判死              | 改成 `exit 0` → 没浏览器还报绿           |
+| advisory 路径的预算 ≤ 180s             | 改回 3×300s → 一个不重要的尝试占 15 min  |
+
+## 首轮实测（run 32268096879）
+
+分片本身一次到位：
+
+| job                                | 分片耗时                 | 原耗时 |
+| ---------------------------------- | ------------------------ | ------ |
+| Lint and Validate                  | 1 min（与 e2e 同时起跑） | 1 min  |
+| E2E shard 1/2/3                    | 2.4 / 3.5 / 4 min        | 7 min  |
+| E2E (Docker image) shard 1/2/3     | 3.3 / 失败 / 4.6 min     | 8 min  |
+| E2E (Cloudflare Pages) shard 1/2/3 | 3.7 / 7.4 / 7 min        | 12 min |
+| 三个汇总 job                       | 各 0 min，红绿传递正确   | —      |
+
+## 然后撞上 apt，两次
+
+`E2E (Docker image) shard 2` 连挂两轮，形态完全一样：
+
+```
+15:32:12  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
+          （此后 4 分半，零输出）
+15:36:31  ##[warning] ... exceeded 300s (attempt 2/3)
+```
+
+三次尝试全卡在同一处，每次烧掉 ~17 min。日志里 `azure.archive.ubuntu.com` 的条目
+全是 `Ign:`——runner 自带的 Azure 镜像没生效，退回公网 archive 然后停摆。就是
+2026-08-19-ci-workflow-hardening.md 记的那个老问题。
+
+**它不是分片造成的，但分片把它放大了**：跑 apt 的 job 从 3 个变成 11 个，一轮
+run 撞上的概率同步翻倍。这条必须在同一个 PR 里处理，否则等于拿可靠性换速度。
+
+### 处理：缓存命中时，apt 的成败不再决定 job
+
+`.github/scripts/install-playwright.sh` 分两条路：
+
+| 路径     | 命令                  | 尝试     | 失败时          |
+| -------- | --------------------- | -------- | --------------- |
+| 缓存命中 | `install-deps`        | 1 × 120s | warning，继续跑 |
+| 冷缓存   | `install --with-deps` | 3 × 300s | error，job 红   |
+
+依据：缓存命中意味着浏览器二进制已经在盘上，apt 唯一还能补的是系统库，而 hosted
+runner 镜像本来就带 chromium 那套。库真的缺，Playwright 启动浏览器时会原话说出来，
+红在测试步骤——信息一点没少，只是不再需要一整轮 run 去换。冷缓存不动：那时候没有
+浏览器，这步失败就是真的没法跑。
+
+顺带把 3×300s 压成 1×120s——一个"输了也无所谓"的尝试不该占用 15 分钟预算。
 
 ## 结果
 
-| 阶段 | 关键路径                        |
-| ---- | ------------------------------- |
-| 改前 | ~14 min                         |
-| 改后 | ~5 min（预期，以首次 run 为准） |
+| 阶段                          | 关键路径                            |
+| ----------------------------- | ----------------------------------- |
+| 改前                          | ~14 min                             |
+| 分片后（实测，去掉 apt 那次） | ~7.5 min（瓶颈是 pages 的 7.4 min） |
+| pages 3 → 5 片                | ~5 min（预期）                      |
+
+pages 每片还要付 ~2 min 的 `build.sh` + wrangler 启动固定成本，所以再往上切收益
+会被这块吃掉。
 
 ## 没做的（留着，需要拍板）
 

--- a/docs/explorations/2026-08-19-ci-e2e-sharding.md
+++ b/docs/explorations/2026-08-19-ci-e2e-sharding.md
@@ -1,0 +1,115 @@
+# CI 提速：同一批用例跑三遍、并发只有 1~2，与分片改造
+
+2026-08-19
+
+## 起因
+
+用户反馈 "GitHub 的 CI 执行非常慢"。先量，不猜。
+
+## 慢在哪：量出来的
+
+取 run `32204565815`（一次全绿的 PR 档），按 job 和 step 拆：
+
+| job                              | 总时长 | 拆解                                                                          |
+| -------------------------------- | ------ | ----------------------------------------------------------------------------- |
+| Lint and Validate                | 1 min  | 每一步都在 20s 以内                                                           |
+| E2E                              | 7 min  | setup 41s + **测试 6.9 min**（95 用例 / 2 workers）                           |
+| E2E (Docker image)               | 8 min  | setup 41s + docker build **45s** + **测试 6.3 min**（同 95 用例 / 2 workers） |
+| E2E (Cloudflare Pages semantics) | 12 min | setup 44s + **测试 11.1 min**（同 95 用例 / **1 worker** + retries:1）        |
+
+关键路径 = 等 lint 走完（~1.5 min）+ 最慢的 pages（12 min）≈ **14 min**。
+
+结论只有一条：**慢的全部是 E2E**。安装、构建这些常见嫌疑人都不成立——
+
+- `pnpm install` + 浏览器缓存命中：~40s（`.github/actions/setup` 已经缓存过了）
+- `vite build`（e2e job 的 webServer 里）：~25s
+- `docker build`（含完整 pnpm install + 构建）：**45s**，层缓存都省得加
+- lint job 全程：1 min
+
+真正的浪费是结构性的两条：
+
+1. **同一批 ~95 个用例跑了三遍**，只有服务器不同（vite preview / 生产镜像 /
+   wrangler pages dev）。
+2. **并发度只有 1~2**。runner 4 核，Playwright 默认 `workers = 核数/2 = 2`；
+   pages 那套还是 `workers: 1`（故意的，见下）。
+
+## 改了什么
+
+### 1. 三套 E2E 各切 3 个分片
+
+仓库是公开的，Actions 额度无限，多开 runner 不花钱。
+
+选分片而不是调大 `workers`：runner 只有 4 核，每个 worker 拖一个 WASM 编辑器
+进程，加 worker 换来的多半是内存压力和 flaky；而 pages 那套的单 worker 是
+`playwright.pages.config.ts` 里写明的缓解措施（并发下浏览器 abort 大文件会把
+workerd 打崩）。分片是唯一不动各套并发语义的加速方式。
+
+实测分片切得很均匀，重的 `embed-regression`（36 个用例、292s）也会被拆开：
+
+```
+shard 1/3: 33 tests in 10 files   (embed-regression 8)
+shard 2/3: 33 tests in 11 files   (embed-regression 4)
+shard 3/3: 32 tests in 12 files
+```
+
+### 2. e2e 不再 `needs: lint`
+
+lint 只有 1 min，但 e2e 要等它整个 job 结束，白加 ~90s 在关键路径上。代价只是
+lint 红的那次 e2e 白跑一轮——免费，而且那次顺带把 e2e 的结论也拿到了。
+
+### 3. 汇总 job 顶住必需检查名
+
+main 的分支保护按**名字**匹配六个必需检查。分片后 job 名会变成 `E2E shard 1`
+之类，三个必需检查就永远 pending、PR 永远合不了。所以分片 job 叫
+`... shard N`，另加三个只做一件事的汇总 job（`if: always()`，
+`needs.<分片>.result != success` 就退 1），沿用原来的
+`E2E` / `E2E (Docker image)` / `E2E (Cloudflare Pages semantics)`，分支保护一个字
+都不用动。
+
+`fail-fast: false`：一个分片红了不该掩盖另外两个的结论，一次 run 就应该把所有
+失败都报出来。
+
+## 踩到的坑：pnpm 会把参数吃掉
+
+第一版把 docker 分片写成：
+
+```yaml
+run: pnpm run test:e2e:docker -- --shard=${{ matrix.shard }}/3
+```
+
+实测（`pnpm run test:e2e -- --list --shard=2/3`）——**参数根本没到 Playwright**，
+`--list` 也没生效，它老老实实跑完了整套 98 个用例。这个 bug 的形态最恶心：三个
+分片各自跑完整套件，工作量翻三倍、提速为零，而且**全绿**，没有任何症状。
+
+改成直接调脚本，并给 `bin/test-e2e-docker.sh` 加上 `"$@"` 转发：
+
+```yaml
+run: sh ./bin/test-e2e-docker.sh --shard=${{ matrix.shard }}/3
+```
+
+## 用例固化
+
+新增的不变量全部进了 `test/unit/workflow-contract.test.ts`，四条都做了反向验证
+（改坏必须变红，已逐条实测）：
+
+| 断言                                   | 改坏的方式                               |
+| -------------------------------------- | ---------------------------------------- |
+| 分片数 == `--shard=N/M` 的 M           | matrix 三片配 `/4` → 静默少跑 1/4 还报绿 |
+| 三个汇总 job 的名字 == 必需检查名      | 改名 → PR 永远 pending                   |
+| 汇总 job 在分片红时必须退 1            | 换成 `echo ok` → 绿得毫无意义            |
+| docker 分片直接调脚本，不经 `pnpm run` | 换回 `pnpm run … -- --shard` → 分片失效  |
+
+## 结果
+
+| 阶段 | 关键路径                        |
+| ---- | ------------------------------- |
+| 改前 | ~14 min                         |
+| 改后 | ~5 min（预期，以首次 run 为准） |
+
+## 没做的（留着，需要拍板）
+
+pages 和 docker 这两层真正要证明的是"托管语义"和"镜像可用"，却各自跑了全部 36 个
+`embed-regression` 真实编辑器用例。PR 只跑该层相关子集、push main / nightly 跑全量，
+能再省 ~2 min 并砍掉一半 runner 时间。但这两层抓到过 PDF 被 308 卡住、字体目录缺
+缓存头这类真实缺陷（见 CLAUDE.md 托管语义回归一节），缩范围是产品判断，不是性能
+判断，所以这次没动。

--- a/test/unit/workflow-contract.test.ts
+++ b/test/unit/workflow-contract.test.ts
@@ -89,6 +89,30 @@ describe('the Playwright install script', () => {
     expect(script).toMatch(/for attempt in \$\(seq 1 "\$attempts"\)/);
   });
 
+  it('lets a stalled apt through once the browsers came from the cache', () => {
+    // A cache hit means the binaries are already there and apt could only be
+    // adding system libraries the runner image already ships. Treating its
+    // stall as fatal turned a bad Ubuntu mirror into a red pull request --
+    // twice on one run, and sharding tripled the number of jobs exposed.
+    expect(script).toMatch(/deps_are_advisory=true/);
+    expect(script).toMatch(/if \[ "\$deps_are_advisory" = "true" \]; then[\s\S]*?exit 0/);
+  });
+
+  it('still fails hard when there is no cached browser to fall back on', () => {
+    // Without the cache this step is what puts the browsers on disk; letting
+    // it fail would hand the test step an error about nothing being installed.
+    expect(script).toMatch(/deps_are_advisory=false/);
+    expect(script).toMatch(/::error::playwright[\s\S]*?\nexit 1/);
+  });
+
+  it('does not spend the patient budget on an attempt it is willing to lose', () => {
+    // The advisory path gave up only after 3 x 300s: a quarter of an hour per
+    // job, spent to reach a verdict that no longer changes anything.
+    const advisory = script.match(/deps_are_advisory=true\n\s*default_attempts=(\d+)\n\s*default_timeout=(\d+)/);
+    expect(advisory).not.toBeNull();
+    expect(Number(advisory![1]) * Number(advisory![2])).toBeLessThanOrEqual(180);
+  });
+
   it('clears the apt locks a killed attempt leaves behind', () => {
     // Without this the retry fails instantly on "Could not get lock", which
     // would make the retry loop pure decoration.

--- a/test/unit/workflow-contract.test.ts
+++ b/test/unit/workflow-contract.test.ts
@@ -89,6 +89,27 @@ describe('the Playwright install script', () => {
     expect(script).toMatch(/for attempt in \$\(seq 1 "\$attempts"\)/);
   });
 
+  it('does not call apt at all once the browsers came from the cache', () => {
+    // Read off a healthy run: every library Chromium needs already reports
+    // "is already the newest version" on the hosted image, and the only thing
+    // install-deps installs is 21 MB of fonts that nothing here renders
+    // through (the editor draws with its own vendored catalog). That call was
+    // a network dependency on Ubuntu's mirrors in the hot path of every job,
+    // buying nothing and stalling regularly.
+    const cachedBranch = script.match(/BROWSERS_CACHED:-\}" = "true" \]; then\n([\s\S]*?)\nelse\n/);
+    expect(cachedBranch).not.toBeNull();
+    const body = cachedBranch![1];
+    // The branch has to leave before it can reach a playwright invocation.
+    expect(body).toMatch(/^\s*exit 0$/m);
+    expect(body.search(/^\s*exit 0$/m)).toBeLessThan(body.search(/command=\(/));
+  });
+
+  it('keeps the apt config write off the path that never reaches apt', () => {
+    // Ordering, not decoration: a skip that still sudo-writes an apt config is
+    // a skip that can still fail for apt's reasons.
+    expect(script.indexOf('skipping the apt font install')).toBeLessThan(script.indexOf('99-ci-timeouts'));
+  });
+
   it('lets a stalled apt through once the browsers came from the cache', () => {
     // A cache hit means the binaries are already there and apt could only be
     // adding system libraries the runner image already ships. Treating its

--- a/test/unit/workflow-contract.test.ts
+++ b/test/unit/workflow-contract.test.ts
@@ -125,9 +125,61 @@ describe('bin/serve-pages-dev.sh', () => {
 
 describe('.github/workflows/ci.yml', () => {
   const ci = workflows.find(({ file }) => file === 'ci.yml')!.src;
+  const ciJobs = parseJobs(ci);
 
   it('drops the run for a superseded pull request commit, but never for main', () => {
     expect(ci).toMatch(/^concurrency:$/m);
     expect(ci).toMatch(/cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/);
+  });
+
+  const sharded = ciJobs.filter(({ body }) => body.includes('--shard='));
+
+  it('shards every E2E suite (the three of them are the whole cost of the run)', () => {
+    expect(sharded.map(({ name }) => name)).toEqual(['e2e-shard', 'e2e-pages-shard', 'e2e-docker-shard']);
+  });
+
+  it.each(sharded)('job $name splits into exactly as many shards as it declares', ({ body }) => {
+    // A matrix of three against `--shard=N/4` silently drops a quarter of the
+    // suite and still reports green -- the failure mode is invisible, so the
+    // two numbers are pinned to each other here.
+    const matrix = body.match(/shard: \[([^\]]+)\]/);
+    const denominator = body.match(/--shard=\$\{\{ matrix\.shard \}\}\/(\d+)/);
+    expect(matrix).not.toBeNull();
+    expect(denominator).not.toBeNull();
+    expect(matrix![1].split(',').length).toBe(Number(denominator![1]));
+  });
+
+  it.each([
+    ['e2e', 'E2E', 'e2e-shard'],
+    ['e2e-pages', 'E2E (Cloudflare Pages semantics)', 'e2e-pages-shard'],
+    ['e2e-docker', 'E2E (Docker image)', 'e2e-docker-shard'],
+  ])('%s reports the shard verdict under the name branch protection requires', (id, checkName, shardJob) => {
+    // main requires these three checks by name. Renaming a summary job, or
+    // letting one pass while its shards failed, leaves every pull request
+    // either permanently pending or merged on a green that means nothing.
+    const job = ciJobs.find(({ name }) => name === id);
+    expect(job).toBeDefined();
+    expect(job!.body).toMatch(new RegExp(`^ {4}name: ${checkName.replace(/[()]/g, '\\$&')}$`, 'm'));
+    expect(job!.body).toMatch(new RegExp(`^ {4}needs: ${shardJob}$`, 'm'));
+    expect(job!.body).toMatch(/^ {4}if: always\(\)$/m);
+    expect(job!.body).toMatch(new RegExp(`RESULT: \\$\\{\\{ needs\\.${shardJob}\\.result \\}\\}`));
+    expect(job!.body).toMatch(/\[ "\$RESULT" = "success" \] \|\| exit 1/);
+  });
+
+  it('passes the shard to the Docker suite without going through pnpm', () => {
+    // `pnpm run test:e2e:docker -- --shard=1/3` drops the arguments on the
+    // floor: every shard then runs the whole suite, three times over, and the
+    // run stays green while the sharding does nothing at all. Measured, not
+    // assumed -- see docs/explorations/2026-08-19-ci-e2e-sharding.md.
+    expect(ci).toMatch(/run: sh \.\/bin\/test-e2e-docker\.sh --shard=/);
+    expect(ci).not.toMatch(/pnpm run test:e2e:docker.*--shard/);
+  });
+});
+
+describe('bin/test-e2e-docker.sh', () => {
+  const script = readFileSync(resolve(ROOT, 'bin/test-e2e-docker.sh'), 'utf8');
+
+  it('forwards its arguments to Playwright', () => {
+    expect(script).toMatch(/playwright test --config playwright\.docker\.config\.ts "\$@"/);
   });
 });


### PR DESCRIPTION
## 起因

CI 一次 PR 档要 ~14 分钟。先量再改。

## 慢在哪（run `32204565815`，全绿的一次）

| job | 总时长 | 拆解 |
|---|---|---|
| Lint and Validate | 1 min | 每步都在 20s 以内 |
| E2E | 7 min | setup 41s + **测试 6.9 min**（95 用例 / 2 workers）|
| E2E (Docker image) | 8 min | setup 41s + docker build **45s** + **测试 6.3 min** |
| E2E (Cloudflare Pages semantics) | 12 min | setup 44s + **测试 11.1 min**（**1 worker**）|

关键路径 = 等 lint（~1.5 min）+ 最慢的 pages（12 min）≈ **14 min**。

常见嫌疑人全都不成立：install 缓存命中 ~40s、`vite build` ~25s、完整
`docker build` 只要 45s。浪费是结构性的——**同一批 ~95 个用例跑三遍**，
而且**并发只有 1~2**。

## 改动

1. **三套 E2E 各切 3 个分片**。选分片而不是加 workers：runner 4 核、每个
   worker 拖一个 WASM 编辑器进程，而 pages 那套的单 worker 是
   `playwright.pages.config.ts` 里写明的缓解措施（并发下 workerd 会被打崩）。
   分片不动任何一套自己的并发语义。实测切得很均匀（33/33/32），重的
   `embed-regression` 也会被拆开。
2. **e2e 不再 `needs: lint`**。lint 只有 1 min，但等它整个 job 结束白加 ~90s
   在关键路径上；公开仓库 runner 免费，lint 红那次多跑一轮 e2e 是划算的。
3. **三个汇总 job 顶住必需检查名**。分支保护按名字匹配，分片后 job 名会变，
   所以分片叫 `... shard N`，汇总 job 沿用 `E2E` / `E2E (Docker image)` /
   `E2E (Cloudflare Pages semantics)`——**分支保护设置一个字都不用改**。

## 踩到的坑

第一版 docker 分片写的是 `pnpm run test:e2e:docker -- --shard=N/3`。实测
（`pnpm run test:e2e -- --list --shard=2/3`）**参数根本没到 Playwright**，
整套 98 个用例照跑。这个 bug 全绿、无症状、提速为零、工作量翻三倍。改成直接
`sh ./bin/test-e2e-docker.sh --shard=…`，脚本加 `"$@"` 转发。

## 用例

四条新不变量进 `test/unit/workflow-contract.test.ts`，逐条反向验证过（改坏必须变红）：

| 断言 | 改坏的方式 |
|---|---|
| 分片数 == `--shard=N/M` 的 M | 三片配 `/4` → 静默少跑 1/4 还报绿 |
| 三个汇总 job 名 == 必需检查名 | 改名 → PR 永远 pending |
| 汇总 job 在分片红时必须退 1 | 换成 `echo ok` → 绿得毫无意义 |
| docker 分片不经 `pnpm run` | 换回去 → 分片失效 |

## 预期

关键路径 ~14 min → **~5 min**（以本 PR 的首次 run 为准）。

记录见 `docs/explorations/2026-08-19-ci-e2e-sharding.md`，CLAUDE.md 的 CI 一节同步更新。

未做、需要拍板的下一步也写在探索文档末尾：pages / docker 两层在 PR 上只跑该层
相关子集、全量挪到 main / nightly，能再省 ~2 min 并砍掉一半 runner 时间——但那
两层抓到过真实缺陷，缩范围是产品判断不是性能判断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)