### PR TITLE
feat(ui): remove the floating Menu button from the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ notes. Entries describe what users experience, not internal refactors.
   service worker) and try again; a full regression campaign against
   real-world documents runs nightly and gates the next release announcement.
 
+### Removed
+
+- The floating "Menu" button in the bottom-right corner of the editor, and the
+  first-run bubble that pointed at it. It sat over the vertical scrollbar just
+  above the zoom bar. Opening and creating documents start from the homepage
+  (or `/editor?new=docx`, `/editor?file=<url>`); the AI assistant opens with
+  `?agent=1`. Theme now follows the switch in the homepage footer -- there is
+  no in-editor theme toggle any more.
+
 ### Changed
 
 - Hovering (or focusing) an Open / New button starts downloading the editor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ lib/                  # 应用层（纯 TypeScript，只在本站点用）
     readonly.ts           # 运行时只读（挂载永远可编辑，加载后加 restriction）
     ui-theme.ts           # 默认经典主题与站点主题跟随
     file-helpers.ts       # 文件名/MIME/字节形状小工具
-  ui.ts                 # 控制面板、菜单、FAB 等 UI 组件
+  ui.ts                 # 落地 hero 显隐 + 控制面板（右下角 Menu FAB 已于 2026-08-20 移除）
   analytics.ts          # Cloudflare Web Analytics（刻意不用 GA；线上实际走 CF 面板边缘注入，因此 embed 视图会被计入、/embed-demo 双计，读数规则见 docs/explorations/2026-08-17-analytics-edge-injection-double-count.md）
   pending-open.ts       # 静态落地页经 IndexedDB 交接文件（?open=local）
   agent-plugin/         # Agent 协同编辑：editor-bridge（直调 window.editor）、tools、ui/

--- a/docs/explorations/2026-08-20-remove-menu-fab.md
+++ b/docs/explorations/2026-08-20-remove-menu-fab.md
@@ -1,0 +1,86 @@
+# 移除编辑器右下角的 Menu 悬浮按钮
+
+2026-08-20
+
+## 起因
+
+用户截图指出编辑器右下角那个 "Menu" 悬浮按钮（压在垂直滚动条上、紧挨底部缩放条），
+要求去掉。
+
+## 删之前先查它挂着什么
+
+`lib/ui.ts` 的 FAB 里有 6 项：上传文档、新建 Word / Excel / PPT、AI 助手、主题切换。
+逐项确认在**文档已打开**的状态下还有没有别的入口：
+
+| 菜单项              | 别的入口                                    |
+| ------------------- | ------------------------------------------- |
+| 上传文档            | 无（编辑器 `help:false`、无拖拽、无快捷键） |
+| 新建 Word/Excel/PPT | 无（同上）                                  |
+| AI 助手             | 有——`?agent=1`                              |
+| 主题切换            | 无（落地 hero 一打开文档就隐藏）            |
+
+代码注释里本来就写着主题那一行的存在理由："the hero is hidden once a document is
+open ... without this row there is no way to flip it while editing"。
+
+所以这不是纯装饰，删掉是有代价的。把这四项的取舍摆给用户确认后，选了「整个删掉」：
+打开/新建从首页（或 `/editor?new=docx`、`?file=`）走，主题在首页页脚切。
+
+## 删除范围
+
+| 文件                             | 内容                                                                                             |
+| -------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `lib/ui.ts`                      | `buildFab` / `getFab` / `createFixedActionButton` / `showMenuGuide` 及引导气泡状态；391 → 124 行 |
+| `lib/document.ts`                | `showMenuGuideFn` 与三处 1s 延时调用、`setUICallbacks` 的对应入参                                |
+| `lib/events.ts`                  | 同上（RENDER_OFFICE 路径）                                                                       |
+| `index.ts`                       | 两处 callback 装配、`createFixedActionButton()`、`import 'ranui/theme-switch'`                   |
+| `styles/base.css`                | `.fab-*` / `.menu-guide*` / `guideFadeIn                                                         | Out`；499 → 311 行 |
+| `packages/shared/src/i18n.ts`    | `menu` / `menuGuide` 词条（接口 + 8 个语言，共 18 处）                                           |
+| `test/unit/i18n-locales.test.ts` | CORE_KEYS、`pt` 的 same-as-english 例外、德语回退用例换用 `uploadDocument`                       |
+| `test/e2e/app-smoke.spec.ts`     | 两处 `#fab-container` 断言                                                                       |
+
+`import 'ranui/theme-switch'` 一并删掉：全仓只有 FAB 那一行用它，落地页的
+`<r-theme-switch>` 是静态 HTML 自带 `label="Theme"`，不经过 i18n。
+
+## 顺手保住的一件事：prefetch
+
+FAB 的每个"新建/打开"行都挂着 `pointerenter → prefetchEditorAssets`（悬停即开始拉
+引擎）。删掉 FAB 会连这个也一起丢，而且 `lib/prefetch.ts` 会变成整仓无人 import 的
+死模块（它导出的 `prefetchOnIntent` 此前根本没被用过）。
+
+所以把控制面板那四个按钮接上 `prefetchOnIntent`——这正是那个 helper 存在的理由。
+行为不丢，模块不死。
+
+## 没删的：theme\* 词条
+
+`themeLabel` / `themeSystem` / `themeLight` / `themeDark` 现在在本仓也没人用了，但
+`packages/shared` 是 ran 生态三处站点共享的包，这几个是通用的开关标签，别的站点可能
+在用——跨仓的删除不该我单方面做。`menu` / `menuGuide` 则删了：它们的文案
+（"菜单在右下角，悬停即可查看"）只描述这个已经不存在的 FAB，留着会误导翻译。
+
+## 用例
+
+`app-smoke.spec.ts` 反过来钉住这个决定：`/editor` 上 `#fab-container` 与 `#menu-guide`
+必须 `toHaveCount(0)`。落地页那条原本用 `#fab-container` 证明"`/` 不加载编辑器 bundle"，
+改用 `#control-panel-container`（同样只由 bundle 构建）。
+
+本地跑 `app-smoke` / `main-site` / `entry-paths` 三个 spec 验证控制面板路径没被带坏；
+单测全绿，`tsc --noEmit`、oxlint、prettier、生产构建均通过。
+
+## 踩到的坑：本地 tsc 读的是 workspace 包的旧构建产物
+
+删完 i18n 词条后本地 `pnpm run lint:ts` 是绿的，CI 上 `Lint and Validate` 却红在
+`tsc --noEmit`：
+
+```
+test/unit/i18n.test.ts(143,16): error TS2345:
+  Argument of type '"menu"' is not assignable to parameter of type 'keyof I18nMessages'
+```
+
+原因是 `@ranuts/shared` 的 `exports` 指向 **`dist/`**（`./i18n` → `dist/i18n.d.ts`），
+不是 `src/`。本地那份 `packages/shared/dist/` 是改动之前构建的，`I18nMessages` 里还留着
+`menu`，所以 tsc 看不出问题；CI 的 `pnpm install --frozen-lockfile` 会触发包的 `prepare`
+（`tsc -p`）重建 dist，类型这才真正更新，漏改的那处引用当场报错。
+
+**改了 `packages/*/src` 之后，本地校验前先 `pnpm -C packages/<name> run build`**（或
+`pnpm -r run prepare`），否则 tsc 校验的是上一个版本的类型。这是典型的"本地绿、CI 红"
+不对称，和仓库里记过的 vite preview / 线上那几条同类。

