### PR TITLE
fix(ci): make the production deploy gate wait for the build it is smoking

### DIFF
--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -41,16 +41,31 @@ jobs:
       # hashed entry asset (Vite hashes are content-derived, so an identical
       # build here yields the same asset name as the Pages build). Skipped for
       # schedule/dispatch runs, which smoke whatever is live.
+      #
+      # The asset to watch is the EDITOR's, taken from editor.html. `/` has
+      # shipped no bundle since the route split (2026-08-16), so the old
+      # `assets/index-*.js` grep against `dist/index.html` found nothing --
+      # and an empty expectation matched an empty answer on the first poll,
+      # so this step reported "live after 20s" without waiting for anything.
+      # Every smoke since has run against whatever happened to be deployed;
+      # it only surfaced once a case could tell the builds apart.
+      #
+      # An empty ASSET is now a hard error rather than a vacuous pass: this
+      # gate is worthless if it cannot name what it is waiting for.
       - name: Wait for the deploy of this commit
         if: github.event_name == 'push'
         env:
           PROD_URL: ${{ github.event.inputs.url || 'https://edit.chaxus.com' }}
         run: |
           sh ./bin/build.sh >/dev/null 2>&1
-          ASSET=$(grep -o 'assets/index-[A-Za-z0-9_-]*\.js' dist/index.html | head -1)
+          ASSET=$(grep -o 'assets/editor-[A-Za-z0-9_-]*\.js' dist/editor.html | head -1)
+          if [ -z "$ASSET" ]; then
+            echo "::error::no editor entry asset in dist/editor.html; the deploy gate cannot tell builds apart"
+            exit 1
+          fi
           echo "expecting $ASSET"
           for i in $(seq 1 60); do
-            LIVE=$(curl -s "$PROD_URL/" | grep -o 'assets/index-[A-Za-z0-9_-]*\.js' | head -1)
+            LIVE=$(curl -s "$PROD_URL/editor" | grep -o 'assets/editor-[A-Za-z0-9_-]*\.js' | head -1)
             if [ "$LIVE" = "$ASSET" ]; then echo "live after $((i*20))s"; exit 0; fi
             sleep 20
           done

