### PR TITLE
ci(nightly): stop the corpus run reporting infrastructure noise as findings

### DIFF
--- a/.github/workflows/nightly-corpus.yml
+++ b/.github/workflows/nightly-corpus.yml
@@ -55,8 +55,14 @@ jobs:
           CORPUS_FILTER: ${{ github.event.inputs.filter || '' }}
           CORPUS_VISUAL: ${{ github.event.inputs.visual || '1' }}
           # Expected-to-fail inputs: encrypted/password files, deliberately
-          # truncated/corrupt regression samples, macro-only containers.
-          CORPUS_EXCLUDE: "password|protect|encrypt|corrupt|truncat|broken|invalid|damaged|\\.xlsm$|\\.xlsb$|\\.docm$|\\.pptm$"
+          # truncated/corrupt regression samples, macro-only containers, and
+          # POI's fuzzer output (clusterfuzz-testcase-*, *Fuzzer*, Fuzzed.doc,
+          # poi-fuzz.xls, crash-<sha1>.*) -- byte soup kept precisely because
+          # it broke a parser, so "this editor will not open it" is not a
+          # finding. 15 of the 20 red rows on 2026-08-21 were these. The terms
+          # are narrow on purpose: a bare `crash` would also drop
+          # 51921-Word-Crash067.doc, which is a real document from a bug report.
+          CORPUS_EXCLUDE: "password|protect|encrypt|corrupt|truncat|broken|invalid|damaged|clusterfuzz|fuzzer|fuzzed|poi-fuzz|crash-[0-9a-f]{6}|\\.xlsm$|\\.xlsb$|\\.docm$|\\.pptm$"
         run: pnpm exec playwright test test/e2e/corpus.spec.ts --workers=2 --reporter=list
 
       - name: Summarize