--- a/index.ts
+++ b/index.ts
@@ -8,18 +8,10 @@ import { parseReadonly } from '@ranuts/shared/document-utils';
 import { applyDocumentLanguage } from '@ranuts/shared/i18n';
 import { getDocmentObj } from '@ranuts/shared/store';
 import { initAnalytics } from './lib/analytics';
-import {
-  createControlPanel,
-  createFixedActionButton,
-  hideControlPanel,
-  hideLanding,
-  showControlPanel,
-  showMenuGuide,
-} from './lib/ui';
+import { createControlPanel, hideControlPanel, hideLanding, showControlPanel } from './lib/ui';
 import 'ranui/button';
 import 'ranui/card';
 import 'ranui/select';
-import 'ranui/theme-switch';
 import { initWebMcp } from './lib/web-mcp';
 import '@khmyznikov/pwa-install';
 import './styles/base.css';
@@ -56,7 +48,6 @@ initAnalytics();
 setUICallbacks({
   hideControlPanel,
   showControlPanel,
-  showMenuGuide,
 });
 
 // Set up UI callbacks for events module. Opening a document over the desktop
@@ -64,7 +55,6 @@ setUICallbacks({
 // hideControlPanel's built-in hideLanding() call.
 setEventUICallbacks({
   hideControlPanel,
-  showMenuGuide,
 });
 
 // Export onCreateNew to window
@@ -77,7 +67,6 @@ window.hideControlPanel = hideControlPanel;
 window.showControlPanel = showControlPanel;
 
 // Initialize UI components
-createFixedActionButton();
 createControlPanel();
 
 // This bundle runs on /editor (editor.html). The homepage / is a static landing

--- a/lib/document.ts
+++ b/lib/document.ts
@@ -8,16 +8,10 @@ import { showLoading } from './loading';
 // These will be passed as callbacks or called after document operations
 let hideControlPanelFn: (() => void) | null = null;
 let showControlPanelFn: (() => void) | null = null;
-let showMenuGuideFn: (() => void) | null = null;
 
-export function setUICallbacks(callbacks: {
-  hideControlPanel: () => void;
-  showControlPanel: () => void;
-  showMenuGuide: () => void;
-}): void {
+export function setUICallbacks(callbacks: { hideControlPanel: () => void; showControlPanel: () => void }): void {
   hideControlPanelFn = callbacks.hideControlPanel;
   showControlPanelFn = callbacks.showControlPanel;
-  showMenuGuideFn = callbacks.showMenuGuide;
 }
 
 // Create a single hidden file input (ranui builder, ecosystem convention)
@@ -29,10 +23,9 @@ const fileInput = View('input')
 document.body.appendChild(fileInput);
 
 export const onCreateNew = async (ext: string): Promise<void> => {
-  // Note: Loading is now shown in the menu button click handler
-  // This function should not show loading again to avoid double loading indicators
+  // Callers own the loading indicator (the control panel shows it around this
+  // call), so showing one here too would stack two of them.
   try {
-    // Always hide control panel and ensure FAB is visible when creating new document
     if (hideControlPanelFn) {
       hideControlPanelFn();
     }
@@ -43,19 +36,13 @@ export const onCreateNew = async (ext: string): Promise<void> => {
     await loadEditorApi();
     const { fileName, file: fileBlob } = getDocmentObj();
     await handleDocumentOperation({ file: fileBlob, fileName, isNew: !fileBlob });
-    // Show menu guide after document is loaded
-    if (showMenuGuideFn) {
-      setTimeout(() => {
-        showMenuGuideFn!();
-      }, 1000);
-    }
   } catch (error) {
     console.error('Error creating new document:', error);
     // Ensure control panel is shown on error
     if (showControlPanelFn) {
       showControlPanelFn();
     }
-    throw error; // Re-throw to let the menu button handler catch it
+    throw error; // Re-throw so the caller can restore its own UI
   }
 };
 
@@ -74,12 +61,6 @@ export const openLocalFile = async (file: File): Promise<void> => {
     });
     const { fileName, file: fileBlob } = getDocmentObj();
     await handleDocumentOperation({ file: fileBlob, fileName, isNew: !fileBlob });
-    // Show menu guide after document is loaded
-    if (showMenuGuideFn) {
-      setTimeout(() => {
-        showMenuGuideFn!();
-      }, 1000);
-    }
   } catch (error) {
     console.error('Error opening document:', error);
     // Ensure control panel is shown on error
@@ -192,13 +173,6 @@ export const openDocumentFromUrl = async (
       isNew: !fileBlob,
       readonly: options?.readonly,
     });
-
-    // Show menu guide after document is loaded
-    if (showMenuGuideFn) {
-      setTimeout(() => {
-        showMenuGuideFn!();
-      }, 1000);
-    }
   } catch (error) {
     console.error('Error opening document from URL:', error);
     alert(`Failed to open document: ${error instanceof Error ? error.message : 'Unknown error'}`);

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -6,11 +6,9 @@ import { showLoading } from './loading';
 
 // UI callbacks to avoid circular dependency
 let hideControlPanelFn: (() => void) | null = null;
-let showMenuGuideFn: (() => void) | null = null;
 
-export function setEventUICallbacks(callbacks: { hideControlPanel: () => void; showMenuGuide: () => void }): void {
+export function setEventUICallbacks(callbacks: { hideControlPanel: () => void }): void {
   hideControlPanelFn = callbacks.hideControlPanel;
-  showMenuGuideFn = callbacks.showMenuGuide;
 }
 
 export interface RenderOfficeData {
@@ -43,12 +41,6 @@ export const events: Record<string, MessageHandler<any, unknown>> = {
         });
         const { fileName, file: fileBlob } = getDocmentObj();
         await handleDocumentOperation({ file: fileBlob, fileName, isNew: !fileBlob });
-        // Show menu guide after document is loaded
-        if (showMenuGuideFn) {
-          setTimeout(() => {
-            showMenuGuideFn!();
-          }, 1000);
-        }
       } catch (error) {
         console.error('Error rendering office document:', error);
       } finally {

--- a/lib/ui.ts
+++ b/lib/ui.ts
@@ -1,19 +1,18 @@
-import { localStorageGetItem, localStorageSetItem } from 'ranuts/utils';
-import { ButtonBuilder, Div, View } from 'ranui/builder';
-import { prefetchEditorAssets, type EditorKind } from './prefetch';
+import { Div, View } from 'ranui/builder';
+import { prefetchOnIntent, type EditorKind } from './prefetch';
 import { t } from '@ranuts/shared/i18n';
 import { showLoading } from './loading';
 import { onCreateNew, onOpenDocument } from './document';
 
 // Landing hero visibility. The hero (#landing-hero) lives in the served HTML for
 // SEO/GEO; it toggles in lockstep with the legacy control panel so EVERY show/hide
-// path (including the FAB error fallbacks below) keeps them in sync. Centralizing
-// it here — rather than only in index.ts's callbacks — means no raw
-// showControlPanel()/hideControlPanel() call can surface the legacy overlay on top
-// of the hero. body.landing-active also lets the page scroll and hides the legacy
-// overlay (see styles/base.css); in embed mode CSS force-hides the hero regardless.
+// path keeps them in sync. Centralizing it here — rather than only in index.ts's
+// callbacks — means no raw showControlPanel()/hideControlPanel() call can surface
+// the legacy overlay on top of the hero. body.landing-active also lets the page
+// scroll and hides the legacy overlay (see styles/base.css); in embed mode CSS
+// force-hides the hero regardless.
 //
-// Unlike the panel/FAB singletons below, the hero is NOT built by this module,
+// Unlike the panel singleton below, the hero is NOT built by this module,
 // so its absence can't be ruled out at the type level — the lookup is memoized
 // (safe: the hero is only ever toggled, never removed or replaced) but stays
 // nullable, and callers keep the guard.
@@ -32,25 +31,19 @@ export const hideLanding = (): void => {
   if (hero) hero.style.display = 'none';
 };
 
-// DOM this module owns, as lazy singletons — the TS equivalent of a Swift
+// DOM this module owns, as a lazy singleton — the TS equivalent of a Swift
 // `lazy var`: built on first access via `??=`, so consumers always get a
-// non-null element and never carry Optional guards. The two FAB elements live
-// in one object because they're created together and only make sense together.
-// (index.ts still calls the create* wrappers at boot, so in practice
-// everything is built up front; the laziness just makes call order a non-issue.)
+// non-null element and never carry Optional guards. (index.ts still calls the
+// create* wrapper at boot, so in practice it is built up front; the laziness
+// just makes call order a non-issue.)
 let controlPanel: HTMLElement | null = null;
-let fab: { container: HTMLElement; button: HTMLElement } | null = null;
 
 const getControlPanel = (): HTMLElement => (controlPanel ??= buildControlPanel());
-const getFab = (): { container: HTMLElement; button: HTMLElement } => (fab ??= buildFab());
 
-// Hide control panel and show top floating bar
+// Hide the control panel; a document is taking over.
 export const hideControlPanel = (): void => {
-  // A document is taking over — dismiss the crawlable landing hero with the panel.
+  // Dismiss the crawlable landing hero with the panel.
   hideLanding();
-
-  // Always ensure FAB is visible when hiding control panel
-  getFab().container.style.display = 'block';
 
   const panel = getControlPanel();
   // Immediately disable pointer events to prevent blocking
@@ -62,7 +55,7 @@ export const hideControlPanel = (): void => {
   }, 300);
 };
 
-// Show control panel and hide FAB
+// Show the control panel; back to the home state.
 export const showControlPanel = (): void => {
   // Back to the home state (no document, or an error) — bring the hero back so
   // it, not the legacy overlay, is what the user (and crawlers) see.
@@ -73,269 +66,9 @@ export const showControlPanel = (): void => {
   setTimeout(() => {
     panel.style.opacity = '1';
   }, 10);
-  // Only hide FAB if editor is not open
-  // If editor is already open, keep FAB visible so user can access menu
-  if (!window.editor) {
-    getFab().container.style.display = 'none';
-  }
 };
 
-// Create fixed action button in bottom right corner. Kept as the public
-// boot-time API (index.ts warms the UI up front); idempotent via the lazy
-// getter, so a second call never builds a duplicate.
-export const createFixedActionButton = (): HTMLElement => getFab().container;
-
-// Build the FAB (menu panel + trigger button) and mount it. Function
-// declaration (hoisted) so the lazy getters above can reference it.
-function buildFab(): { container: HTMLElement; button: HTMLElement } {
-  let isMenuOpen = false;
-  let hideMenuTimeout: NodeJS.Timeout;
-
-  const showMenu = () => {
-    clearTimeout(hideMenuTimeout);
-    isMenuOpen = true;
-    menuPanel.style.display = 'flex';
-    menuPanel.style.pointerEvents = 'auto';
-    setTimeout(() => {
-      menuPanel.style.opacity = '1';
-      menuPanel.style.transform = 'translateY(0) scale(1)';
-    }, 10);
-  };
-
-  const hideMenu = () => {
-    isMenuOpen = false;
-    menuPanel.style.opacity = '0';
-    menuPanel.style.transform = 'translateY(10px) scale(0.95)';
-    setTimeout(() => {
-      menuPanel.style.display = 'none';
-      menuPanel.style.pointerEvents = 'none';
-    }, 200);
-  };
-
-  const createMenuButton = (
-    text: string,
-    onClick: () => void | Promise<void>,
-    showLoadingImmediately = true,
-    prefetchKind?: EditorKind | 'loader',
-  ): HTMLDivElement =>
-    Div()
-      .class('fab-menu-item')
-      .children(
-        ButtonBuilder()
-          .class('fab-menu-button')
-          .text(text)
-          // Hovering a New/Open entry is intent: start pulling the engine now.
-          .on('pointerenter', () => {
-            if (prefetchKind) prefetchEditorAssets(prefetchKind === 'loader' ? undefined : prefetchKind);
-          })
-          .on('click', async () => {
-            hideMenu();
-            // Only show loading immediately if specified (for operations that don't require user interaction)
-            let removeLoading: (() => void) | null = null;
-            if (showLoadingImmediately) {
-              const loadingResult = showLoading();
-              removeLoading = loadingResult.removeLoading;
-            }
-            try {
-              // Small delay to ensure menu hide animation completes
-              await new Promise((resolve) => setTimeout(resolve, 100));
-              await onClick();
-            } catch (error) {
-              console.error('Error in menu button action:', error);
-              // Show control panel on error
-              showControlPanel();
-            } finally {
-              // Only remove loading if it was shown
-              if (removeLoading) {
-                removeLoading();
-              }
-            }
-          })
-          .build(),
-      )
-      .build();
-
-  // Menu panel - compact style
-  const menuPanel = Div()
-    .id('fab-menu')
-    .class('fab-menu')
-    .children(
-      createMenuButton(
-        t('uploadDocument'),
-        () => {
-          onOpenDocument();
-          // If user cancelled, nothing happens (onchange won't fire)
-          // If user selected file, document will be opened in handleChange
-        },
-        false, // Don't show loading immediately - wait for file selection
-        'loader',
-      ),
-      createMenuButton(
-        t('newWord'),
-        async () => {
-          await onCreateNew('.docx');
-        },
-        true,
-        'docx',
-      ),
-      createMenuButton(
-        t('newExcel'),
-        async () => {
-          await onCreateNew('.xlsx');
-        },
-        true,
-        'xlsx',
-      ),
-      createMenuButton(
-        t('newPowerPoint'),
-        async () => {
-          await onCreateNew('.pptx');
-        },
-        true,
-        'pptx',
-      ),
-      // AI assistant entry — lazy-loads the agent panel on first click (no bundle
-      // cost until used). Idempotent: if a panel already exists (e.g. opened via
-      // ?agent=1 or a prior click), do nothing and let its own launcher reopen it.
-      createMenuButton(
-        t('agentTitle'),
-        async () => {
-          if (document.querySelector('.agent-panel')) return;
-          const { createAgentPanel } = await import('./agent-plugin');
-          createAgentPanel();
-        },
-        false,
-      ),
-      // Light / dark / system. The landing hero has the same <r-theme-switch>
-      // in its footer, but the hero is hidden once a document is open and the
-      // editor follows the site theme (lib/editor-theme.ts) -- without this
-      // row there is no way to flip it while editing.
-      Div()
-        .class('fab-menu-item fab-menu-theme')
-        .children(
-          View('r-theme-switch')
-            .class('theme-switch')
-            .attr('label', t('themeLabel'))
-            .attr('label-system', t('themeSystem'))
-            .attr('label-light', t('themeLight'))
-            .attr('label-dark', t('themeDark')),
-        ),
-    )
-    // Keep menu visible when hovering over it
-    .on('mouseenter', () => {
-      clearTimeout(hideMenuTimeout);
-      if (!isMenuOpen) {
-        showMenu();
-      }
-    })
-    // Hide menu when leaving menu panel
-    .on('mouseleave', () => {
-      hideMenuTimeout = setTimeout(() => {
-        hideMenu();
-      }, 200);
-    })
-    .build();
-
-  // Main FAB button
-  const button = ButtonBuilder()
-    .id('fab-button')
-    .class('fab-button')
-    .text(t('menu'))
-    // Show menu on hover button
-    .on('mouseenter', () => {
-      showMenu();
-    })
-    // Hide menu when leaving button (if not moving to menu)
-    .on('mouseleave', (e) => {
-      const relatedTarget = e.relatedTarget as HTMLElement;
-      // If moving to menu panel, don't hide
-      if (relatedTarget && (relatedTarget === menuPanel || menuPanel.contains(relatedTarget))) {
-        return;
-      }
-      hideMenuTimeout = setTimeout(() => {
-        hideMenu();
-      }, 200);
-    })
-    .build();
-
-  const container = Div().id('fab-container').class('fab-container').children(menuPanel, button).build();
-  document.body.appendChild(container);
-  return { container, button };
-}
-
-// Show menu guide tooltip
-let menuGuideElement: HTMLElement | null = null;
-const MENU_GUIDE_DISMISSED_KEY = 'menu-guide-dismissed';
-
-export const showMenuGuide = (): void => {
-  // Check if guide was dismissed in localStorage
-  if (localStorageGetItem(MENU_GUIDE_DISMISSED_KEY) === 'true') {
-    return;
-  }
-
-  // Check if guide was already shown in this session
-  if (menuGuideElement) {
-    return;
-  }
-
-  const { button } = getFab();
-
-  const hideGuide = (saveToStorage = false) => {
-    if (saveToStorage) {
-      localStorageSetItem(MENU_GUIDE_DISMISSED_KEY, 'true');
-    }
-    if (guide.parentNode) {
-      guide.style.animation = 'guideFadeOut 0.3s ease';
-      setTimeout(() => {
-        if (guide.parentNode) {
-          guide.parentNode.removeChild(guide);
-        }
-        menuGuideElement = null;
-      }, 300);
-    }
-  };
-
-  const guide = Div()
-    .id('menu-guide')
-    .class('menu-guide')
-    .children(
-      Div().class('menu-guide-arrow').build(),
-      Div().class('menu-guide-text').text(t('menuGuide')).build(),
-      ButtonBuilder()
-        .class('menu-guide-close')
-        .text('×')
-        .on('click', (e) => {
-          e.stopPropagation();
-          hideGuide(true);
-        })
-        .build(),
-    )
-    .build();
-
-  document.body.appendChild(guide);
-  menuGuideElement = guide;
-
-  // Auto hide after 5 seconds (don't save to storage)
-  setTimeout(() => {
-    if (menuGuideElement === guide) {
-      hideGuide(false);
-    }
-  }, 5000);
-
-  // Hide when hovering over menu button (don't save to storage)
-  button.addEventListener(
-    'mouseenter',
-    () => {
-      if (menuGuideElement === guide) {
-        hideGuide(false);
-      }
-    },
-    { once: true },
-  );
-};
-
-// Create and append the control panel. Same boot-time wrapper pattern as
-// createFixedActionButton above.
+// Create and append the control panel.
 export const createControlPanel = (): void => {
   getControlPanel();
 };
@@ -355,32 +88,41 @@ function buildControlPanel(): HTMLElement {
       .on('click', onClick)
       .build();
 
-  const newDocButton = (id: string, label: string, ext: string): HTMLElement =>
-    createTextButton(id, label, async () => {
+  const newDocButton = (id: string, label: string, kind: EditorKind): HTMLElement => {
+    const button = createTextButton(id, label, async () => {
       hideControlPanel();
       const { removeLoading } = showLoading();
       try {
-        await onCreateNew(ext);
+        await onCreateNew(`.${kind}`);
       } catch (error) {
-        console.error(`Error creating new document (${ext}):`, error);
+        console.error(`Error creating new document (.${kind}):`, error);
         showControlPanel();
       } finally {
         removeLoading();
       }
     });
+    // Hovering a New entry is intent: start pulling that engine now. This used
+    // to hang off the removed menu's rows; the panel is what is left.
+    prefetchOnIntent(button, kind);
+    return button;
+  };
+
+  const uploadButton = createTextButton('upload-button', t('uploadDocument'), () => {
+    onOpenDocument();
+    // If user cancelled, nothing happens (onchange won't fire, panel stays visible)
+    // If user selected a file, the document opens and the panel hides in handleChange
+  });
+  // No extension known yet, so this warms the shared loader only.
+  prefetchOnIntent(uploadButton);
 
   // Button group - centered horizontally with wrap support
   const buttonGroup = Div()
     .class('control-panel-button-group')
     .children(
-      createTextButton('upload-button', t('uploadDocument'), () => {
-        onOpenDocument();
-        // If user cancelled, nothing happens (onchange won't fire, panel stays visible)
-        // If user selected a file, the document opens and the panel hides in handleChange
-      }),
-      newDocButton('new-word-button', t('newWord'), '.docx'),
-      newDocButton('new-excel-button', t('newExcel'), '.xlsx'),
-      newDocButton('new-pptx-button', t('newPowerPoint'), '.pptx'),
+      uploadButton,
+      newDocButton('new-word-button', t('newWord'), 'docx'),
+      newDocButton('new-excel-button', t('newExcel'), 'xlsx'),
+      newDocButton('new-pptx-button', t('newPowerPoint'), 'pptx'),
     )
     .build();
 

--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -150,8 +150,6 @@ export interface I18nMessages {
   newWord: string;
   newExcel: string;
   newPowerPoint: string;
-  menu: string;
-  menuGuide: string;
   themeLabel: string;
   themeSystem: string;
   themeLight: string;
@@ -225,8 +223,6 @@ const completeMessages: Record<LanguageCode.ZH | LanguageCode.EN, I18nMessages> 
     newWord: '新建 Word',
     newExcel: '新建 Excel',
     newPowerPoint: '新建 PowerPoint',
-    menu: '菜单',
-    menuGuide: '菜单在右下角，悬停即可查看（点击关闭后不再提示）',
     themeLabel: '主题',
     themeSystem: '跟随系统',
     themeLight: '浅色',
@@ -283,8 +279,6 @@ const completeMessages: Record<LanguageCode.ZH | LanguageCode.EN, I18nMessages> 
     newWord: 'New Word',
     newExcel: 'New Excel',
     newPowerPoint: 'New PowerPoint',
-    menu: 'Menu',
-    menuGuide: "Menu is in the bottom right corner, hover to view (click to close, won't show again)",
     themeLabel: 'Theme',
     themeSystem: 'System',
     themeLight: 'Light',
@@ -348,8 +342,6 @@ const partialMessages: Record<Exclude<Language, LanguageCode.ZH | LanguageCode.E
     newWord: 'Word を新規作成',
     newExcel: 'Excel を新規作成',
     newPowerPoint: 'PowerPoint を新規作成',
-    menu: 'メニュー',
-    menuGuide: 'メニューは右下にあります。カーソルを合わせると開きます（閉じると次回から表示されません）',
     themeLabel: 'テーマ',
     themeSystem: 'システム',
     themeLight: 'ライト',
@@ -371,8 +363,6 @@ const partialMessages: Record<Exclude<Language, LanguageCode.ZH | LanguageCode.E
     newWord: '새 Word 문서',
     newExcel: '새 Excel 문서',
     newPowerPoint: '새 PowerPoint 문서',
-    menu: '메뉴',
-    menuGuide: '메뉴는 오른쪽 아래에 있습니다. 마우스를 올리면 열립니다(닫으면 다시 표시되지 않습니다)',
     themeLabel: '테마',
     themeSystem: '시스템',
     themeLight: '라이트',
@@ -394,9 +384,6 @@ const partialMessages: Record<Exclude<Language, LanguageCode.ZH | LanguageCode.E
     newWord: 'Neues Word-Dokument',
     newExcel: 'Neue Excel-Tabelle',
     newPowerPoint: 'Neue PowerPoint-Präsentation',
-    menu: 'Menü',
-    menuGuide:
-      'Das Menü ist unten rechts – zum Öffnen mit der Maus darauf zeigen (nach dem Schließen wird dieser Hinweis nicht mehr angezeigt)',
     themeLabel: 'Design',
     themeSystem: 'System',
     themeLight: 'Hell',
@@ -420,9 +407,6 @@ const partialMessages: Record<Exclude<Language, LanguageCode.ZH | LanguageCode.E
     newWord: 'Nuevo documento de Word',
     newExcel: 'Nueva hoja de Excel',
     newPowerPoint: 'Nueva presentación de PowerPoint',
-    menu: 'Menú',
-    menuGuide:
-      'El menú está abajo a la derecha: pasa el cursor para abrirlo (si lo cierras, no volverá a mostrarse este aviso)',
     themeLabel: 'Tema',
     themeSystem: 'Sistema',
     themeLight: 'Claro',
@@ -445,9 +429,6 @@ const partialMessages: Record<Exclude<Language, LanguageCode.ZH | LanguageCode.E
     newWord: 'Novo documento do Word',
     newExcel: 'Nova planilha do Excel',
     newPowerPoint: 'Nova apresentação do PowerPoint',
-    menu: 'Menu',
-    menuGuide:
-      'O menu fica no canto inferior direito: passe o cursor para abrir (ao fechar, este aviso não aparece novamente)',
     themeLabel: 'Tema',
     themeSystem: 'Sistema',
     themeLight: 'Claro',
@@ -470,9 +451,6 @@ const partialMessages: Record<Exclude<Language, LanguageCode.ZH | LanguageCode.E
     newWord: 'سند Word جدید',
     newExcel: 'کاربرگ Excel جدید',
     newPowerPoint: 'ارائهٔ PowerPoint جدید',
-    menu: 'منو',
-    menuGuide:
-      'منو در گوشهٔ پایین سمت راست است؛ نشانگر را روی آن ببرید تا باز شود (پس از بستن دیگر نمایش داده نمی‌شود)',
     themeLabel: 'پوسته',
     themeSystem: 'سیستم',
     themeLight: 'روشن',

--- a/styles/base.css
+++ b/styles/base.css
@@ -22,9 +22,7 @@ h2 {
   font-size: 1.5rem;
 }
 
-body.embed-mode #control-panel-container,
-body.embed-mode #fab-container,
-body.embed-mode #menu-guide {
+body.embed-mode #control-panel-container {
   display: none !important;
 }
 
@@ -61,190 +59,6 @@ r-button[type='text']::part(content) {
     font-size: 16px;
     padding: 8px 16px;
   }
-}
-
-/* Style for FAB menu buttons — editor chrome consumes the ranui token layer
-   (/ran-tokens.css is linked globally), so dark mode comes for free. */
-.fab-menu-button {
-  font-size: 16px;
-  padding: var(--ran-space-3) var(--ran-space-4);
-  background: transparent;
-  border: none;
-  box-shadow: none;
-  outline: none;
-  cursor: pointer;
-  color: var(--ran-color-text);
-  width: 100%;
-  text-align: left;
-  line-height: 1.5;
-  white-space: nowrap;
-}
-
-/* Menu item hover - entire row background (monochrome, Geist state ladder) */
-.fab-menu-item:hover {
-  background-color: var(--ran-color-bg-hover);
-}
-
-/* Menu guide animations */
-@keyframes guideFadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes guideFadeOut {
-  from {
-    opacity: 1;
-    transform: translateY(0);
-  }
-  to {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-}
-
-/* FAB Container */
-.fab-container {
-  position: fixed;
-  bottom: var(--ran-space-6);
-  right: var(--ran-space-6);
-  z-index: 1000;
-  display: none;
-}
-
-/* FAB Button */
-.fab-button {
-  min-width: 52px;
-  height: 40px;
-  padding: 0 16px;
-  border-radius: var(--ran-radius-sm);
-  background: var(--ran-gray-alpha-100);
-  border: 1px solid var(--ran-color-border);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--ran-color-text);
-  font-size: 14px;
-  font-weight: 500;
-  user-select: none;
-  white-space: nowrap;
-}
-.fab-button:hover {
-  background: var(--ran-gray-alpha-200);
-}
-
-/* FAB Menu */
-.fab-menu {
-  position: absolute;
-  /* Anchoring geometry, not rhythm: derived from the trigger it sits above, so it stays
-     attached if the button's height changes. ranui's spacing scale governs the gaps
-     *between* things — the 100% here is the container's own height. */
-  bottom: calc(100% + var(--ran-space-2));
-  right: 0;
-  background: var(--ran-color-bg-elevated);
-  /* md, not sm: this is a floating surface (a menu panel), and ranui maps sm to controls,
-     md to cards and dialogs. The items inside it are the controls, and they take sm. */
-  border-radius: var(--ran-radius-md);
-  box-shadow: var(--ran-shadow-menu);
-  padding: var(--ran-space-2);
-  display: none;
-  flex-direction: column;
-  gap: var(--ran-space-1);
-  min-width: 220px;
-  opacity: 0;
-  transform: translateY(10px) scale(0.95);
-  transition:
-    opacity var(--ran-motion-duration-base) ease,
-    transform var(--ran-motion-duration-base) ease;
-  pointer-events: none;
-  z-index: 1001;
-  border: 1px solid var(--ran-color-border);
-}
-
-.fab-menu-item {
-  width: 100%;
-  border-radius: var(--ran-radius-sm);
-}
-/* Theme row: a control, not a command -- no hover fill, hairline above. */
-.fab-menu-theme {
-  display: flex;
-  justify-content: center;
-  padding: var(--ran-space-2) var(--ran-space-3);
-  margin-top: var(--ran-space-1);
-  border-top: 1px solid var(--ran-color-border);
-}
-.fab-menu-theme:hover {
-  background-color: transparent;
-}
-
-/* Menu Guide */
-.menu-guide {
-  position: fixed;
-  /* Clears the FAB (24 bottom + 40 tall) plus a gap plus the 10px arrow below this bubble.
-     A sum of derived values, so it is deliberately not a single scale step. */
-  bottom: 90px;
-  right: var(--ran-space-6);
-  background: var(--ran-color-bg-elevated);
-  border-radius: var(--ran-radius-md);
-  /* Overlay tier, not modal: this is a pointer bubble that guides, it does not block.
-     ranui reserves --ran-shadow-modal for r-modal-class dialogs. */
-  box-shadow: var(--ran-shadow-menu);
-  padding: var(--ran-space-6) var(--ran-space-10) var(--ran-space-6) var(--ran-space-6);
-  z-index: 1002;
-  max-width: 300px;
-  animation: guideFadeIn 0.3s ease;
-  pointer-events: auto;
-  border: 1px solid var(--ran-color-border);
-}
-
-/* Pure CSS triangle: the three border widths *are* the arrow's shape, not spacing.
-   Snapping them to the 4px scale would just change how the arrow looks. */
-.menu-guide-arrow {
-  position: absolute;
-  bottom: -10px;
-  right: 40px;
-  width: 0;
-  height: 0;
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
-  border-top: 10px solid var(--ran-color-bg-elevated);
-}
-
-.menu-guide-text {
-  font-size: 16px;
-  color: var(--ran-color-text);
-  line-height: 1.6;
-  margin: 0;
-  font-weight: 500;
-  padding-right: 0;
-}
-
-.menu-guide-close {
-  position: absolute;
-  top: 8px;
-  right: 12px;
-  background: none;
-  border: none;
-  font-size: 24px;
-  color: var(--ran-color-text-disabled);
-  cursor: pointer;
-  padding: 0;
-  width: 24px;
-  height: 24px;
-  line-height: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  /* No transition on `color`. CSS cannot tell *why* a property changed, so a palette prop
-     listed here also fades when the theme flips its token — this button would cross-fade at
-     its own pace while the rest of the page has already switched. Hover feedback snapping is
-     the intended trade (ranui DESIGN.md §5). */
 }
 
 /* Full-screen loading overlay (lib/loading.ts). gray-alpha rides the token
@@ -488,8 +302,6 @@ r-dropdown[role='listbox'] {
    setting costs nothing and removes the vestibular trigger. Kept to this file's own
    selectors — ranui's components carry their own reduced-motion rules. */
 @media (prefers-reduced-motion: reduce) {
-  .fab-menu,
-  .menu-guide,
   .loading-mask,
   .agent-launcher {
     transition-duration: 0.01ms !important;

--- a/test/e2e/app-smoke.spec.ts
+++ b/test/e2e/app-smoke.spec.ts
@@ -8,9 +8,10 @@ test('homepage is the static landing: hero present, no editor bundle', async ({ 
 
   await expect(page.locator('#landing-hero')).toBeVisible();
   await expect(page.locator('#hero-open')).toBeVisible();
-  // Route split: / never mounts the editor shell.
+  // Route split: / never mounts the editor shell, so nothing the editor
+  // bundle builds is on the page.
   await expect(page.locator('#iframe')).toHaveCount(0);
-  await expect(page.locator('#fab-container')).toHaveCount(0);
+  await expect(page.locator('#control-panel-container')).toHaveCount(0);
   expect(page.url()).not.toContain('/editor');
   expect(pageErrors).toEqual([]);
 });
@@ -25,8 +26,11 @@ test('/editor?new=docx mounts the editor shell; legacy /?new=docx redirects ther
   // The #iframe placeholder is replaced by the DocsAPI iframe (name=frameEditor,
   // no id) as soon as the editor mounts, so accept either state.
   await expect(page.locator('#iframe, iframe[name="frameEditor"]').first()).toBeAttached();
-  await expect(page.locator('#fab-container')).toBeAttached();
   await expect(page.locator('#control-panel-container')).toBeAttached();
+  // The bottom-right "Menu" FAB and its first-run guide bubble were removed on
+  // 2026-08-20; nothing should bring them back.
+  await expect(page.locator('#fab-container')).toHaveCount(0);
+  await expect(page.locator('#menu-guide')).toHaveCount(0);
   expect(pageErrors).toEqual([]);
 });
 

--- a/test/unit/i18n-locales.test.ts
+++ b/test/unit/i18n-locales.test.ts
@@ -22,8 +22,6 @@ const CORE_KEYS: Array<keyof I18nMessages> = [
   'newWord',
   'newExcel',
   'newPowerPoint',
-  'menu',
-  'menuGuide',
   'themeLabel',
   'themeSystem',
   'themeLight',
@@ -46,7 +44,7 @@ const CORE_KEYS: Array<keyof I18nMessages> = [
 const SAME_AS_ENGLISH: Partial<Record<string, Array<keyof I18nMessages>>> = {
   de: ['themeSystem'],
   es: ['themeSystem'],
-  pt: ['menu', 'themeSystem'],
+  pt: ['themeSystem'],
 };
 
 const restore = () => {
@@ -88,7 +86,7 @@ describe('shell locales', () => {
     try {
       // The agent panel is deliberately English outside en/zh.
       expect(t('agentSend')).toBe('Send');
-      expect(t('menu')).toBe('Menü');
+      expect(t('uploadDocument')).toBe('Dokument öffnen / bearbeiten');
     } finally {
       restore();
     }

--- a/test/unit/i18n.test.ts
+++ b/test/unit/i18n.test.ts
@@ -140,7 +140,7 @@ describe('editor UI locale (getOnlyOfficeLang) follows the visitor beyond en/zh'
     const m = await import('@ranuts/shared/i18n');
     expect(m.getLanguage()).toBe(LanguageCode.FA);
     expect(m.getOnlyOfficeLang()).toBe('en');
-    expect(m.t('menu')).toBe('منو');
+    expect(m.t('uploadDocument')).toBe('باز کردن / ویرایش سند');
   });
 
   it('an unsupported ?locale (fa) falls back to the browser language for the editor', async () => {


### PR DESCRIPTION
去掉编辑器右下角那个压在滚动条上、紧挨缩放条的 "Menu" 悬浮按钮。

## 删之前先查了它挂着什么

FAB 里有 6 项。逐项确认**文档已打开**时还有没有别的入口：

| 菜单项 | 别的入口 |
|---|---|
| 上传文档 | 无（编辑器 `help:false`、无拖拽、无快捷键）|
| 新建 Word / Excel / PPT | 无（同上）|
| AI 助手 | 有 —— `?agent=1` |
| 主题切换 | 无（落地 hero 一打开文档就隐藏）|

代码注释里本来就写着主题那行的存在理由。所以这不是纯装饰，删掉有代价：**打开/新建改从首页或 URL（`?new=` / `?file=`）走，主题改在首页页脚切，编辑中不再有主题开关。** 这个取舍是明确确认过的。

## 删除范围

| 文件 | 内容 |
|---|---|
| `lib/ui.ts` | `buildFab` / `createFixedActionButton` / `showMenuGuide` 及引导气泡；**391 → 124 行** |
| `lib/document.ts` / `lib/events.ts` | `showMenuGuideFn` 与四处延时调用、callback 入参 |
| `index.ts` | callback 装配、`createFixedActionButton()`、已无人用的 `import 'ranui/theme-switch'` |
| `styles/base.css` | `.fab-*` / `.menu-guide*` / `guideFadeIn`、`guideFadeOut`；**499 → 311 行** |
| `packages/shared/src/i18n.ts` | `menu` / `menuGuide`（接口 + 8 语言，18 处）|
| 测试 | i18n CORE_KEYS、德语回退用例换键、app-smoke 两处断言 |

`theme*` 词条**没删**：那是三站共享包里的通用开关标签，跨仓删除不该我单方面做；`menu` / `menuGuide` 删了——它们的文案只描述这个已经不存在的 FAB，留着会误导翻译。

## 顺手保住的一件事

FAB 每个"新建/打开"行都挂着 `pointerenter → prefetchEditorAssets`（悬停即开始拉引擎）。直接删会连这个一起丢，而且 `lib/prefetch.ts` 会变成全仓无人 import 的死模块（它导出的 `prefetchOnIntent` 此前从没被用过）。所以把控制面板那四个按钮接上了 `prefetchOnIntent`——行为不丢，模块不死。

## 用例

`app-smoke.spec.ts` 反过来钉住这个决定：`/editor` 上 `#fab-container` 与 `#menu-guide` 必须 `toHaveCount(0)`。落地页那条原本用 `#fab-container` 证明 "`/` 不加载编辑器 bundle"，改用 `#control-panel-container`。

**反向验证**：把删除 stash 掉、只留新用例重跑，`app-smoke` 确实变红（1 failed / 3 passed）。

本地另跑了 `main-site` / `entry-paths` 确认控制面板路径没被带坏，9 个用例全过；单测 617 全绿，`tsc --noEmit`、oxlint、prettier、生产构建均通过。

记录见 `docs/explorations/2026-08-20-remove-menu-fab.md`，CHANGELOG 已加 Removed 条目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)