--- a/docs/explorations/2026-08-20-prod-smoke-deploy-gate-was-vacuous.md
+++ b/docs/explorations/2026-08-20-prod-smoke-deploy-gate-was-vacuous.md
@@ -1,0 +1,77 @@
+# 线上冒烟等的是一个不存在的文件名（2026-08-20）
+
+日期：2026-08-20 · 相关：[#159](https://github.com/ranuts/document/pull/159) 合并后 main 的两处红
+
+#159 合并进 main 之后，`Production smoke` 与 `CI` 各红一条。两条都不是被合并的代码坏了，
+但其中一条是**长期存在、这次才被看见**的真 bug。
+
+## 一、Production smoke：部署门禁一秒放行
+
+红的是 #159 新加的用例：
+
+```
+✘ app-smoke.spec.ts › the editor page fits the viewport and renders in the ranui typeface
+  Expected: 700    Received: 724
+```
+
+24px 正是那个 `visibility: hidden` 的 file input——也就是说**它测到的是旧构建**。
+
+`prod-smoke.yml` 的「等这次提交上线」那一步是这么写的：
+
+```sh
+ASSET=$(grep -o 'assets/index-[A-Za-z0-9_-]*\.js' dist/index.html | head -1)
+LIVE=$(curl -s "$PROD_URL/"      | grep -o 'assets/index-[A-Za-z0-9_-]*\.js' | head -1)
+[ "$LIVE" = "$ASSET" ] && exit 0
+```
+
+**2026-08-16 路由拆分之后，`/` 是不带 bundle 的静态落地页**，`index.html` 里根本没有
+`assets/index-*.js`。于是 `ASSET` 是空串、`LIVE` 也是空串，第一轮就相等：
+
+```
+expecting
+live after 20s
+```
+
+从路由拆分那天起，每一次 push main 之后的线上冒烟，**都是对"当时碰巧还在线上的那个构建"**
+跑的。之前一直绿，是因为没有任何一条用例能分辨新旧构建；#159 加了两条能分辨的，
+它立刻显形——而且显形的方式是"新代码在线上是坏的"，最容易把人带偏。
+
+修法：
+
+- 盯 **editor 页**的入口资源（`assets/editor-<hash>.js`，取自 `dist/editor.html`，
+  轮询 `$PROD_URL/editor`）——那是真正带构建产物的页面；
+- `ASSET` 为空直接 `::error::` 退出，不再"空等于空"地免费通过。一个说不出自己在等什么的
+  门禁没有存在价值。
+
+`workflow-contract.test.ts` 把两条都钉住了，并且顺带钉住前提：editor 页有 module script、
+落地页没有。反向验证：把这一步换回旧写法，两条用例变红。
+
+## 二、CI（e2e-pages 分片 5）：wrangler 中途崩了
+
+时间线（同一个分片，日志里连着）：
+
+```
+14:33:19  ✓ visual-roundtrip docx（存回再打开，多 MB）
+14:33:21  [WebServer] ✘ [ERROR]           ← workerd 挂了，日志写进 wrangler 的 log 文件
+14:33:23  ✘ visual-roundtrip pptx          "The document failed to open: Failed to fetch"
+14:33:24  ✘ 同一条 retry #1（345ms）        ERR_CONNECTION_REFUSED
+14:33:44  ✓ visual-roundtrip xlsx           ← 服务器已经自己回来了
+```
+
+`bin/serve-pages-dev.sh` 的重启循环工作正常（约 20 秒回来），CLAUDE.md 里也早写了
+「并发下 workerd 会被大文件 abort 打崩」——所以那套才是单 worker。缺的是**另一半**：
+Playwright 的 webServer 就绪检查只在启动时做一次，重试又是立刻发出的，于是崩溃的那一下
+同时带走"当时那条用例"和"它的重试"，整片红给一个 20 秒后就恢复的服务器。
+
+修法：`test/e2e/lib/l0.ts` 里加一个 auto fixture，在每条用例开始前先问一次端口；答得上来就
+什么都不做（一个请求的成本），答不上来才等（最多 60s）。由 `playwright.pages.config.ts` 设
+`E2E_WAIT_FOR_SERVER=1` 打开——**只对这一套**。别的套由不会中途消失的服务器托着，在那儿等
+只会把"服务器根本没起来"藏起来。
+
+**等待的时间要额外补给用例，不能从它自己的预算里扣**：默认超时 30s，重启要 20s，扣完只剩
+10s 去打开一篇文档，用例照样红，只是理由更难看。所以进入等待前先
+`testInfo.setTimeout(testInfo.timeout + 60s)`。实测（把 baseURL 指向一个死端口）：
+补预算之前失败信息是 `Test timeout of 30000ms exceeded while setting up "serverUp"`，
+补之后是 fixture 自己的 `server at … did not come back within 60000ms`——等满了 60 秒才放弃。
+
+`workflow-contract.test.ts` 把重启循环与等待 fixture 钉成一对（缺任一半，红）。

--- a/playwright.pages.config.ts
+++ b/playwright.pages.config.ts
@@ -21,6 +21,13 @@ const PORT = Number(process.env.PAGES_PORT || 8788);
 // crash costs one retried test instead of the whole job.
 const SERVE = `sh ./bin/serve-pages-dev.sh ${PORT}`;
 
+// The suite's own server can die mid-run: workerd aborts on a large response
+// and bin/serve-pages-dev.sh restarts it (~20 s), while Playwright keeps
+// sending tests -- including the immediate retry of the case that hit the
+// outage. With this set, each test waits for the port to answer first (see
+// waitForServer in test/e2e/lib/l0.ts).
+process.env.E2E_WAIT_FOR_SERVER = '1';
+
 export default defineConfig({
   ...base,
   // No `@serial`: this suite proves Cloudflare Pages hosting semantics.

--- a/test/e2e/lib/l0.ts
+++ b/test/e2e/lib/l0.ts
@@ -241,7 +241,59 @@ export class L0Collector {
   }
 }
 
-export const test = base.extend<{ l0: L0Collector }>({
+/**
+ * Wait until the server under test answers again.
+ *
+ * Only used where the server can go away mid-run: `wrangler pages dev` is
+ * killed by workerd aborting on a large response (which is why that suite is
+ * single-worker in the first place), and bin/serve-pages-dev.sh restarts it --
+ * about 20 s. Playwright does not notice: its webServer readiness check ran
+ * once at startup, and a retry fires immediately, so the retry lands on the
+ * same dead port and the whole shard goes red for a server that was back
+ * seconds later.
+ *
+ * Bounded: if the server never comes back the test fails on its own timeout,
+ * with the same evidence it would have had anyway.
+ */
+const SERVER_WAIT_MS = 60_000;
+
+/** One request, swallowing the connection error a dead port raises. */
+async function serverAnswers(baseURL: string): Promise<boolean> {
+  try {
+    await fetch(baseURL, { method: 'GET' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForServer(baseURL: string): Promise<void> {
+  const deadline = Date.now() + SERVER_WAIT_MS;
+  for (;;) {
+    if (await serverAnswers(baseURL)) return;
+    if (Date.now() > deadline) throw new Error(`server at ${baseURL} did not come back within ${SERVER_WAIT_MS}ms`);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+}
+
+export const test = base.extend<{ l0: L0Collector; serverUp: void }>({
+  // Opt-in per config (playwright.pages.config.ts sets the variable): every
+  // other suite is served by something that does not fall over mid-run, and
+  // waiting there would only hide a server that failed to start.
+  serverUp: [
+    async ({ baseURL }, use, testInfo) => {
+      if (process.env.E2E_WAIT_FOR_SERVER && baseURL && !(await serverAnswers(baseURL))) {
+        // Pay for the wait out of extra time rather than out of the test's own
+        // budget: the default is 30 s, so a 20 s restart would otherwise leave
+        // 10 s to open a document in and the case would fail anyway -- just
+        // with a less honest message.
+        testInfo.setTimeout(testInfo.timeout + SERVER_WAIT_MS);
+        await waitForServer(baseURL);
+      }
+      await use();
+    },
+    { auto: true },
+  ],
   l0: [
     async ({ page }, use, testInfo) => {
       const collector = new L0Collector(page);

--- a/test/unit/workflow-contract.test.ts
+++ b/test/unit/workflow-contract.test.ts
@@ -166,6 +166,18 @@ describe('bin/serve-pages-dev.sh', () => {
     expect(config).toMatch(/bin\/serve-pages-dev\.sh/);
     expect(config).not.toMatch(/wrangler@latest pages dev/);
   });
+
+  it('makes the tests wait for the restart the loop performs', () => {
+    // The restart loop only helps if something waits for it. Playwright checks
+    // the server once, at startup, and fires a retry immediately -- so a
+    // mid-run crash took the case that hit it AND its retry, for a server that
+    // was back ~20 s later. Both halves have to exist: the loop that restarts,
+    // and the fixture that waits.
+    expect(config).toMatch(/process\.env\.E2E_WAIT_FOR_SERVER = '1'/);
+    const l0 = readFileSync(resolve(ROOT, 'test/e2e/lib/l0.ts'), 'utf8');
+    expect(l0).toMatch(/E2E_WAIT_FOR_SERVER/);
+    expect(l0).toMatch(/async function waitForServer/);
+  });
 });
 
 describe('.github/workflows/ci.yml', () => {
@@ -244,6 +256,39 @@ describe('.github/workflows/ci.yml', () => {
     // assumed -- see docs/explorations/2026-08-19-ci-e2e-sharding.md.
     expect(ci).toMatch(/run: sh \.\/bin\/test-e2e-docker\.sh --shard=/);
     expect(ci).not.toMatch(/pnpm run test:e2e:docker.*--shard/);
+  });
+});
+
+describe('.github/workflows/prod-smoke.yml', () => {
+  const src = readFileSync(resolve(WORKFLOW_DIR, 'prod-smoke.yml'), 'utf8');
+  const editorHtml = readFileSync(resolve(ROOT, 'editor.html'), 'utf8');
+  const landingHtml = readFileSync(resolve(ROOT, 'index.html'), 'utf8');
+
+  /**
+   * The deploy gate has to watch a file that CARRIES the build.
+   *
+   * It used to grep `assets/index-*.js` out of `dist/index.html` and poll `/`
+   * for the same name. `/` has shipped no bundle since the route split
+   * (2026-08-16), so the expectation was the empty string -- which matched the
+   * equally empty answer on the first poll. The step printed "live after 20s"
+   * and every production smoke since ran against whatever was already
+   * deployed. Nothing noticed until a case could tell two builds apart, and
+   * then it read as "the new code is broken in production".
+   */
+  it('waits on the entry asset of the page that actually has one', () => {
+    expect(src).toContain("grep -o 'assets/editor-[A-Za-z0-9_-]*\\.js' dist/editor.html");
+    expect(src).toContain('curl -s "$PROD_URL/editor"');
+    // The premise of the two lines above: the editor page is the one that
+    // loads a bundle, and the landing page is the one that does not.
+    expect(editorHtml).toMatch(/<script[^>]+type="module"/);
+    expect(landingHtml).not.toMatch(/<script[^>]+type="module"/);
+  });
+
+  it('fails loudly when it cannot name what it is waiting for', () => {
+    // An empty expectation is what made the gate vacuous; it must never again
+    // be allowed to pass for free.
+    expect(src).toMatch(/if \[ -z "\$ASSET" \]; then/);
+    expect(src).toMatch(/::error::[^\n]*deploy gate/);
   });
 });
 


### PR DESCRIPTION
Merging #159 turned two workflows red on main, and only one of them was
about the merged code -- neither was a defect in it.

The deploy gate has been vacuous since the route split (2026-08-16). It
grepped `assets/index-*.js` out of dist/index.html and polled `/` for the same
name, but `/` has shipped no bundle since that split: the expectation was the
empty string, the answer was the empty string, and the step printed "live after
20s" without waiting for anything. Every production smoke since has run against
whatever happened to be deployed. Nothing noticed until #159 added two cases
that can tell two builds apart, at which point it read as "the new code is
broken in production" -- it was the OLD build, still live, failing an assertion
written for the new one. The gate now watches the editor page's entry asset,
which is the one that carries a build, and an empty expectation is a hard error
rather than a free pass.

The other red was the pages suite's own server dying mid-run: workerd aborted
(the reason that suite is single-worker), bin/serve-pages-dev.sh restarted it
~20 s later, and in between Playwright ran a case and its immediate retry
against a dead port. The restart loop only ever helped if something waited for
it, so each test in that suite now waits for the port to answer first --
bounded, opt-in per config, and still failing on its own timeout if the server
never returns.

Both halves of each pair are pinned in workflow-contract: the gate's grep with
the premise it rests on (the editor page has a module script, the landing page
does not), and the restart loop with the fixture that waits for it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>