--- a/docs/explorations/2026-08-22-nightly-corpus-false-red.md
+++ b/docs/explorations/2026-08-22-nightly-corpus-false-red.md
@@ -1,0 +1,145 @@
+# 夜间套件天天红：16 个假失败来自一行 device，15 个来自 fuzz 语料
+
+2026-08-22
+
+## 起因
+
+用户拿着 run `32519705139`（Nightly corpus，2026-08-21 03:17 那趟）问"这个 action 是为什么"。
+翻了一下 `gh run list`：这个 workflow **从 8-15 上线起每一趟都是 failure**。红成常态，
+就没人看了——而它本来是 v9 回归战役的信号源。
+
+三个 job 挂了两个：
+
+| job                            | 结果                   |
+| ------------------------------ | ---------------------- |
+| Cross-browser (WebKit+Firefox) | 20 failed / 174 passed |
+| Real-document matrix (POI)     | 20 failed / 280 passed |
+| Slow-network budgets           | ✅                     |
+
+40 个红里，**31 个不是缺陷**。
+
+## 一、16 个假失败：`devices['Pixel 5']` 把 browserName 变成了 chromium
+
+`test/e2e/mobile-slide.spec.ts`（#145 手机版式那套）文件顶上写：
+
+```ts
+test.use({ ...devices['Pixel 5'] });
+```
+
+Playwright 的 device 描述符里带 `defaultBrowserType: 'chromium'`，它**压过 project 的浏览器**。
+于是在夜间的 webkit / firefox 两个 project 下：
+
+1. 实际要启的是 Chromium，而这个 job 只装了 webkit + firefox
+   → `browserType.launch: Executable doesn't exist at …/chromium_headless_shell-1234/…`；
+2. 本来该拦住它的三道守卫
+
+   ```ts
+   test.skip(({ browserName }) => browserName !== 'chromium', 'device emulation needs chromium');
+   ```
+
+   **永远不触发**——`browserName` 也被 device 改成了 `'chromium'`。
+
+8 条用例 × 2 个引擎 = 16 个红，全是"浏览器没装"，与被测代码无关。
+
+### 修法：按 project 名判，不按 browserName 判
+
+`browserName` 是"实际启的是谁"，而这里要问的是"我在哪个 project 下跑"。Playwright 没有
+内置的 project 名 fixture，`test.skip` 的条件回调只拿得到 fixtures（`ConditionBody<TestArgs> = (args) => boolean`，
+没有 testInfo），所以在 `test/e2e/lib/l0.ts` 里加一个 worker 级 fixture：
+
+```ts
+projectName: [
+  async ({}, use, workerInfo) => {
+    await use(workerInfo.project.name);
+  },
+  { scope: 'worker' },
+],
+```
+
+三处守卫改成 `test.skip(({ projectName }) => projectName !== 'chromium', …)`。它不依赖任何
+其它 fixture，所以求值时不会去创建 `page`，浏览器压根不会启。
+
+两个细节，都是试出来的：
+
+- 第一个参数**必须**是解构模式。写成 `async (_unused, use, workerInfo)` 直接被 Playwright
+  拒绝：`First argument must use the object destructuring pattern: _unused`。空解构 `{}` 会被
+  oxlint 的 `no-empty-pattern` 警告，本仓此前零 disable 注释，这里只能破例加一条
+  `// eslint-disable-next-line no-empty-pattern`（**注释必须紧贴上一行、不能带 `-- 理由` 尾巴**，
+  否则 oxlint 不认，实测警告照旧）。
+- 加在 l0 而不是 spec 里：三个 config（browsers / pages / docker）都从 l0 导入 `test`，
+  以后再有 spec 踩同样的坑，守卫是现成的。
+
+### 反向验证
+
+`E2E_BASE_URL=http://127.0.0.1:9`（配置里 `REMOTE` 非空就不起 webServer，跳过的用例根本不需要服务器）：
+
+| 状态                     | 结果                                 |
+| ------------------------ | ------------------------------------ |
+| 改成 `projectName` 后    | **16 skipped**                       |
+| 退回 `browserName`       | **16 failed**                        |
+| chromium project（改后） | **1 passed**（真跑，真 build，6.9s） |
+
+## 二、15 个假失败：POI 的 fuzz 语料
+
+语料 job 的 20 个红：11 个 `-82`（打开转换失败）、9 个 `Target crashed`（渲染进程直接崩）。
+按文件名拆开看，其中 15 个是 POI 自己的模糊测试产物：
+
+- `clusterfuzz-testcase-minimized-POIXWPFFuzzer-*.docx`（12 个）
+- `crash-517626e815e0afa9decd0ebb6d1dee63fb9907dd.docx`
+- `Fuzzed.doc`
+- `clusterfuzz-testcase-minimized-POIHWPFFuzzer-*.doc`
+
+这些文件被 POI 收进来，恰恰是因为它们**能把解析器搞崩**——是被 minimizer 削到最小的字节汤，
+不是文档。"本编辑器也打不开它"不构成发现。workflow 里的 `CORPUS_EXCLUDE` 已经排掉了
+`password|corrupt|truncat|broken|invalid|damaged`，只是没覆盖 fuzz 这一类。
+
+### 词要窄，不能直接写 `fuzz|crash`
+
+把 POI 的 test-data（spreadsheet / document / slideshow 三个目录，1298 个受支持扩展名的文件）
+拉下来核了一遍：`fuzz|crash` 命中 89 个，其中两个是**真实 bug 报告里的文档**——
+`51921-Word-Crash067.doc` / `.docx`（POI bug 51921，崩的是 Word 不是 fuzzer）。把它们排掉就
+排掉了真信号。最终用：
+
+```
+clusterfuzz|fuzzer|fuzzed|poi-fuzz|crash-[0-9a-f]{6}
+```
+
+命中 87 个（8 个 fuzz 家族 + 5 个 `crash-<sha1>` + `Fuzzed.doc` + `poi-fuzz.xls`），
+`51921-Word-Crash067.*` 保留。全量语料从 1298 → 排掉 119（原本 ~32）。
+
+## 三、剩下的 9 个是真信号，留着
+
+| 文件                   | 表现                                                             |
+| ---------------------- | ---------------------------------------------------------------- |
+| `47950_lower.doc`      | -82 打不开                                                       |
+| `47950_upper.doc`      | -82 打不开                                                       |
+| `Bug51944.doc`         | -82 打不开                                                       |
+| `2100a8d4….ppt`        | -82 打不开                                                       |
+| `deep-table-cell.docx` | 跑 1.8 min 后**渲染进程崩溃**                                    |
+| WebKit `entry-paths`   | IndexedDB 交接 `page.evaluate: null`                             |
+| WebKit `main-site` ×2  | 编辑器 90s 不 ready；`sdk-all.js … due to access control checks` |
+| Firefox `open-retry`   | SW 拦截 `fonts/076` / `api.js` 时报 unexpected error             |
+
+这轮不动它们——本次改的是"让红代表缺陷"，不是把红消掉。四个 `.doc` / `.ppt` 的 -82 和
+`deep-table-cell.docx` 的崩溃属于 v9 战役方向零的账，WebKit/Firefox 那四条是引擎差异，
+Chromium 门禁看不到。
+
+## 用例固化
+
+`test/unit/workflow-contract.test.ts` 新增一个 `.github/workflows/nightly-corpus.yml` 段：
+
+1. **按 project 跳过，不按 browserName**——扫 `test/e2e/*.spec.ts`，凡是做了
+   `test.use({ ...devices[...] })` 的 spec，禁止出现 `test.skip(({ browserName })`，
+   必须出现 `test.skip(({ projectName })`，并要求 l0 里确有 `projectName` fixture。
+2. **排掉 fuzz 产物、但不排掉真实 bug 文档**——直接从 YAML 里抠出 `CORPUS_EXCLUDE` 编译成
+   正则，对四个应排的文件名断言 `true`、对 `51921-Word-Crash067.doc` / `deep-table-cell.docx` /
+   `Bug51944.doc` 断言 `false`。
+
+两条都做了反向验证：分别退回旧写法后，`vitest run test/unit/workflow-contract.test.ts`
+报 `2 failed | 57 passed`；恢复后 59 passed。
+
+## 教训
+
+一个"红了是信号不是门禁"的套件，如果红的原因里混着基础设施噪音，它就退化成噪音本身——
+连着七晚全红，没人再点开看，那 9 个真信号也就等于没报。**信号源的第一要求是低假阳性，
+不是高灵敏度。**

--- a/test/e2e/lib/l0.ts
+++ b/test/e2e/lib/l0.ts
@@ -276,7 +276,23 @@ async function waitForServer(baseURL: string): Promise<void> {
   }
 }
 
-export const test = base.extend<{ l0: L0Collector; serverUp: void }>({
+export const test = base.extend<{ l0: L0Collector; serverUp: void }, { projectName: string }>({
+  // The name of the project a test is running under. `browserName` cannot
+  // stand in for it: a spec that does `test.use({ ...devices['Pixel 5'] })`
+  // pulls in the device's `defaultBrowserType: 'chromium'`, so under the
+  // nightly's webkit/firefox projects `browserName` reads 'chromium' while
+  // the project is not -- a `browserName !== 'chromium'` guard then never
+  // fires and Playwright tries to launch a browser that job never installed.
+  projectName: [
+    // Playwright rejects anything but a destructuring pattern in this position
+    // ("First argument must use the object destructuring pattern"); empty is
+    // how a fixture says it depends on no other fixture.
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use, workerInfo) => {
+      await use(workerInfo.project.name);
+    },
+    { scope: 'worker' },
+  ],
   // Opt-in per config (playwright.pages.config.ts sets the variable): every
   // other suite is served by something that does not fall over mid-run, and
   // waiting there would only hide a server that failed to start.

--- a/test/e2e/mobile-slide.spec.ts
+++ b/test/e2e/mobile-slide.spec.ts
@@ -19,6 +19,10 @@ import { expect, test } from './lib/l0';
  * repaints on contextlost/contextrestored; the last test drives those events
  * directly, since a real eviction cannot be provoked on demand.
  */
+// Pixel 5 carries `defaultBrowserType: 'chromium'`, so this file launches
+// Chromium under every project -- including the nightly's webkit/firefox ones,
+// which do not install it. The per-describe guards below therefore key on the
+// project name, not on `browserName` (which this line makes read 'chromium').
 test.use({ ...devices['Pixel 5'] });
 
 // Installed in every frame before any page script: the editor lives in a
@@ -44,7 +48,7 @@ const INSTALL_FRAME_FINDER = () => {
 
 test.describe('presentation on a phone-sized viewport (real editor)', () => {
   test.describe.configure({ timeout: 180_000 });
-  test.skip(({ browserName }) => browserName !== 'chromium', 'device emulation needs chromium');
+  test.skip(({ projectName }) => projectName !== 'chromium', 'device emulation needs chromium');
 
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(INSTALL_FRAME_FINDER);
@@ -211,7 +215,7 @@ test.describe('presentation on a phone-sized viewport (real editor)', () => {
  */
 test.describe('other formats on a phone-sized viewport (real editor)', () => {
   test.describe.configure({ timeout: 180_000 });
-  test.skip(({ browserName }) => browserName !== 'chromium', 'device emulation needs chromium');
+  test.skip(({ projectName }) => projectName !== 'chromium', 'device emulation needs chromium');
 
   for (const { type, canvas } of [
     { type: 'docx', canvas: '#id_viewer' },
@@ -262,7 +266,7 @@ test.describe('other formats on a phone-sized viewport (real editor)', () => {
  */
 test.describe('viewport follow on a live editor (real editor)', () => {
   test.describe.configure({ timeout: 180_000 });
-  test.skip(({ browserName }) => browserName !== 'chromium', 'device emulation needs chromium');
+  test.skip(({ projectName }) => projectName !== 'chromium', 'device emulation needs chromium');
   test.use({ viewport: { width: 1280, height: 900 }, isMobile: false, hasTouch: false, deviceScaleFactor: 1 });
 
   test('narrowing a desktop window into a phone-sized one adapts the open document', async ({ page }) => {

--- a/test/unit/workflow-contract.test.ts
+++ b/test/unit/workflow-contract.test.ts
@@ -344,3 +344,54 @@ describe('bin/test-e2e-docker.sh', () => {
     expect(script).toMatch(/playwright test --config playwright\.docker\.config\.ts "\$@"/);
   });
 });
+
+/**
+ * The nightly runs the PR-time specs on two engines the gate does not cover,
+ * and the real-document matrix on a public corpus. Both have a way of going
+ * red for a reason that is not a defect in this repository, and a nightly that
+ * is red every morning is a nightly nobody reads.
+ */
+describe('.github/workflows/nightly-corpus.yml', () => {
+  const src = readFileSync(resolve(ROOT, '.github/workflows/nightly-corpus.yml'), 'utf8');
+  const exclude = new RegExp(/CORPUS_EXCLUDE: "(.*)"/.exec(src)![1].replace(/\\\\/g, '\\'), 'i');
+
+  it('skips a device-emulating spec by project, not by browser name', () => {
+    // `devices['Pixel 5']` carries `defaultBrowserType: 'chromium'`, which wins
+    // over the project's browser -- so under the webkit/firefox projects
+    // `browserName` reads 'chromium', a `browserName !== 'chromium'` guard
+    // never fires, and Playwright tries to launch a browser this job does not
+    // install. That was 16 of the 20 red rows on 2026-08-21.
+    const specs = readdirSync(resolve(ROOT, 'test/e2e'))
+      .filter((file) => file.endsWith('.spec.ts'))
+      .map((file) => ({ file, body: readFileSync(resolve(ROOT, 'test/e2e', file), 'utf8') }))
+      .filter(({ body }) => /test\.use\(\{\s*\.\.\.devices\[/.test(body));
+
+    expect(specs.length).toBeGreaterThan(0);
+    for (const { file, body } of specs) {
+      expect(body, `${file} guards on browserName under a device override`).not.toMatch(
+        /test\.skip\(\(\{ browserName \}\)/,
+      );
+      expect(body, `${file} has no project guard`).toMatch(/test\.skip\(\(\{ projectName \}\)/);
+    }
+    // The fixture the guard reads; `browserName` is built in, this one is ours.
+    expect(readFileSync(resolve(ROOT, 'test/e2e/lib/l0.ts'), 'utf8')).toMatch(/projectName: \[/);
+  });
+
+  it('drops the corpus fuzzer output without dropping real bug-report files', () => {
+    // Byte soup minimized by a fuzzer until it broke a parser: "this editor
+    // will not open it either" is not a finding, and 15 such files were red on
+    // 2026-08-21. The terms have to stay narrow -- a bare `crash` also matches
+    // documents attached to real bug reports.
+    for (const name of [
+      'clusterfuzz-testcase-minimized-POIXWPFFuzzer-4791943399604224.docx',
+      'crash-517626e815e0afa9decd0ebb6d1dee63fb9907dd.docx',
+      'Fuzzed.doc',
+      'poi-fuzz.xls',
+    ]) {
+      expect(exclude.test(`corpus/document/${name}`), `${name} should be excluded`).toBe(true);
+    }
+    for (const name of ['51921-Word-Crash067.doc', 'deep-table-cell.docx', 'Bug51944.doc']) {
+      expect(exclude.test(`corpus/document/${name}`), `${name} should still run`).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
The Nightly corpus workflow has been red **every night since it landed** (8-15 onwards). In run [32519705139](https://github.com/ranuts/document/actions/runs/32519705139), 31 of the 40 red rows were not defects.

## 16 假失败：`devices['Pixel 5']` 把 browserName 变成 chromium

`test/e2e/mobile-slide.spec.ts` 顶上的 `test.use({ ...devices['Pixel 5'] })` 带 `defaultBrowserType: 'chromium'`，压过 project 的浏览器。于是在夜间的 webkit/firefox project 下：实际要启 Chromium（这个 job 只装 webkit+firefox → `Executable doesn't exist`），而三道 `browserName !== 'chromium'` 守卫也失效——`browserName` 同样读成 `'chromium'`。

改为按 project 名判断。Playwright 的 `test.skip` 条件回调只拿得到 fixtures（没有 testInfo），也没有内置的 project fixture，所以在 `test/e2e/lib/l0.ts` 加了一个 worker 级 `projectName`。它不依赖其它 fixture，求值时不会创建 `page`，浏览器压根不启。

## 15 假失败：POI 的 fuzz 语料

`clusterfuzz-testcase-*` / `crash-<sha1>.*` / `Fuzzed.doc` / `poi-fuzz.xls`——被 minimizer 削到最小、专为搞崩解析器而留的字节汤。"本编辑器也打不开"不构成发现。

词刻意窄：拉了 POI test-data 全量核对，`fuzz|crash` 会命中 89 个，其中 `51921-Word-Crash067.doc/.docx` 是真实 bug 报告里的文档。最终 `clusterfuzz|fuzzer|fuzzed|poi-fuzz|crash-[0-9a-f]{6}` 命中 87 个，保留那两个。

## 剩下 9 个真信号，故意留红

四个 `.doc`/`.ppt` 报 -82 打不开、`deep-table-cell.docx` 跑 1.8 min 崩渲染进程、四条 WebKit/Firefox 引擎差异（IndexedDB 交接、`access control checks`、SW 拦截报错）。本次改的是"让红代表缺陷"，不是把红消掉。

## 反向验证（约定 3）

| 状态 | 结果 |
| --- | --- |
| `projectName` 守卫 | 16 skipped |
| 退回 `browserName` | 16 failed |
| chromium project（改后，真 build） | 1 passed |
| 两条新 workflow-contract 用例，退回旧写法 | `2 failed \| 57 passed` |
| 恢复后 | 59 passed |

`test/unit/workflow-contract.test.ts` 新增两条：device-override 的 spec 必须按 `projectName` 跳过、`CORPUS_EXCLUDE` 必须排掉 fuzz 产物且不排掉真实 bug 文档。

记录：`docs/explorations/2026-08-22-nightly-corpus-false-red.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)