### PR TITLE
feat: autosave recovery points, a local history page, and a seven-day window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ notes. Entries describe what users experience, not internal refactors.
 
 ## [Unreleased]
 
+### Added
+
+- **Your edits are kept while you work, and you can get them back.** Every
+  document you edit is now saved to a recovery point inside your own browser --
+  never uploaded, never leaving the device. If the tab closes, the browser
+  crashes, or you simply come back the next day, the editor offers the work
+  back by name and tells you when you made it. The homepage offers it too, so
+  you do not have to remember where you were.
+- **A local history page** at `/history`, linked from the homepage: everything
+  this browser is holding, newest first, searchable by title (any part of the
+  name, in any language), with a delete on every row and a "clear everything"
+  at the top. Rows that hold the only copy of your work -- edits you never
+  exported to disk -- say so.
+- **It clears itself.** A document is deleted seven days after you last edit or
+  open it, automatically, whether or not you visit the page. The rule is stated
+  on the homepage and on the history page, and every row shows how long it has
+  left. Autosave can also be switched off entirely.
+- **Closing a tab with unsaved edits now asks first.** It never did, so a
+  mistaken Cmd+W or Ctrl+R silently threw the session away.
+- **A reload comes back to the same document.** The address bar now carries the
+  document's identity (`?doc=<id>`), so refreshing an unsaved document reopens
+  it instead of starting a blank one, and two files sharing a name stay
+  separate.
+
 ### Known issues
 
 - A report of "An error occurred during the work with the document" while

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ lib/                  # 应用层（纯 TypeScript，只在本站点用）
     guards/               # chrome / shared-worker / fetch-fonts / image-pipeline /
                           # serverless-save / long-action / series-settings /
                           # font-loading / comment-selection / canvas-loss /
-                          # wasm-binary-release
+                          # wasm-binary-release / unload-prompt
     open-state.ts         # 就绪、打开失败、frame 首个错误（三处共用的单一状态源）
     open-failure.ts       # 失败分类、-82 guard、环境类失败重开一次（经 setOpenRunner 注入避免环）
     font-system.ts        # 字体系统就绪判定 + awaitFontSystem（#144）
@@ -81,6 +81,16 @@ lib/                  # 应用层（纯 TypeScript，只在本站点用）
   ui.ts                 # 落地 hero 显隐 + 控制面板（右下角 Menu FAB 已于 2026-08-20 移除）
   analytics.ts          # Cloudflare Web Analytics（刻意不用 GA；线上实际走 CF 面板边缘注入，因此 embed 视图会被计入、/embed-demo 双计，读数规则见 docs/explorations/2026-08-17-analytics-edge-injection-double-count.md）
   pending-open.ts       # 静态落地页经 IndexedDB 交接文件（?open=local）
+  unsaved-guard.ts      # 未保存提示（beforeunload）+ 全局脏位，编辑器 onDocumentStateChange 驱动
+  embed-mode.ts         # isEmbedMode() 单一实现（save-stream / unsaved-guard / history 共用）
+  history/              # 本地历史（自动保存恢复点），2026-08-22
+    db.ts                 # IndexedDB schema：docs（元数据）+ blobs（字节）两个 store
+    store.ts              # CRUD、内存分页与标题子串搜索、每篇 3 rev、七天过期、配额降级
+    autosave.ts           # 节拍器：脏位 + 空闲 + 间隔三重条件，visibilitychange 补一刀，Web Locks 互斥
+    session.ts            # 会话身份：mint docId 并写进 ?doc=<id>
+    recovery.ts           # 启动恢复条（Office Document Recovery 模型）
+    types.ts / index.ts   # 记录形状与保留期工具 / 对外装配（含 savedToDisk 回调注入）
+  history-page.ts       # /history 页面（第三个 vite entry，见 history.html）
   sw-update.ts          # SW 更新策略的编辑器一侧（有文档打开时不提升 worker）；落地页一侧在 public/sw-register.js
   agent-plugin/         # Agent 协同编辑：editor-bridge（直调 window.editor）、tools、ui/
 packages/             # pnpm workspace，供 ran 生态三处站点共享（包名 @ranuts/*）
@@ -99,7 +109,8 @@ content/              # 生成页面的 markdown 源（content/<locale>/*.md，f
 docs/                 # embed-api / fonts 文档、explorations/（每次改动的记录）、superpowers/plans/
 index.ts              # 编辑器入口（初始化事件、UI、PWA），挂在 editor.html
 index.html            # `/`：静态落地页（无编辑器 bundle；CTA 跳 /editor，旧深链内联脚本重定向）
-editor.html           # `/editor`：编辑器页面（?new= ?file= ?src= ?embed=1 ?open=local）
+editor.html           # `/editor`：编辑器页面（?new= ?file= ?src= ?embed=1 ?open=local ?doc=<id>）
+history.html          # `/history`：本地历史页（noindex，只读 IndexedDB 元数据，不加载编辑器）
 ```
 
 ---
@@ -229,6 +240,7 @@ test/setup/vitest.ts          # 全局 mock：matchMedia、URL.createObjectURL�
 | 失败与守卫        | `open-failure`（-82 可见 + 保存快速拒绝，兼作 L0 自检）、`comment-bulk-actions`（守卫 8）、`wasm-memory`（守卫 10：40 MB x2t 二进制用完即还）                                                                                                                                                                                                            |
 | 视觉 / 性能       | `visual-roundtrip`（无基线：原始 vs 存回再打开逐像素）、`slow-network` _opt-in_ `SLOW_NET=1`                                                                                                                                                                                                                                                             |
 | 交互面（策略 §9） | `api-surface` _opt-in_ `API_SWEEP=1`、`shortcut-surface` _opt-in_ `SHORTCUT_SWEEP=1`、`ui-crawl` _opt-in_ `UI_CRAWL=1`（逐页签点遍工具栏按钮，归因到按钮）、`monkey` _opt-in_ `MONKEY=1`（定种子随机序列，可精确回放）                                                                                                                                   |
+| 本地历史          | `history-page`（分页/中文子串搜索/删除/清空/七天过期/首页披露）、`autosave-recovery`（真实编辑器：编辑→隐藏页面→快照→恢复条→存回；`?doc=` 刷新回同一篇；embed 不写历史）                                                                                                                                                                                 |
 | 真实语料          | `corpus` _opt-in_ `CORPUS_DIR=…`（见上）                                                                                                                                                                                                                                                                                                                 |
 
 另有三套独立配置：`playwright.pages.config.ts`（`bin/build.sh` + `wrangler pages dev`，
@@ -512,9 +524,27 @@ docs/explorations/2026-08-19-ci-e2e-sharding.md。
    在没有该修复时同样全绿（它其实被另一处改动覆盖了），`layout.rightMenu`
    单向失效的用例也是宽屏挂载、根本走不到出问题的分支。反向验证的结论
    （"去掉 X 后用例 Y 变红"）写进 PR 说明与 docs/explorations 记录。
-6. **循环依赖处理**：`onlyoffice-editor.ts` 与 `converter.ts` 之间通过回调注入（`setConverterCallbacks`）解耦；`ui.ts` 与 `document.ts` 之间通过 `setUICallbacks` 解耦
-7. **编辑器操作队列**：`createEditorInstance` 内部有 `editorOperationQueue`，防止并发创建/销毁编辑器
-8. **.claude/ 目录**：已加入 `.gitignore`，不提交本地 Claude Code 配置
+6. **本地历史（自动保存恢复点，2026-08-22 起）**：定位是 AutoRecover 而**不是** AutoSave——
+   快照只进本机 IndexedDB，永远不动用户磁盘上的文件，也**不清除未保存提示**（只有真正导出到
+   磁盘才清）。四条硬约束，改这块前先读
+   docs/explorations/2026-08-22-autosave-history-implementation.md：
+   1. **身份是 `?doc=<id>`，不是文件名**。会话在挂载前 mint id 并写进地址栏；按标题复用行
+      会把无关文档的历史合并（每个新建空文档都叫 `New_Document.docx`）。一行 = 一次编辑会话；
+      只打开不编辑不留行（行由第一次快照创建）。
+   2. **七天自动清除**，从 `max(updatedAt, lastOpenedAt)` 起算，在启动、每次写快照、
+      打开历史页三处清扫——只在历史页清扫等于没有清扫。这个窗口是对用户的承诺，
+      写在首页 HTML（不是脚本生成）与历史页每一行的倒计时里，改数字要三处一起改。
+   3. **不能自己调 `asc_DownloadAs`**：没有 in-flight 请求时 `routeSavedFile` 会直接把
+      字节存到磁盘（用户会收到一堆莫名下载）。一律走 `requestSaveDocument`，
+      被用户的保存占用时跳过这一拍。
+   4. **embed 模式与只读一律不写**；两个标签页开同一 id 由 Web Locks 互斥，拿不到锁的那个
+      不写快照（否则两边轮流覆盖，比没有历史更糟）。
+      节拍是 90s 间隔 + 2s 空闲 + 脏位三重条件，另加 `visibilitychange → hidden` 补一刀
+      （`beforeunload` 里发起导出来不及）。**E2E 等快照的窗口必须小于 90s**，否则周期 tick
+      会替你把用例变绿，测不到它声称测的分支（踩过）。
+7. **循环依赖处理**：`onlyoffice-editor.ts` 与 `converter.ts` 之间通过回调注入（`setConverterCallbacks`）解耦；`ui.ts` 与 `document.ts` 之间通过 `setUICallbacks` 解耦
+8. **编辑器操作队列**：`createEditorInstance` 内部有 `editorOperationQueue`，防止并发创建/销毁编辑器
+9. **.claude/ 目录**：已加入 `.gitignore`，不提交本地 Claude Code 配置
 
 ---
 

--- a/docs/explorations/2026-08-22-autosave-history-evaluation.md
+++ b/docs/explorations/2026-08-22-autosave-history-evaluation.md
@@ -1,0 +1,355 @@
+# 自动保存到 IndexedDB + 本地文档历史页：可行性评估
+
+日期：2026-08-22
+状态：评估，未实现
+
+## 零、结论先说
+
+方向对，痛点真实（现在刷新一次，未导出的编辑全没了），但**难点不在存储，在导出**。
+
+我们的"一次快照"不是 Excalidraw 那种几十 KB 的 JSON.stringify，而是一次
+`asc_DownloadAs` 全量导出：SDK 序列化 + x2t 转换 + ArrayBuffer 跨 frame 传回，
+而 x2t 每次要 283 MB 堆。所以照搬"每次变更防抖 300ms 落盘"的做法会直接把编辑器
+拖垮，移动端还会撞上 #145 的 canvas 丢失。
+
+另外这件事会改变产品定位的一句话：从"关掉标签页什么都不剩"变成"你的文档留在
+这台机器上"。这是新增的隐私面，必须是显式的、可关的、可清空的。
+
+还有一层比自动保存更便宜、我们却完全没做：**离开前的未保存提示**（`beforeunload`，
+全仓零命中）。手滑关标签页目前是静默失去一切，而挡住它只要几十行、不需要任何存储。
+这一步应该独立、立刻做。
+
+建议按"四层防线"铺（见下节），一期先做恢复点 + 找回入口，顺便拿到真实的导出耗时数据，
+再决定二期的历史库长什么样。
+
+## 一、"关掉网页就没了"是网页应用的通病：业界的四层防线
+
+这个痛点不是我们独有的，凡是有编辑态的网页应用都会碰上，而业界的解法**是叠起来用的四层，
+不是四选一**。先把"丢"拆开看：手滑关标签页、刷新、浏览器崩溃/OOM、手机切后台被杀、
+换台机器回来——每一种的解法都不同层。
+
+### 第 0 层：离开前拦住（beforeunload）
+
+最便宜、最普遍、也最被低估的一层。GitHub 的评论框、Gmail、Jira、Notion、几乎所有在线表单
+都有：有未保存改动时挂 `beforeunload`，浏览器就会在关闭/刷新前弹一次确认。
+代价是几十行代码，不需要任何存储，不涉及任何隐私权衡。
+
+**本站现在完全没有**（全仓 grep `beforeunload` 零命中）。也就是说用户手滑按了 ⌘W，
+浏览器一声不响就关了，编辑器里几小时的改动直接蒸发——这是当前最大的一处敞口，
+而且它跟自动保存是两件独立的事，不该等自动保存做完才做。
+
+限制要知道：提示文案不能自定义（各家浏览器统一措辞）；页面必须有过用户交互
+（sticky activation）才会弹；移动端切走/杀进程不触发。所以它挡的是"手滑"，
+挡不住崩溃和没电——那两种要靠下面的层。
+
+### 第 1 层：直接写回用户磁盘（File System Access）
+
+让网页表现得像桌面 Office：打开文件时就拿到一个可写句柄，之后的保存直接覆盖磁盘上的原文件。
+网页关不关都无所谓，**因为文件本来就在用户磁盘上**。
+
+关键的一点是 `FileSystemFileHandle` **可以存进 IndexedDB**，下次回来用
+`queryPermission()` / `requestPermission()` 续上，于是"最近文件列表 + 一键继续编辑原文件"
+就成立了——draw.io、VS Code Web 走的都是这条路。Chrome 122 起还支持持久权限
+（用户可以授予永久访问，不必每次点）。
+
+覆盖面：Chromium 桌面（Chrome / Edge / Opera 86+）。Safari 完全不支持本地磁盘 picker
+（只有 OPFS），Firefox 也不支持，且 Mozilla 的标准立场是反对。所以这是增量能力，不是底座。
+
+本项目其实已经在用 ranuts 的 `saveFileToDisk`（File System Access + 锚点兜底），
+但**每次保存都重走一遍 picker、不留句柄**。把句柄留下来，这一层就成立一大半。
+
+而且这一层**对隐私最友好**：数据回到用户自己的文件系统，浏览器里不留副本，泄露面从源头就不产生。
+
+### 第 2 层：浏览器内恢复点（IndexedDB / OPFS）
+
+第 1 层覆盖不到的场景才需要它：Safari / Firefox / 移动端、用户拒绝授权、
+`?new=docx` 这种还没落过盘的新文档、以及崩溃时那一刻。这就是本文讨论的主体，
+定位是 AutoRecover 而不是 AutoSave（见下一节）。
+
+### 第 3 层：找回入口（存了不等于找得回）
+
+用户主动关掉标签页、第二天从域名根回来时，页面上必须有线索，否则恢复点等于不存在。
+业界三种入口，按需要的规模依次上：
+
+1. **启动时的恢复提示**——编辑器页 boot 读元数据（不读 blob），有较新的未导出快照就挂一条
+   恢复条："上次编辑的《x.docx》有未保存的改动：恢复 / 丢弃"。这就是 Office 的
+   Document Recovery 窗格、WordPress 的"检测到比当前版本更新的自动草稿，要恢复吗"。
+   注意 WordPress 那句提示的重点是**版本比较**（哪一份更新），不是"有个备份"——
+   对应到我们这里是"磁盘上那份 vs 浏览器里这份谁更新"，恢复条上要显示时间差。
+2. **落地页的一行"继续上次编辑"**——静态页不带 editor bundle，但读 IndexedDB 元数据
+   只要几 KB 的独立小脚本，形态跟现有的 `open-local.js` / `landing-prefetch.js` 完全同构。
+3. **`/history` 路由页**——条目多起来之后才需要，分页 / 搜索 / 批量管理。
+
+要承认一件事：恢复点不止一条时（用户先后编辑过三个文档），**那条恢复条本身就是个迷你列表**，
+Office 的恢复窗格也是列表。所以一期真正省掉的不是"列表"，而是"路由页 + 分页 + 搜索"。
+
+由此推出一期的一条硬约束：**存储层必须按最终形态写，不能为"只有一篇"做简化**。
+如果图省事做成固定 key 的单条快照，二期就得推倒重来，还要多写一次迁移。
+
+### 关掉网页那一刻的时序
+
+导出是异步的，`beforeunload` 里现发起基本来不及；移动端切后台被杀更是完全没有机会。
+所以主保障是 `visibilitychange → hidden` 那一拍（后台冻结前通常还有时间）加上周期性快照本身，
+最坏情况丢失一个快照间隔的编辑量——跟 Office AutoRecover 默认 10 分钟同理，可接受，
+但要在 UI 上说清楚"这是恢复点，不是备份"。
+
+## 二、四种持久化机制流派
+
+### 1. 云 + 操作日志：Google Docs、Office AutoSave
+
+Google Docs 离线把编辑捕获在本地（IndexedDB）作为操作队列，联网后同步；
+Office 的 AutoSave 只在文件存在 OneDrive/SharePoint 时才工作。
+
+这一派需要服务器，本项目直接出局。但有一条**必须借鉴的概念区分**：Office 里
+AutoSave 和 AutoRecover 是两件不同的事——AutoRecover **不是保存**，它是"把最近的
+改动记到另一个地方"，默认 10 分钟一次，纯本地，只在崩溃后问你要不要恢复。
+
+我们要做的其实是 AutoRecover，不是 AutoSave。这个区分决定了后面所有的取舍：
+恢复点可以慢、可以有损（只保最近几个）、可以不覆盖原文件。
+
+### 2. 全量快照 + 防抖：Excalidraw、tldraw
+
+Excalidraw 的 `LocalData` 类统一编排防抖落盘，在 `onChange` / `visibilitychange` /
+`unload` 三处触发；场景元素和 appState 走 localStorage，**二进制文件（图片）和素材库
+才走 IndexedDB**（用 idb-keyval）。协作时暂停本地写。
+
+tldraw 更省事：给 `<Tldraw persistenceKey="...">` 一个 key 就自动落 IndexedDB 并跨标签页
+同步；自定义后端则用 `getSnapshot` / `loadSnapshot`，快照分 `document`（形状/页面，存服务器）
+和 `session`（相机、选区、UI 状态，只存本地）。store 监听器用 throttle 压频率。
+
+**它们敢高频是因为快照便宜。** 这一派可借鉴的是形态（防抖 + 三处触发点 + 会话状态与
+文档状态分开），不是频率。
+
+### 3. 增量 op log + 周期压实：Yjs 的 y-indexeddb
+
+每次 update 往 store 追加一条记录，攒到阈值就把全部 update 合并成一个 snapshot、
+清掉旧记录（compaction）。优点是写入极便宜（只写 delta），代价是需要一套可重放的
+操作模型。
+
+对我们来说这条路要求 sdkjs 的协作 changes 流能在离线单机被重放——**未验证**，风险高，
+放三期。
+
+### 4. 只存句柄，不存内容：VS Code Web 一类的"最近打开"
+
+把 `FileSystemFileHandle` 存进 IndexedDB，列表只有元数据；重新打开时向用户要一次
+读权限。零存储成本、零新增隐私面，但只有 Chromium 系有效（Safari/Firefox 无
+File System Access 写句柄），而且**它不解决"刷新丢失未保存改动"**——句柄指向的是
+用户磁盘上那份旧文件。
+
+可以作为历史列表的补充维度（"最近打开过的本地文件"），不能作为主方案。
+
+### 存储侧的通用共识
+
+- 配额差异很大：Chrome 约给可用磁盘的 60%（跨源共享），Firefox 约 10%/eTLD+1，
+  Safari 最保守，且**7 天没访问就可能整站清掉**。
+- 写之前用 `navigator.storage.estimate()` 估，写的时候 catch `QuotaExceededError`。
+- `navigator.storage.persist()` 可以把站点提升成持久化（不参与自动驱逐）；Chrome 按
+  参与度自动判定，Firefox 会弹权限。web.dev 的建议是**只给"丢了就是重大损失"的数据
+  申请**——本地文档恰好符合，但申请时机应该在用户第一次真的产生了历史之后，不是启动就问。
+- 官方口径都强调：别把浏览器存储当唯一副本。我们没有第二副本，所以这句要翻译成产品语言
+  写进 UI——"这是恢复点，不是备份，请照常导出到磁盘"。
+
+## 三、放到本项目上，四个真问题
+
+### 问题 1：我们的快照贵，而且 SDK 自带的那条路已经被我们焊死了
+
+`lib/onlyoffice/guards/serverless-save.ts`（守卫 5）已经把 `autoSaveGap` /
+`autoSaveGapFast` / `autoSaveGapRealTime` 全设成 0，并把 `asc_setAutoSaveGap` 钉死成
+no-op。原因是无服务器下 SDK 的 autosave loop 会拿到假的保存成功，把
+`isDocumentCanSave` 翻回 false，导致 Save 按钮和 Ctrl+S 永久变灰。
+
+**所以自动保存不能靠"把 gap 调回去"来实现**，必须在应用层自己造节拍器，走
+`requestSaveDocument`。改这里之前先读那个守卫的注释，别把它撤了。
+
+触发信号有现成的：vendor 的 `api.js` 暴露 `onDocumentStateChange` 事件（我们目前
+没有监听）。节拍应该是三重条件的合取，而不是单纯的定时器：
+
+- 文档被改过（`onDocumentStateChange` 置脏位）
+- 距上次快照超过 T（建议起步 60~120s，按实测调）
+- 当前空闲（`requestIdleCallback` / 距最后一次输入 >2s），且没有 in-flight 的保存
+
+再加两个必存点：`visibilitychange → hidden`、`beforeunload`（后者只能尽力，导出是
+异步的，多半来不及——所以真正的保障是前两个，unload 只当兜底）。
+
+**成本目前是未知数**，这是一期最该先量的东西。`bin/corpus-report.mjs` 的表里已经有
+`save p50/p95 (ms)` 一栏，跑一轮语料就有分布。
+
+可能的加速路径（**待验证，别当结论用**）：导出成内部 bin 格式而不是 docx。
+`lib/file-types.ts` 里已经有 `DOCY: 4097` / `XLSY: 4098`（PPT 侧常量表里还没有）。
+bin 是 SDK 自己的序列化产物，理论上不经过 x2t，重开时走 `openDocument({buffer})`。
+要实测三件事：`asc_DownloadAs(DOCY)` 是否真的绕过 x2t、产物能否被重新打开、体积多大
+（bin 通常比 docx 大，因为不压缩）。#113 那次已经确认过 file-stream 通道上能出现带
+`DOCY` 头的字节，所以这条路至少不是凭空想的。
+
+### 问题 2：保存通道是单例，而且没人接的字节会直接下载到磁盘
+
+`lib/onlyoffice/save-stream.ts` 里 `embeddedSaveRequest` 全局只有一个；只读、打开失败、
+已有 in-flight 请求都会立即 reject。更要紧的是 `routeSavedFile()`：当没有 in-flight
+请求时，它会调 `saveFileToDisk` —— 也就是说**自动保存如果自己去调 `asc_DownloadAs`，
+用户会莫名其妙收到一堆下载**。
+
+所以自动保存必须：
+
+- 走 `requestSaveDocument`，不自己碰 `asc_DownloadAs`；
+- 用户手动保存优先，自动保存遇到 in-flight 就跳过这一轮（不排队，下一拍再说）；
+- embed 模式（`isEmbedMode()`）一律不写历史——那是宿主页的文档，不该进我们的库；
+- 只读、打开失败的文档不写。
+
+### 问题 3：隐私面——已定调，靠显眼的删除与清空
+
+站点现在的卖点是"文件从不离开你的设备"，隐含"关掉就没了"。加了历史之后，共享电脑、
+演示机、公用机上多出一个泄露面。
+
+**处理方式已经拍板：默认开启，用显眼的单条删除 + 一键全部清空来解决**，不靠默认关闭
+或层层询问来回避（那会让功能对绝大多数人等于不存在，而痛点恰恰发生在用户还没去翻设置的时候）。
+
+要做到"删了就是真删"，有三件事不能省：
+
+1. **清空要连字节一起删**——`docs` 元数据、`blobs` 字节、存下来的 FSA 句柄、
+   （如果日后用了）OPFS 文件，一次全清。只删索引等于没删，磁盘上的痕迹还在。
+2. **不做标记删除**，删除即落库，并且删完立刻能在 UI 上看到条目消失。
+3. **入口要显眼且随处可达**——历史页有"清空全部"，列表每条有删除，
+   连启动时的恢复条上也要能直接"丢弃"，不能只藏在设置里。
+
+另外保留一个总开关（关闭时同时清空），成本很低。无痕模式下 IndexedDB 会话结束即清，
+本来就符合预期，不用特殊处理；IndexedDB 不可用时静默降级（`pending-open.ts` 已是这个写法，照抄）。
+
+**顺带一提**：第 1 层（写回磁盘）从根上就不产生浏览器副本——能走那条路的用户，
+泄露面比"存在浏览器里再提供删除"小一圈。这也是把它排在第 2 层前面的原因之一。
+
+### 问题 4：两个标签页开同一篇，自动保存会互相覆盖
+
+这是自动保存独有的新问题：没有自动保存时，两个标签页各改各的、谁按保存谁的算；
+有了自动保存，两边会轮流把对方的快照盖掉，**比不自动保存更糟**。
+
+业界标准答案是 Web Locks API：`navigator.locks.request('doc:<id>', …)` 拿文档级锁，
+拿不到就退化（提示"另一个标签页正在编辑"，本页不写快照）。tldraw 那一派则用
+BroadcastChannel 做跨标签同步。我们一期至少要有互斥 + 提示，同步可以不做。
+
+## 四、数据模型
+
+两个 store，**元数据和字节必须分开**——这是列表页快不快的分水岭，列表只读元数据，
+不会把几十 MB 的 blob 拖进内存。
+
+```
+docs   (keyPath: id)
+  id, title, titleLower, ext, docType, size, origin('local'|'url'|'new'),
+  createdAt, updatedAt, lastOpenedAt, revCount
+  index: by_updatedAt, by_titleLower
+
+blobs  (keyPath: [docId, rev])
+  docId, rev, savedAt, bytes(Blob), byteLength
+  index: by_docId
+```
+
+存 `Blob` 而不是 `ArrayBuffer`：Chrome/Firefox 下 Blob 走独立的 blob 存储、不必整个进
+主线程内存，读的时候才 `arrayBuffer()`。
+
+**分页别用 offset。** IndexedDB 没有便宜的 count-skip，正确做法是 `by_updatedAt` 上
+`openCursor(range, 'prev')` + `advance(n)`，或 keyset（记住上一页最后的
+`[updatedAt, id]` 作为下一页的 `IDBKeyRange.upperBound`）。不过元数据每条 <1KB，
+几千条**全量读进内存再排序过滤也完全够用**——一期就这么做，别一上来上游标，量大了再换。
+
+**标题搜索：IndexedDB 只能做前缀范围查询**（`IDBKeyRange.bound(q, q + '￿')`），
+子串和中文分词都做不到。业界常规两条路：内存 `includes()` 过滤（几千条是微秒级），
+或建 n-gram token 索引。一期直接内存过滤，别引 flexsearch 那一套。
+
+**字节放 IndexedDB 还是 OPFS？** OPFS 对大二进制明显更快（不走结构化克隆，可流式与随机写），
+现代浏览器都支持（Chrome/Edge、Firefox 111+、Safari 15.2+），业界拿它跑 SQLite WASM、
+视频编辑、模型权重。但我们的写入是**分钟级、一次几 MB**，不是高频 I/O，IndexedDB 那点
+结构化克隆成本完全吃得下；而 OPFS 要自己管目录、孤儿文件清理、以及与元数据的一致性。
+建议一期全放 IndexedDB，把 OPFS 记成"实测发现写入卡主线程再换"的备选，别为了新技术提前上。
+（iOS Safari 在存储压力下对两者都会激进驱逐，没拿到 `persist()` 谁也保不住。）
+
+**保留策略是必须的，不是可选项**，否则迟早 `QuotaExceededError`：
+
+- 每个文档最多留 N 个 rev（建议 3：最新 + 2 个恢复点），超了删最旧；
+- 全库上限取 `min(500 MB, quota × 50%)`；
+- 超限按 `lastOpenedAt` LRU 淘汰整个文档；
+- 写前 `estimate()`，写时 catch 配额错误 → 先淘汰再重试一次，仍失败就关掉自动保存
+  并提示用户（**不能静默失败**——静默失败的自动保存比没有自动保存更危险）。
+
+## 五、历史页放哪
+
+首页是不带 editor bundle 的静态落地页，这条不能破。历史页应该是**第三个 vite entry**
+（`history.html` → `/history`），只依赖 IndexedDB 读元数据 + ranui 组件，几 KB，
+不要塞进 `editor.html`，也不要塞进 `index.html`。
+
+打开一条历史，最省的做法是复用现成的 `?open=local` 交接：历史页把选中的 rev 写进
+`document-handoff` 的 `pending` key，跳 `/editor?open=local`，编辑器一行不用改。
+但那样会丢掉"这是历史里的哪一条"的身份，之后的自动保存会新建一条记录。所以更好的是
+加一条 `?open=history&id=<id>` 分支，`lib/pending-open.ts` 里多一个读法，编辑器侧记住
+`docId` 后续覆盖同一条。
+
+顺带要跟的（漏一个 CI 就红）：
+
+- 双语（`public/zh-CN/` 那侧同名页）+ 首页卡片入口 + `sitemap.xml` + `llms.txt`，
+  否则 `test/unit/landing-pages.test.ts` 先红；
+- `history.html` 属于"固定名、随部署变化"的文件 → `_headers` 的 no-cache 组 +
+  `sw.js` 的 `DEPLOY_COUPLED` 两处都要加（`hosting-contract.test.ts` /
+  `sw-routing.test.ts` 钉着）；
+- 镜像那侧的 `sws.toml` 同步。
+
+## 六、分期建议
+
+**第 0 步：`beforeunload` 未保存提示（现在就能做，独立于一切）**
+零存储、零隐私成本、几十行代码，挡住"手滑关标签页"这一类最常见的丢失。不要等自动保存。
+
+**一期：存储层（最终形态）+ 自动快照 + 找回入口**
+两个 store、索引、rev、保留策略、配额降级全部按最终形态落地；UI 只做两件事——编辑器页的
+恢复条、落地页的"继续上次编辑"；再加 Web Locks 的多标签互斥，以及恢复条上就能"丢弃"的删除入口。
+不做路由页、不做分页搜索。这一步消掉"刷新/关页全丢"，
+同时量出真实的导出耗时与内存曲线，为二期定频率、并回答要不要走 DOCY。
+
+**一期半（可选，仅 Chromium）：留住 File System Access 句柄**
+把打开/保存时拿到的句柄存进 IndexedDB，实现"继续编辑并写回原文件"。这一层能覆盖到的用户，
+浏览器里根本不需要留副本，隐私面最小。Safari/Firefox 无此能力，所以它只能是增量。
+
+**二期：`/history` 完整管理页**
+路由页、分页、标题搜索、单条删除、清空、双语落地页契约（sitemap / llms.txt / 首页卡片）。
+因为一期的数据层已经是最终形态，这一期基本只是 UI。
+
+**三期（仅当一期数据说明全量导出太贵）**
+DOCY/XLSY 内部格式，或 changes op log 重放（y-indexeddb 那一派）。
+
+**另一种切法**：如果你觉得"没有列表页就等于没做完"，可以把二期的**骨架**并进一期——
+路由页 + 双语 + SW/headers 契约是一次性成本，早做晚做一样贵，晚做还要再跑一遍那套契约
+测试；只把分页和搜索留到条目真的多起来再补。代价是一期变长，且频率参数还没实测就要定。
+
+## 七、要固化的用例（CLAUDE.md 约定 5）
+
+- 单测：store 的 CRUD、分页（游标或内存路径）、搜索过滤、保留策略的淘汰顺序、
+  `QuotaExceededError` 的降级路径、embed/只读不写历史的判定。
+- E2E（真实编辑器）：编辑 → 等一拍自动保存 → reload → 恢复后内容一致；
+  历史页的分页/搜索/删除/清空；`?open=history` 打开后继续编辑仍覆盖同一条。
+- `beforeunload`：有未保存改动时拦截、无改动时不拦截（Playwright 可用 dialog 事件断言）。
+- 多标签互斥：两个 page 开同一 id，只有一个在写快照。
+- 删除与清空：删除后元数据与字节都取不到（不是只从列表里消失）。
+- **反向验证**：把自动保存的写入摘掉，reload 恢复用例必须变红；把保留策略摘掉，
+  配额用例必须变红。结论写进 PR 说明。
+
+## 八、还没答的问题
+
+1. 一次 `asc_DownloadAs` 在典型 docx/xlsx/pptx 上要多久、内存峰值多少（跑语料就有）。
+2. `DOCY`/`XLSY` 是否绕过 x2t、产物能否重新打开、体积比 docx 大多少。
+3. PDF、只读、新建空文档要不要进历史（我倾向：新建要，只读不要，PDF 看它是否可编辑）。
+4. `visibilitychange → hidden` 那一拍在移动端到底还剩多少时间能跑完一次导出（要实测，
+   不够的话移动端就得把快照间隔压短，用频率换成功率）。
+5. 第 1 层（FSA 句柄）值不值得提前到一期——它对 Chromium 用户的收益比恢复点大，
+   但对 Safari/Firefox 用户是零。
+
+## 参考
+
+- [Local Storage and Auto-Save | excalidraw/excalidraw (DeepWiki)](https://deepwiki.com/excalidraw/excalidraw/6.4-local-storage-and-auto-save)
+- [Persistence • tldraw Docs](https://tldraw.dev/docs/persistence)
+- [Architecture | yjs/y-indexeddb (DeepWiki)](https://deepwiki.com/yjs/y-indexeddb/2-architecture)
+- [Storage quotas and eviction criteria — MDN](https://developer.mozilla.org/en-US/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria)
+- [Persistent storage — web.dev](https://web.dev/articles/persistent-storage)
+- [Updates to Storage Policy — WebKit](https://webkit.org/blog/14403/updates-to-storage-policy/)
+- [AutoSave vs AutoRecover in Microsoft Office — Office Watch](https://office-watch.com/2025/about-microsoft-office-autosave-autorecover-and-other-save-options/)
+- [Persistent permissions for the File System Access API — Chrome for Developers](https://developer.chrome.com/blog/persistent-permissions-for-the-file-system-access-api)
+- [File System Access API — caniuse](https://caniuse.com/native-filesystem-api)
+- [WordPress autosave / local backup restore prompt — WP Training Manual](https://wptrainingmanual.com/wordpress-tutorials/autosave-post-revisions/)
+- [LocalStorage vs IndexedDB vs OPFS vs WASM-SQLite — RxDB](https://rxdb.info/articles/localstorage-indexeddb-cookies-opfs-sqlite-wasm.html)
+- [Window: beforeunload event — MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event)
+- [Web Locks API — MDN](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API)

--- a/docs/explorations/2026-08-22-autosave-history-evaluation.md
+++ b/docs/explorations/2026-08-22-autosave-history-evaluation.md
@@ -1,7 +1,8 @@
 # 自动保存到 IndexedDB + 本地文档历史页：可行性评估
 
 日期：2026-08-22
-状态：评估，未实现
+状态：评估 → 已实施（见 [实施记录](./2026-08-22-autosave-history-implementation.md)，
+其中第三节修正了本文"按文件名复用历史行"的设计，第四节补上了本文没有的七天保留窗口）
 
 ## 零、结论先说
 
@@ -214,6 +215,8 @@ bin 是 SDK 自己的序列化产物，理论上不经过 x2t，重开时走 `op
 另外保留一个总开关（关闭时同时清空），成本很低。无痕模式下 IndexedDB 会话结束即清，
 本来就符合预期，不用特殊处理；IndexedDB 不可用时静默降级（`pending-open.ts` 已是这个写法，照抄）。
 
+**已实施**：默认开启 + 历史页每行删除 + 一键清空 + 七天自动清除（见实施记录第四节）。
+
 **顺带一提**：第 1 层（写回磁盘）从根上就不产生浏览器副本——能走那条路的用户，
 泄露面比"存在浏览器里再提供删除"小一圈。这也是把它排在第 2 层前面的原因之一。
 
@@ -242,8 +245,10 @@ blobs  (keyPath: [docId, rev])
   index: by_docId
 ```
 
-存 `Blob` 而不是 `ArrayBuffer`：Chrome/Firefox 下 Blob 走独立的 blob 存储、不必整个进
-主线程内存，读的时候才 `arrayBuffer()`。
+~~存 `Blob` 而不是 `ArrayBuffer`~~ —— **实施时改成了 typed array**：字节从编辑器 frame
+过来就是 ArrayBuffer、回去也是 ArrayBuffer，Blob 只是入口包一层、出口再异步拆一层；
+而且它是所有 structured clone 实现都忠实往返的形状（fake-indexeddb 就还不出 Blob）。
+见实施记录。
 
 **分页别用 offset。** IndexedDB 没有便宜的 count-skip，正确做法是 `by_updatedAt` 上
 `openCursor(range, 'prev')` + `advance(n)`，或 keyset（记住上一页最后的

--- a/docs/explorations/2026-08-22-autosave-history-implementation.md
+++ b/docs/explorations/2026-08-22-autosave-history-implementation.md
@@ -1,0 +1,129 @@
+# 自动保存与本地历史：实施记录
+
+日期：2026-08-22
+分支：`feat/autosave-history`
+评估文档：[2026-08-22-autosave-history-evaluation.md](./2026-08-22-autosave-history-evaluation.md)
+
+## 做了什么
+
+评估里排的四层防线，这轮落了三层半：
+
+| 层                           | 状态                                                                   |
+| ---------------------------- | ---------------------------------------------------------------------- |
+| 第 0 层 离开前拦截           | 已做（`lib/unsaved-guard.ts`），另带出 vendor 冲突一处（见下）         |
+| 第 1 层 写回磁盘（FSA 句柄） | **未做**，留在评估文档里的"一期半"                                     |
+| 第 2 层 浏览器内恢复点       | 已做（`lib/history/`，两个 store、保留策略、配额降级、Web Locks 互斥） |
+| 第 3 层 找回入口             | 已做（编辑器恢复条、落地页"继续编辑"、`/history` 完整管理页）          |
+
+外加评估当时没写、由用户在实施中提出的两条，都属于"没有它这个功能是错的"：
+
+- **文档身份用 id，不用标题**（下面第三节）
+- **七天自动清除**，且必须写在用户看得见的地方（下面第四节）
+
+## 一、第 0 层带出的问题：vendor 也挂了 beforeunload
+
+加完 `beforeunload` 守卫，E2E 的 L0 fixture 立刻红了一条：
+
+```
+Blocked attempt to show multiple 'beforeunload' confirmation panels for a single navigation.
+```
+
+查 vendor：`web-apps/apps/documenteditor/main/app.js` 在可编辑时会
+`window.onbeforeunload = onBeforeUnload`——编辑器 iframe 里本来就有一个。
+
+重复只是症状，真问题是**哪一个说的是真话**。vendor 那个读的是 SDK 自己的
+"document modified" 账本，而守卫 5（serverless save）把 Save/Ctrl+S 改道到
+`asc_DownloadAs`，SDK 的账本永远不知道文档已经保存了——于是用户存过盘之后它照样弹。
+那是训练用户"闭着眼睛点确认"的最快方法。
+
+所以加了**守卫 11**（`guards/unload-prompt.ts`）：用 `defineProperty` 吃掉 frame 里的赋值，
+让宿主窗口成为唯一发声的一方；宿主那个是被真实导出清掉的。
+
+## 二、存储层的两个非显然选择
+
+**快照存 `Uint8Array` 而不是 `Blob`。** 评估文档原本推荐 Blob（浏览器可以不把它读进 JS 堆）。
+写单测时发现 fake-indexeddb 不能忠实往返 Blob（读回来的对象没有原型），这本来只是测试问题，
+但顺着想了一遍：字节从编辑器 frame 过来就是 ArrayBuffer，回去也是 ArrayBuffer，
+Blob 只是在入口包一层、出口再异步拆一层。改存 typed array，少一次转换，
+且它是所有 structured clone 实现都忠实往返的形状。评估文档已同步更正。
+
+**标题搜索在内存里做。** IndexedDB 的 key range 只能前缀匹配——"report" 匹配不到
+"Quarterly Report"，中文更是完全没戏。元数据每条不到 1 KB，全量读出来 `includes()`
+既简单又更强。E2E 里专门有一条用中文子串钉住。
+
+## 三、身份：id 而不是标题（实施中修正）
+
+第一版用 `findDocByTitle` 复用行：同名文件继续写同一条历史。用户当场指出这不成立——
+标题会重复。确实：两个人各有一个 `Report.docx`，一个人还有去年那份，而**每个新建空文档
+都叫 `New_Document.docx`**。按名字复用等于把无关文档的历史合并到一行。
+
+改成：会话在编辑器挂载之前就 mint 一个 id（`lib/history/session.ts`），
+并 `replaceState` 写进地址栏 `?doc=<id>`。id 是编辑器、历史页、恢复条三方共同的"这一篇"，
+标题退回成标签。
+
+这条改动顺手修掉一个真实的丢失场景：**刷新 `?new=docx` 原本会新开一个空白文档**，
+刚才的编辑只能靠恢复条找回；现在 `?doc=<id>` 直接把最新快照打开在原地。
+E2E `autosave-recovery.spec.ts` 的第二条用例钉的就是这个（刷新后 id 不变、历史仍是一行、
+输入的句子还在）。
+
+**一行 = 一次编辑会话**，而不是"一个文件永远一行"。同一个文件今天明天各编辑一次会是两行。
+这与恢复点的语义一致，也让"两个同名文件"永远不会撞车；行数由七天窗口 + 每篇 3 个 rev +
+LRU 预算一起兜底。另外，**只打开不编辑不会留下任何行**——行是第一次快照才创建的。
+
+## 四、七天，以及把它说出来
+
+保留窗口从 `max(updatedAt, lastOpenedAt)` 起算七天，因此一份一直在用的文档不会在用户手里过期。
+清除发生在三个地方，缺一个这条规则就名不副实：应用启动时、每次写快照时（同一事务内，
+先清过期再算预算）、历史页打开时。
+
+**说出来的地方比实现更要紧**，这一条是用户明确要求的：
+
+- 首页（中英双语）hero 下面常驻一行：自动保存 + 保留 7 天 + `本地历史` 链接。
+  **写在 HTML 里，不由脚本生成**——对用户数据的承诺必须对首次访问者、爬虫、
+  关掉 JS 的人同样成立。`history-recent.js` 只负责在本机确实存有内容时补一段"继续编辑 X"。
+- 历史页顶部重复规则，**每一行还各带自己的倒计时**（"3 天后清除"）。
+  "这个能不能靠"是对着某一篇文档问的，不是对着功能问的。
+
+## 五、四个踩到的坑（都会把"没测到"伪装成"绿"）
+
+1. **fake timers 会卡死 fake-indexeddb**。它的事务走宏任务队列，`vi.useFakeTimers()`
+   一开，`await putSnapshot()` 永远不 resolve，表现为测试超时而不是报错。
+   过期用例改用 `vi.useFakeTimers({ toFake: ['Date'] })`，只伪造时钟。
+2. **单调时钟跨测试泄漏**。`stamp()` 保证 `updatedAt` 严格递增（同毫秒批量写入时列表顺序
+   才稳定），但它是模块级的，只增不减。一条把系统时间推后七天的用例，会让**之后每一条**
+   用例写入的记录都带着未来的时间戳，于是再也没有东西看起来过期。加了
+   `resetHistoryClockForTests()`，三个历史相关测试文件的 `wipe()` 都调它。
+3. **E2E 的 120 秒窗口让用例失去意义**。`autosave-recovery` 第一版等快照等 120s，
+   而周期性 tick 是 90s——所以无论 `visibilitychange` 那条分支在不在，用例都会绿。
+   反向验证（删掉 hidden 快照）一次就抓出来了：删了还是绿，只是从 8 秒变成 1.6 分钟。
+   窗口收到 45s（明确小于 SNAPSHOT_INTERVAL_MS）之后才真正钉住它要钉的分支。
+4. **preview 服务器复用旧构建**（CLAUDE.md 早有记载，还是踩了）：四条新用例同时红，
+   页面 DOM 是上一轮的。`lsof -ti :4176 | xargs kill -9` + 删掉 `dist-e2e-4176/` 后全绿。
+   凡是"一改就全灭"，先怀疑跑道。
+
+## 六、反向验证（约定 3）
+
+每条都是"去掉修复 → 恰好一条用例变红 → 恢复 → 全绿"：
+
+| 去掉什么                                           | 变红的用例                                                 |
+| -------------------------------------------------- | ---------------------------------------------------------- |
+| `beforeunload` 里的 `preventDefault()/returnValue` | blocks unload once the editor reports an edit              |
+| 每篇 3 个 rev 的裁剪                               | keeps only the newest revisions…                           |
+| 预算淘汰                                           | evicts the least-recently-opened document…                 |
+| `clearAllHistory` 里的 blob clear                  | clears the library, bytes included                         |
+| 配额失败后的淘汰重试                               | makes room and retries once…                               |
+| `getRecoverableDoc` 的 dismissed 判定              | remembers a dismissal…                                     |
+| `getRecoverableDoc` 的 savedToDisk 判定            | says nothing about a document that was saved to disk       |
+| `restoreDocument` 传回的 historyId                 | reopens the newest snapshot through the ordinary open path |
+| `visibilitychange` 快照                            | E2E: edits survive the tab going away（45s 窗口下）        |
+| 历史页的过期清扫                                   | E2E: deletes documents past the retention window           |
+
+## 七、没做的和下一步
+
+- **第 1 层（File System Access 句柄）没做**。对 Chromium 桌面用户，它的收益比恢复点还大
+  （文件直接写回磁盘、浏览器里根本不留副本），Safari/Firefox 则完全没有。留作增量。
+- **导出成本仍未量化**。评估里说"一期最该先量的东西"，这轮只观察到本地 preview 上一次
+  `visibilitychange` 快照到落库是秒级；真实语料上的 p50/p95 还没跑（`bin/corpus-report.mjs`
+  已有那一栏）。90s 的间隔是拍脑袋的起步值，量完再调。
+- **DOCY/XLSY 内部格式**（跳过 x2t 的可能路径）仍未验证，条件同上。
+- 移动端 `visibilitychange → hidden` 到进程被杀之间到底还剩多少时间，没测。

--- a/history.html
+++ b/history.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="img/64.png" rel="shortcut icon" />
+    <link rel="icon" type="image/png" href="img/64.png" />
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#000000" />
+
+    <!-- /history: the local document library. Everything it lists lives in this
+         browser's IndexedDB and has never been uploaded, so there is nothing
+         here for a crawler to see and nothing that would mean the same thing
+         to a different visitor. Its UI language follows the app's i18n
+         (?locale=), not a per-language static page. -->
+    <title>Local history</title>
+    <meta name="robots" content="noindex" />
+    <script>
+      try {
+        var t = localStorage.getItem('ran-theme');
+        if (t === 'dark' || t === 'light') {
+          document.documentElement.setAttribute('data-ran-theme', t);
+          document.documentElement.setAttribute('theme', t);
+        }
+      } catch (e) {}
+    </script>
+    <link rel="stylesheet" href="/ran-fonts/fonts.css" />
+    <link rel="stylesheet" href="/ran-tokens.css" />
+  </head>
+
+  <body>
+    <main id="history-root"></main>
+
+    <noscript>
+      <p style="max-width: 720px; margin: 0 auto; padding: 24px; font-family: system-ui, sans-serif">
+        This page needs JavaScript to read the documents stored in your browser.
+      </p>
+    </noscript>
+  </body>
+  <script type="module" src="./lib/history-page.ts"></script>
+</html>

--- a/index.html
+++ b/index.html
@@ -234,15 +234,17 @@
             <a href="/editor?new=xlsx" data-prefetch="xlsx"><r-button id="hero-new-xlsx">New Excel</r-button></a>
             <a href="/editor?new=pptx" data-prefetch="pptx"><r-button id="hero-new-pptx">New PowerPoint</r-button></a>
           </div>
-          <!-- Filled by /history-recent.js when this browser holds autosaved work;
-               stays hidden (and costs nothing) for a first-time visitor. -->
-          <div
-            class="recent reveal d5"
-            data-recent-slot
-            data-recent-label="Continue editing"
-            data-recent-all="Local history"
-            hidden
-          ></div>
+          <!-- Autosave is a promise about the user's data, so it is stated in the
+               served HTML rather than drawn by script: the retention window and the
+               way to inspect and delete what is kept are visible to a first-time
+               visitor, to a crawler, and with JavaScript off. /history-recent.js
+               only fills the "continue editing" slot, and only when this browser is
+               actually holding something. -->
+          <div class="recent reveal d5">
+            <span data-recent-slot data-recent-label="Continue editing" hidden></span>
+            <span class="recent-note">Edits autosave in this browser for 7 days, then delete themselves.</span>
+            <a class="recent-all" href="/history">Local history</a>
+          </div>
           <div class="trust reveal d5">
             <span>0 bytes uploaded</span><span>no account</span><span>works offline</span
             ><span>.docx .xlsx .pptx .csv</span>

--- a/index.html
+++ b/index.html
@@ -174,6 +174,7 @@
     <script src="/lang-switch.js" defer></script>
     <script src="/open-local.js" defer></script>
     <script src="/landing-prefetch.js" defer></script>
+    <script src="/history-recent.js" defer></script>
   </head>
 
   <body>
@@ -233,6 +234,15 @@
             <a href="/editor?new=xlsx" data-prefetch="xlsx"><r-button id="hero-new-xlsx">New Excel</r-button></a>
             <a href="/editor?new=pptx" data-prefetch="pptx"><r-button id="hero-new-pptx">New PowerPoint</r-button></a>
           </div>
+          <!-- Filled by /history-recent.js when this browser holds autosaved work;
+               stays hidden (and costs nothing) for a first-time visitor. -->
+          <div
+            class="recent reveal d5"
+            data-recent-slot
+            data-recent-label="Continue editing"
+            data-recent-all="Local history"
+            hidden
+          ></div>
           <div class="trust reveal d5">
             <span>0 bytes uploaded</span><span>no account</span><span>works offline</span
             ><span>.docx .xlsx .pptx .csv</span>

--- a/index.ts
+++ b/index.ts
@@ -123,57 +123,59 @@ const createNewOnLoad = ['docx', 'xlsx', 'pptx'].includes(newExt) && !documentUr
 // IndexedDB via public/open-local.js — take it out and open it on boot.
 const openParam = getAllQueryString()['open'];
 const openLocalOnLoad = openParam === 'local' && !documentUrl && !createNewOnLoad;
-// `?open=history&id=<id>`: reopen a document from the local history, and keep
-// writing snapshots to that same row rather than starting a second one for a
-// document the user already has.
-const historyIdParam = openParam === 'history' ? (getAllQueryString()['id'] ?? '') : '';
-const openHistoryOnLoad = Boolean(historyIdParam) && !documentUrl && !createNewOnLoad;
+// `?doc=<id>`: which document this is. Every editing session stamps its own id
+// here (see lib/history/session.ts), so a reload comes back to the same
+// document instead of a second blank one, and the history page's Open link is
+// the same URL the editor was already using. File names cannot play this role:
+// they repeat, and two documents sharing one would share a history.
+const docParam = getAllQueryString()['doc'] ?? '';
 
 // Landing hero orchestration. Only the bare homepage (no ?file/?src/?new, not
 // embedded) shows the crawlable hero. If a document is about to load or be
 // created, or we're embedded, hide it immediately to avoid a flash before the
 // editor takes over.
 const isEmbedded = document.body.classList.contains('embed-mode');
-if (documentUrl || isEmbedded || createNewOnLoad || openLocalOnLoad || openHistoryOnLoad) {
+if (documentUrl || isEmbedded || createNewOnLoad || openLocalOnLoad || docParam) {
   hideLanding();
 } else {
   // Bare /editor with nothing to open: the landing lives at / now.
   window.location.replace('/');
 }
 
-if (documentUrl) {
-  // Decode URL if it's encoded
-  try {
-    const decodedUrl = decodeURIComponent(documentUrl);
-    // Open document from URL
-    openDocumentFromUrl(decodedUrl, undefined, { readonly: isReadonly });
-  } catch (error) {
-    // If decoding fails, try using original URL
-    console.warn('Failed to decode URL, using original:', error);
-    openDocumentFromUrl(documentUrl, undefined, { readonly: isReadonly });
-  }
-} else if (createNewOnLoad && !isEmbedded) {
-  void onCreateNew(`.${newExt}`);
-} else if (openHistoryOnLoad && !isEmbedded) {
-  void (async () => {
+void (async () => {
+  // A stored snapshot wins over every other way of opening: it is strictly
+  // newer than the file on disk or the blank document the other parameters
+  // would produce, and it is the copy nobody else has.
+  if (docParam && !isEmbedded) {
     const [{ getDoc }, { restoreDocument }] = await Promise.all([
       import('./lib/history/store'),
       import('./lib/history/recovery'),
     ]);
-    // One-shot param, same as ?open=local: a reload should not reopen an old
-    // snapshot over whatever the user is doing by then.
-    const cleaned = new URL(window.location.href);
-    cleaned.searchParams.delete('open');
-    cleaned.searchParams.delete('id');
-    window.history.replaceState(null, '', cleaned);
-    const doc = await getDoc(historyIdParam);
-    if (!doc || !(await restoreDocument(doc))) {
-      // The row was deleted or its bytes are gone: nothing to open.
-      window.location.replace('/');
+    const doc = await getDoc(docParam);
+    if (doc && (await restoreDocument(doc))) return;
+    // No snapshot yet (nothing was edited before the reload) or it expired:
+    // fall through and open the same document again under the same id.
+  }
+
+  if (documentUrl) {
+    try {
+      const decodedUrl = decodeURIComponent(documentUrl);
+      await openDocumentFromUrl(decodedUrl, undefined, { readonly: isReadonly, docId: docParam || undefined });
+    } catch (error) {
+      // If decoding fails, try using original URL
+      console.warn('Failed to decode URL, using original:', error);
+      await openDocumentFromUrl(documentUrl, undefined, { readonly: isReadonly, docId: docParam || undefined });
     }
-  })();
-} else if (openLocalOnLoad && !isEmbedded) {
-  void import('./lib/pending-open').then(async ({ takePendingFile }) => {
+    return;
+  }
+
+  if (createNewOnLoad && !isEmbedded) {
+    await onCreateNew(`.${newExt}`, { docId: docParam || undefined });
+    return;
+  }
+
+  if (openLocalOnLoad && !isEmbedded) {
+    const { takePendingFile } = await import('./lib/pending-open');
     const file = await takePendingFile();
     // One-shot param: strip it so a reload lands on the plain homepage instead
     // of hiding the hero again with nothing left to open.
@@ -181,13 +183,18 @@ if (documentUrl) {
     cleaned.searchParams.delete('open');
     window.history.replaceState(null, '', cleaned);
     if (file) {
-      await openLocalFile(file);
-    } else {
-      // Stale deep link (reload, bookmarked URL): nothing pending -- back to the landing.
-      window.location.replace('/');
+      await openLocalFile(file, { historyId: docParam || undefined });
+      return;
     }
-  });
-}
+    // Stale deep link (reload, bookmarked URL): nothing pending -- back to the landing.
+    window.location.replace('/');
+    return;
+  }
+
+  // `?doc=` on its own and nothing stored under it: the document it names was
+  // deleted or has expired, so there is nothing here to show.
+  if (docParam && !isEmbedded) window.location.replace('/');
+})();
 
 // Boot-time recovery offer. Deliberately late and lazy: it must not compete
 // with the document that is opening for either attention or bandwidth, and the
@@ -197,7 +204,7 @@ if (!isEmbedded) {
   window.addEventListener('load', () => {
     window.setTimeout(() => {
       void import('./lib/history/recovery').then(({ offerRecovery }) =>
-        offerRecovery({ excludeId: historyIdParam || undefined }),
+        offerRecovery({ excludeId: docParam || undefined }),
       );
     }, 1500);
   });

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ import 'ranui/button';
 import 'ranui/card';
 import 'ranui/select';
 import { initWebMcp } from './lib/web-mcp';
+import { installUnsavedChangesGuard } from './lib/unsaved-guard';
 import '@khmyznikov/pwa-install';
 import './styles/base.css';
 
@@ -38,6 +39,10 @@ initEmbedApi();
 // WebMCP (browser-agent tools): no-op unless the browser exposes
 // document/navigator.modelContext and this is a top-level window.
 initWebMcp();
+
+// Warn before an accidental close/reload throws away edits that never reached
+// the user's disk. No-op in embed mode -- the host page owns that UX.
+installUnsavedChangesGuard();
 
 // Privacy-friendly analytics (no-op unless VITE_CF_BEACON_TOKEN is set; never in embed mode)
 initAnalytics();

--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,7 @@ import 'ranui/card';
 import 'ranui/select';
 import { initWebMcp } from './lib/web-mcp';
 import { installUnsavedChangesGuard } from './lib/unsaved-guard';
+import { initDocumentHistory } from './lib/history';
 import '@khmyznikov/pwa-install';
 import './styles/base.css';
 
@@ -43,6 +44,9 @@ initWebMcp();
 // Warn before an accidental close/reload throws away edits that never reached
 // the user's disk. No-op in embed mode -- the host page owns that UX.
 installUnsavedChangesGuard();
+
+// Local history: keep the recovery points in step with what reaches the disk.
+initDocumentHistory();
 
 // Privacy-friendly analytics (no-op unless VITE_CF_BEACON_TOKEN is set; never in embed mode)
 initAnalytics();
@@ -117,14 +121,20 @@ const newExt = typeof newExtRaw === 'string' ? newExtRaw.replace(/^\./, '').toLo
 const createNewOnLoad = ['docx', 'xlsx', 'pptx'].includes(newExt) && !documentUrl;
 // `?open=local`: a static landing page (e.g. /zh-CN/) stashed a picked file in
 // IndexedDB via public/open-local.js — take it out and open it on boot.
-const openLocalOnLoad = getAllQueryString()['open'] === 'local' && !documentUrl && !createNewOnLoad;
+const openParam = getAllQueryString()['open'];
+const openLocalOnLoad = openParam === 'local' && !documentUrl && !createNewOnLoad;
+// `?open=history&id=<id>`: reopen a document from the local history, and keep
+// writing snapshots to that same row rather than starting a second one for a
+// document the user already has.
+const historyIdParam = openParam === 'history' ? (getAllQueryString()['id'] ?? '') : '';
+const openHistoryOnLoad = Boolean(historyIdParam) && !documentUrl && !createNewOnLoad;
 
 // Landing hero orchestration. Only the bare homepage (no ?file/?src/?new, not
 // embedded) shows the crawlable hero. If a document is about to load or be
 // created, or we're embedded, hide it immediately to avoid a flash before the
 // editor takes over.
 const isEmbedded = document.body.classList.contains('embed-mode');
-if (documentUrl || isEmbedded || createNewOnLoad || openLocalOnLoad) {
+if (documentUrl || isEmbedded || createNewOnLoad || openLocalOnLoad || openHistoryOnLoad) {
   hideLanding();
 } else {
   // Bare /editor with nothing to open: the landing lives at / now.
@@ -144,6 +154,24 @@ if (documentUrl) {
   }
 } else if (createNewOnLoad && !isEmbedded) {
   void onCreateNew(`.${newExt}`);
+} else if (openHistoryOnLoad && !isEmbedded) {
+  void (async () => {
+    const [{ getDoc }, { restoreDocument }] = await Promise.all([
+      import('./lib/history/store'),
+      import('./lib/history/recovery'),
+    ]);
+    // One-shot param, same as ?open=local: a reload should not reopen an old
+    // snapshot over whatever the user is doing by then.
+    const cleaned = new URL(window.location.href);
+    cleaned.searchParams.delete('open');
+    cleaned.searchParams.delete('id');
+    window.history.replaceState(null, '', cleaned);
+    const doc = await getDoc(historyIdParam);
+    if (!doc || !(await restoreDocument(doc))) {
+      // The row was deleted or its bytes are gone: nothing to open.
+      window.location.replace('/');
+    }
+  })();
 } else if (openLocalOnLoad && !isEmbedded) {
   void import('./lib/pending-open').then(async ({ takePendingFile }) => {
     const file = await takePendingFile();
@@ -158,6 +186,20 @@ if (documentUrl) {
       // Stale deep link (reload, bookmarked URL): nothing pending -- back to the landing.
       window.location.replace('/');
     }
+  });
+}
+
+// Boot-time recovery offer. Deliberately late and lazy: it must not compete
+// with the document that is opening for either attention or bandwidth, and the
+// history UI has no business in the critical path of an editor that may have
+// nothing to recover.
+if (!isEmbedded) {
+  window.addEventListener('load', () => {
+    window.setTimeout(() => {
+      void import('./lib/history/recovery').then(({ offerRecovery }) =>
+        offerRecovery({ excludeId: historyIdParam || undefined }),
+      );
+    }, 1500);
   });
 }
 

--- a/lib/document.ts
+++ b/lib/document.ts
@@ -3,6 +3,7 @@ import { View } from 'ranui/builder';
 import { getDocmentObj, setDocmentObj } from '@ranuts/shared/store';
 import { handleDocumentOperation, loadEditorApi } from './converter';
 import { showLoading } from './loading';
+import { beginAutosaveSession } from './history/autosave';
 
 // Import UI functions with type-only to avoid circular dependency
 // These will be passed as callbacks or called after document operations
@@ -46,6 +47,9 @@ export const onCreateNew = async (ext: string): Promise<void> => {
     await loadEditorApi();
     const { fileName, file: fileBlob } = getDocmentObj();
     await handleDocumentOperation({ file: fileBlob, fileName, isNew: !fileBlob });
+    // Recovery points from here on. A blank document is the case with the most
+    // to lose: there is no file on disk to fall back to at all.
+    void beginAutosaveSession({ title: fileName, origin: 'new' });
   } catch (error) {
     console.error('Error creating new document:', error);
     // Ensure control panel is shown on error
@@ -58,7 +62,13 @@ export const onCreateNew = async (ext: string): Promise<void> => {
 
 // Open an already-picked local File (from the file input below, or handed off
 // by a static landing page via lib/pending-open.ts).
-export const openLocalFile = async (file: File): Promise<void> => {
+export const openLocalFile = async (
+  file: File,
+  options?: {
+    /** Continue an existing history row (the file came out of the history). */
+    historyId?: string;
+  },
+): Promise<void> => {
   const { removeLoading } = showLoading();
   try {
     if (hideControlPanelFn) {
@@ -71,6 +81,7 @@ export const openLocalFile = async (file: File): Promise<void> => {
     });
     const { fileName, file: fileBlob } = getDocmentObj();
     await handleDocumentOperation({ file: fileBlob, fileName, isNew: !fileBlob });
+    void beginAutosaveSession({ title: file.name, origin: 'local', docId: options?.historyId });
   } catch (error) {
     console.error('Error opening document:', error);
     // Ensure control panel is shown on error
@@ -183,6 +194,7 @@ export const openDocumentFromUrl = async (
       isNew: !fileBlob,
       readonly: options?.readonly,
     });
+    void beginAutosaveSession({ title: docFileName, origin: 'url' });
   } catch (error) {
     console.error('Error opening document from URL:', error);
     alert(`Failed to open document: ${error instanceof Error ? error.message : 'Unknown error'}`);

--- a/lib/document.ts
+++ b/lib/document.ts
@@ -3,7 +3,7 @@ import { View } from 'ranui/builder';
 import { getDocmentObj, setDocmentObj } from '@ranuts/shared/store';
 import { handleDocumentOperation, loadEditorApi } from './converter';
 import { showLoading } from './loading';
-import { beginAutosaveSession } from './history/autosave';
+import { startDocumentSession } from './history/session';
 
 // Import UI functions with type-only to avoid circular dependency
 // These will be passed as callbacks or called after document operations
@@ -33,7 +33,7 @@ const fileInput = View('input')
   .build() as HTMLInputElement;
 document.body.appendChild(fileInput);
 
-export const onCreateNew = async (ext: string): Promise<void> => {
+export const onCreateNew = async (ext: string, options?: { docId?: string }): Promise<void> => {
   // Callers own the loading indicator (the control panel shows it around this
   // call), so showing one here too would stack two of them.
   try {
@@ -49,7 +49,7 @@ export const onCreateNew = async (ext: string): Promise<void> => {
     await handleDocumentOperation({ file: fileBlob, fileName, isNew: !fileBlob });
     // Recovery points from here on. A blank document is the case with the most
     // to lose: there is no file on disk to fall back to at all.
-    void beginAutosaveSession({ title: fileName, origin: 'new' });
+    startDocumentSession({ title: fileName, origin: 'new', docId: options?.docId });
   } catch (error) {
     console.error('Error creating new document:', error);
     // Ensure control panel is shown on error
@@ -81,7 +81,7 @@ export const openLocalFile = async (
     });
     const { fileName, file: fileBlob } = getDocmentObj();
     await handleDocumentOperation({ file: fileBlob, fileName, isNew: !fileBlob });
-    void beginAutosaveSession({ title: file.name, origin: 'local', docId: options?.historyId });
+    startDocumentSession({ title: file.name, origin: 'local', docId: options?.historyId });
   } catch (error) {
     console.error('Error opening document:', error);
     // Ensure control panel is shown on error
@@ -129,6 +129,8 @@ export const openDocumentFromUrl = async (
   options?: {
     readonly?: boolean;
     fetchOptions?: RequestInit;
+    /** Continue an existing history row (a reload of `?doc=<id>&file=<url>`). */
+    docId?: string;
   },
 ): Promise<void> => {
   const { removeLoading } = showLoading();
@@ -194,7 +196,7 @@ export const openDocumentFromUrl = async (
       isNew: !fileBlob,
       readonly: options?.readonly,
     });
-    void beginAutosaveSession({ title: docFileName, origin: 'url' });
+    startDocumentSession({ title: docFileName, origin: 'url', docId: options?.docId });
   } catch (error) {
     console.error('Error opening document from URL:', error);
     alert(`Failed to open document: ${error instanceof Error ? error.message : 'Unknown error'}`);

--- a/lib/embed-mode.ts
+++ b/lib/embed-mode.ts
@@ -1,0 +1,27 @@
+/**
+ * Embed detection: is this window running inside a host page's iframe (or
+ * explicitly asked to behave as if it were)?
+ *
+ * `initEmbedApi` owns the embed *feature* -- the postMessage protocol, the
+ * origin allowlist and the `embed-mode` body class. This module is just the
+ * cheap, side-effect-free predicate the rest of the app reads to stay out of
+ * the host's way: local save routing, the unsaved-changes guard and the
+ * autosave history all have to be silent when the document on screen belongs
+ * to someone else's page.
+ */
+const EMBED_QUERY_KEYS = ['embed', 'embedded'];
+
+export function isEmbedMode(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  if (window.parent !== window) {
+    return true;
+  }
+  const params = new URLSearchParams(window.location.search);
+  return EMBED_QUERY_KEYS.some((key) => {
+    if (!params.has(key)) return false;
+    const value = params.get(key);
+    return value === '' || value === '1' || value === 'true';
+  });
+}

--- a/lib/history-page.ts
+++ b/lib/history-page.ts
@@ -1,0 +1,269 @@
+/**
+ * /history -- the local document library.
+ *
+ * Everything listed here lives in this browser's IndexedDB and has never left
+ * the device, which is exactly why the page leads with a way to delete it:
+ * the feature's whole privacy cost is that a shared machine now remembers what
+ * was edited on it, and the answer to that is a delete on every row and a
+ * clear-everything that empties the bytes as well as the index.
+ *
+ * The page is an app surface, not a landing page: no per-language HTML file,
+ * no sitemap entry, noindex. Its language follows the app's i18n the way the
+ * editor's does.
+ */
+import 'ranui/button';
+import 'ranui/input';
+import { Div, View } from 'ranui/builder';
+import '../styles/history.css';
+import { applyDocumentLanguage, t } from '@ranuts/shared/i18n';
+import { formatRelativeTime } from './history/recovery';
+import { clearAllHistory, deleteDoc, historyUsage, listDocs } from './history/store';
+import { isAutosaveEnabled, setAutosaveEnabled } from './history/autosave';
+import { hasUnsavedWork, type HistoryDoc } from './history/types';
+
+const SEARCH_DEBOUNCE_MS = 200;
+
+let query = '';
+let page = 1;
+let searchTimer = 0;
+
+function root(): HTMLElement {
+  return document.getElementById('history-root') as HTMLElement;
+}
+
+export function formatBytes(size: number): string {
+  if (size < 1024) return `${size} B`;
+  const units = ['KB', 'MB', 'GB'];
+  let value = size / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value >= 10 ? Math.round(value) : value.toFixed(1)} ${units[unit]}`;
+}
+
+/** Keep the view in the URL so a search or a page survives a reload and can be shared. */
+function syncUrl(): void {
+  const url = new URL(window.location.href);
+  if (query) url.searchParams.set('q', query);
+  else url.searchParams.delete('q');
+  if (page > 1) url.searchParams.set('page', String(page));
+  else url.searchParams.delete('page');
+  window.history.replaceState(null, '', url);
+}
+
+function readUrl(): void {
+  const params = new URLSearchParams(window.location.search);
+  query = params.get('q') ?? '';
+  page = Math.max(1, Number(params.get('page') ?? '1') || 1);
+}
+
+function button(
+  label: string,
+  onClick: () => void,
+  options: { type?: string; id?: string; class?: string } = {},
+): HTMLElement {
+  const builder = View('r-button').text(label).on('click', onClick);
+  if (options.id) builder.id(options.id);
+  if (options.class) builder.class(options.class);
+  builder.attr('type', options.type ?? 'default');
+  return builder.build();
+}
+
+function buildRow(doc: HistoryDoc, refresh: () => void): HTMLElement {
+  const meta = [formatRelativeTime(doc.updatedAt), formatBytes(doc.size)];
+
+  const metaRow = Div()
+    .class('history-row-meta')
+    .children(...meta.map((text) => Div().text(text).build()));
+  if (hasUnsavedWork(doc)) {
+    // The rows that hold the only copy of that work are the reason to keep the
+    // list at all, so they say so rather than looking like every other row.
+    metaRow.children(Div().class('history-badge').text(t('historyUnsaved')).build());
+  }
+
+  return Div()
+    .class('history-row')
+    .data('id', doc.id)
+    .children(
+      Div()
+        .class('history-row-main')
+        .children(Div().class('history-row-title').text(doc.title).build(), metaRow.build())
+        .build(),
+      Div()
+        .class('history-row-actions')
+        .children(
+          button(
+            t('historyOpen'),
+            () => {
+              window.location.href = `/editor?open=history&id=${encodeURIComponent(doc.id)}`;
+            },
+            { class: 'history-open' },
+          ),
+          button(
+            t('historyDelete'),
+            () => {
+              if (!window.confirm(t('historyDeleteConfirm', { title: doc.title }))) return;
+              void deleteDoc(doc.id).then(refresh);
+            },
+            { type: 'danger', class: 'history-delete' },
+          ),
+        )
+        .build(),
+    )
+    .build();
+}
+
+function buildToolbar(usage: number, refresh: () => void): HTMLElement {
+  const search = View('r-input')
+    .id('history-search')
+    .class('history-search')
+    .attr('placeholder', t('historySearchPlaceholder'))
+    .attr('value', query)
+    .on('input', (event: Event) => {
+      const value = (event as CustomEvent<{ value?: string }>).detail?.value ?? '';
+      window.clearTimeout(searchTimer);
+      searchTimer = window.setTimeout(() => {
+        query = value;
+        // A new search starts at the top; staying on page 4 of the previous
+        // result set shows an empty page more often than not.
+        page = 1;
+        refresh();
+      }, SEARCH_DEBOUNCE_MS);
+    })
+    .build();
+
+  const clear = button(
+    t('historyClearAll'),
+    () => {
+      if (!window.confirm(t('historyClearConfirm'))) return;
+      void clearAllHistory().then(refresh);
+    },
+    { type: 'danger', id: 'history-clear-all' },
+  );
+
+  return Div()
+    .class('history-toolbar')
+    .children(
+      search,
+      Div()
+        .class('history-usage')
+        .text(t('historyUsage', { size: formatBytes(usage) }))
+        .build(),
+      clear,
+    )
+    .build();
+}
+
+function buildPager(current: number, pages: number, refresh: () => void): HTMLElement {
+  // Writes the module's page, not a parameter shadowing it: a pager that moved
+  // a local copy would re-render the same page for ever.
+  const goTo = (target: number): void => {
+    page = Math.min(Math.max(1, target), pages);
+    refresh();
+  };
+  const prev = button(t('historyPrev'), () => goTo(current - 1), { id: 'history-prev' });
+  const next = button(t('historyNext'), () => goTo(current + 1), { id: 'history-next' });
+  if (current <= 1) prev.setAttribute('disabled', '');
+  if (current >= pages) next.setAttribute('disabled', '');
+
+  return Div()
+    .class('history-pager')
+    .children(
+      prev,
+      Div()
+        .class('history-page-info')
+        .text(t('historyPageInfo', { page: String(current), pages: String(pages) }))
+        .build(),
+      next,
+    )
+    .build();
+}
+
+function buildAutosaveToggle(refresh: () => void): HTMLElement {
+  const enabled = isAutosaveEnabled();
+  const toggle = View('input')
+    .id('history-autosave')
+    .attr('type', 'checkbox')
+    .on('change', (event: Event) => {
+      setAutosaveEnabled((event.target as HTMLInputElement).checked);
+      refresh();
+    })
+    .build() as HTMLInputElement;
+  toggle.checked = enabled;
+
+  const label = View('label').class('history-autosave').attr('for', 'history-autosave').text(t('historyAutosaveLabel'));
+  return Div()
+    .class('history-autosave')
+    .children(
+      toggle,
+      label.build(),
+      ...(enabled ? [] : [Div().class('history-intro').text(t('historyAutosaveOff')).build()]),
+    )
+    .build();
+}
+
+async function render(): Promise<void> {
+  const [{ items, total, page: current, pageSize }, usage] = await Promise.all([
+    listDocs({ query, page }),
+    historyUsage(),
+  ]);
+  page = current;
+  syncUrl();
+
+  const pages = Math.max(1, Math.ceil(total / pageSize));
+  const refresh = () => void render();
+
+  const header = Div()
+    .class('history-header')
+    .children(
+      Div()
+        .class('history-title-row')
+        .children(
+          View('h1').class('history-title').text(t('historyTitle')).build(),
+          Div()
+            .class('history-back')
+            .children(
+              button(t('historyBack'), () => {
+                window.location.href = '/';
+              }),
+            )
+            .build(),
+        )
+        .build(),
+      View('p').class('history-intro').text(t('historyIntro')).build(),
+      View('p').class('history-notice').text(t('historyNotBackup')).build(),
+    )
+    .build();
+
+  const list = items.length
+    ? Div()
+        .class('history-list')
+        .id('history-list')
+        .children(...items.map((doc) => buildRow(doc, refresh)))
+        .build()
+    : Div()
+        .class('history-empty')
+        .id('history-empty')
+        .text(query ? t('historyEmptySearch') : t('historyEmpty'))
+        .build();
+
+  const pageEl = Div()
+    .class('history-page')
+    .children(
+      header,
+      buildAutosaveToggle(refresh),
+      buildToolbar(usage, refresh),
+      list,
+      ...(pages > 1 ? [buildPager(page, pages, refresh)] : []),
+    )
+    .build();
+
+  const container = root();
+  container.replaceChildren(pageEl);
+}
+
+applyDocumentLanguage();
+readUrl();
+void render();

--- a/lib/history-page.ts
+++ b/lib/history-page.ts
@@ -17,9 +17,9 @@ import { Div, View } from 'ranui/builder';
 import '../styles/history.css';
 import { applyDocumentLanguage, t } from '@ranuts/shared/i18n';
 import { formatRelativeTime } from './history/recovery';
-import { clearAllHistory, deleteDoc, historyUsage, listDocs } from './history/store';
+import { clearAllHistory, deleteDoc, historyUsage, listDocs, pruneExpired } from './history/store';
 import { isAutosaveEnabled, setAutosaveEnabled } from './history/autosave';
-import { hasUnsavedWork, type HistoryDoc } from './history/types';
+import { daysUntilExpiry, hasUnsavedWork, type HistoryDoc } from './history/types';
 
 const SEARCH_DEBOUNCE_MS = 200;
 
@@ -72,7 +72,15 @@ function button(
 }
 
 function buildRow(doc: HistoryDoc, refresh: () => void): HTMLElement {
-  const meta = [formatRelativeTime(doc.updatedAt), formatBytes(doc.size)];
+  const days = daysUntilExpiry(doc);
+  const meta = [
+    formatRelativeTime(doc.updatedAt),
+    formatBytes(doc.size),
+    // Per row, not only in the header: the retention window is the answer to
+    // "is this safe to rely on?", and that question gets asked about a
+    // particular document, not about the feature.
+    days > 0 ? t('historyExpiresIn', { days: String(days) }) : t('historyExpiresToday'),
+  ];
 
   const metaRow = Div()
     .class('history-row-meta')
@@ -97,7 +105,7 @@ function buildRow(doc: HistoryDoc, refresh: () => void): HTMLElement {
           button(
             t('historyOpen'),
             () => {
-              window.location.href = `/editor?open=history&id=${encodeURIComponent(doc.id)}`;
+              window.location.href = `/editor?doc=${encodeURIComponent(doc.id)}`;
             },
             { class: 'history-open' },
           ),
@@ -205,6 +213,10 @@ function buildAutosaveToggle(refresh: () => void): HTMLElement {
 }
 
 async function render(): Promise<void> {
+  // Sweep before reading: a row the user is shown must not be one the seven-day
+  // rule already deleted, and this page is the most likely thing to be open
+  // when that boundary is crossed.
+  await pruneExpired();
   const [{ items, total, page: current, pageSize }, usage] = await Promise.all([
     listDocs({ query, page }),
     historyUsage(),
@@ -233,6 +245,7 @@ async function render(): Promise<void> {
         )
         .build(),
       View('p').class('history-intro').text(t('historyIntro')).build(),
+      View('p').class('history-notice').text(t('historyRetention')).build(),
       View('p').class('history-notice').text(t('historyNotBackup')).build(),
     )
     .build();

--- a/lib/history/autosave.ts
+++ b/lib/history/autosave.ts
@@ -1,0 +1,273 @@
+/**
+ * The autosave metronome.
+ *
+ * This is deliberately not the SDK's own autosave loop. That loop is switched
+ * off on purpose (see onlyoffice/guards/serverless-save.ts): with no document
+ * server behind it, it takes a fake save success and greys out the Save button
+ * forever. So the app keeps its own beat.
+ *
+ * The beat is slow, and that is the design. One snapshot is a full export --
+ * the SDK serialises the document, x2t converts it, and the bytes come back
+ * across the frame boundary, with x2t asking for its 283 MB heap on the way.
+ * Editors whose snapshot is a JSON.stringify can afford to write on every
+ * keystroke; this one cannot, and a phone that is exporting while its user
+ * types is a phone about to lose its canvas (#145). Snapshots therefore need
+ * all of: something to save, a lull in the typing, and time since the last one.
+ *
+ * What this produces is a recovery point, not a save -- Office draws the same
+ * line between AutoRecover and Save, and everything here follows it: snapshots
+ * never clear the unsaved-changes warning, and never touch the user's file.
+ */
+import { t } from '@ranuts/shared/i18n';
+import { localStorageGetItem, localStorageSetItem } from 'ranuts/utils';
+import { requestSaveDocument } from '../onlyoffice/save-stream';
+import { getReadonlyMode } from '../onlyoffice/readonly';
+import { getLastEditAt, hasUnsavedChanges } from '../unsaved-guard';
+import { isEmbedMode } from '../embed-mode';
+import { extensionOf, findDocByTitle, markOpened, putSnapshot } from './store';
+import type { HistoryDoc, HistoryOrigin } from './types';
+
+/** Time between snapshots of a document that is being edited continuously. */
+export const SNAPSHOT_INTERVAL_MS = 90_000;
+/** How often the conditions are re-checked. Cheap: it is a handful of comparisons. */
+export const TICK_MS = 15_000;
+/** Quiet time after the last edit before an export is allowed to start. */
+export const IDLE_GRACE_MS = 2_000;
+/** Consecutive export failures before this session gives up. */
+export const MAX_CONSECUTIVE_FAILURES = 3;
+
+const AUTOSAVE_PREF_KEY = 'document-autosave-enabled';
+
+export interface AutosaveSessionInput {
+  /** File name as shown to the user; also the key that reuses a history row. */
+  title: string;
+  origin: HistoryOrigin;
+  /** Set when the document was opened from history: keep appending to that row. */
+  docId?: string;
+}
+
+export interface SnapshotDecision {
+  now: number;
+  enabled: boolean;
+  dirty: boolean;
+  readonly: boolean;
+  holdsLock: boolean;
+  lastSnapshotAt: number;
+  lastEditAt: number;
+  /** An export this session started is still running. */
+  exporting: boolean;
+}
+
+/**
+ * Whether this tick should take a snapshot. Split out from the scheduler so
+ * the rule can be tested exhaustively without a running editor -- the parts
+ * that need one (the export, the frame) are the parts that cannot be.
+ */
+export function shouldSnapshot(state: SnapshotDecision): boolean {
+  if (!state.enabled || !state.dirty || state.readonly || !state.holdsLock || state.exporting) return false;
+  if (state.now - state.lastSnapshotAt < SNAPSHOT_INTERVAL_MS) return false;
+  return state.now - state.lastEditAt >= IDLE_GRACE_MS;
+}
+
+export function isAutosaveEnabled(): boolean {
+  // Default on. Off by default would mean the feature does not exist for
+  // almost everyone, and the loss it prevents happens before anyone goes
+  // looking through settings.
+  return localStorageGetItem(AUTOSAVE_PREF_KEY) !== 'false';
+}
+
+export function setAutosaveEnabled(enabled: boolean): void {
+  localStorageSetItem(AUTOSAVE_PREF_KEY, enabled ? 'true' : 'false');
+  if (!enabled) stopAutosaveSession();
+}
+
+interface ActiveSession {
+  title: string;
+  origin: HistoryOrigin;
+  docId: string | null;
+  ext: string;
+  timer: number;
+  lastSnapshotAt: number;
+  exporting: boolean;
+  failures: number;
+  holdsLock: boolean;
+  releaseLock: (() => void) | null;
+  onVisibility: () => void;
+  stopped: boolean;
+}
+
+let session: ActiveSession | null = null;
+
+function notify(kind: 'warning' | 'error', text: string): void {
+  (window as unknown as { message?: Record<string, ((msg: string) => void) | undefined> }).message?.[kind]?.(text);
+}
+
+/**
+ * Claim the document for this tab.
+ *
+ * Two tabs editing one document would otherwise take turns overwriting each
+ * other's snapshots, which is worse than not having autosave at all -- the
+ * history would end up holding an interleaving of two divergent documents.
+ * The lock is held for as long as the session lives; `ifAvailable` means a
+ * second tab finds out immediately instead of queueing behind the first.
+ */
+async function acquireLock(name: string): Promise<{ held: boolean; release: (() => void) | null }> {
+  const locks = (navigator as Navigator & { locks?: LockManager }).locks;
+  if (!locks?.request) {
+    // No Web Locks (older Safari): carry on rather than disable autosave. The
+    // cost of the rare double-tab case is lower than the cost of no history.
+    return { held: true, release: null };
+  }
+  return new Promise((resolve) => {
+    let release: (() => void) | null = null;
+    const held = new Promise<void>((resolveHeld) => {
+      release = resolveHeld;
+    });
+    void locks
+      .request(name, { ifAvailable: true }, (lock) => {
+        if (!lock) {
+          resolve({ held: false, release: null });
+          return undefined;
+        }
+        resolve({ held: true, release });
+        return held;
+      })
+      .catch(() => resolve({ held: true, release: null }));
+  });
+}
+
+/** Export the document now and store the bytes. Returns the row, or null. */
+export async function takeSnapshot(): Promise<HistoryDoc | null> {
+  const active = session;
+  if (!active || active.exporting || !active.ext) return null;
+
+  active.exporting = true;
+  try {
+    const file = await requestSaveDocument(active.ext.toUpperCase());
+    const doc = await putSnapshot({
+      id: active.docId ?? undefined,
+      title: active.title,
+      origin: active.origin,
+      bytes: await file.arrayBuffer(),
+    });
+    if (!doc) {
+      // The store gave up (no room, and eviction did not help). Stopping and
+      // saying so beats a silent autosave, which is the most dangerous kind:
+      // the user believes there is a recovery point where there is none.
+      notify('warning', t('autosaveStopped'));
+      stopAutosaveSession();
+      return null;
+    }
+    active.docId = doc.id;
+    active.lastSnapshotAt = Date.now();
+    active.failures = 0;
+    return doc;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    // A save the user asked for owns the channel; this tick simply waits.
+    if (!message.includes('already in progress')) {
+      active.failures += 1;
+      if (active.failures >= MAX_CONSECUTIVE_FAILURES) {
+        console.warn('[history] autosave stopped after repeated export failures:', message);
+        stopAutosaveSession();
+      }
+    }
+    return null;
+  } finally {
+    active.exporting = false;
+  }
+}
+
+function tick(): void {
+  const active = session;
+  if (!active) return;
+  const decision: SnapshotDecision = {
+    now: Date.now(),
+    enabled: isAutosaveEnabled(),
+    dirty: hasUnsavedChanges(),
+    readonly: getReadonlyMode(),
+    holdsLock: active.holdsLock,
+    lastSnapshotAt: active.lastSnapshotAt,
+    lastEditAt: getLastEditAt(),
+    exporting: active.exporting,
+  };
+  if (shouldSnapshot(decision)) void takeSnapshot();
+}
+
+/**
+ * Start watching the document that just opened.
+ *
+ * Called once per open. Any previous session is stopped first: its document is
+ * gone from the frame, and its lock belongs to whoever wants it next.
+ */
+export async function beginAutosaveSession(input: AutosaveSessionInput): Promise<void> {
+  stopAutosaveSession();
+  if (typeof window === 'undefined' || isEmbedMode() || !isAutosaveEnabled()) return;
+
+  const ext = extensionOf(input.title);
+  // Without an extension there is no export format to ask for. (PDFs and every
+  // other supported type do have one, so this is the pathological case only.)
+  if (!ext) return;
+
+  // A blank document always starts its own row: every one of them is called
+  // New_Document.docx, and reusing that row would have them overwrite each
+  // other's history.
+  const existing = input.docId ?? (input.origin === 'new' ? null : (await findDocByTitle(input.title))?.id) ?? null;
+
+  const lockName = `document-history:${input.title.trim().toLowerCase()}`;
+  const { held, release } = await acquireLock(lockName);
+  if (!held) {
+    notify('warning', t('autosaveOtherTab'));
+  }
+
+  const onVisibility = (): void => {
+    // The last chance that reliably gets time to run. beforeunload cannot be
+    // used for this -- an export is asynchronous and the page is already on
+    // its way out -- and a phone being task-switched away never sees one.
+    if (document.visibilityState !== 'hidden') return;
+    const active = session;
+    if (!active || !active.holdsLock || active.exporting) return;
+    if (!hasUnsavedChanges() || getReadonlyMode() || !isAutosaveEnabled()) return;
+    void takeSnapshot();
+  };
+
+  session = {
+    title: input.title,
+    origin: input.origin,
+    docId: existing,
+    ext,
+    // Not "now": a document that opens and is edited immediately should get
+    // its first snapshot one interval in, not two.
+    lastSnapshotAt: Date.now(),
+    exporting: false,
+    failures: 0,
+    holdsLock: held,
+    releaseLock: release,
+    onVisibility,
+    stopped: false,
+    timer: window.setInterval(tick, TICK_MS),
+  };
+
+  document.addEventListener('visibilitychange', onVisibility);
+  if (existing) void markOpened(existing);
+}
+
+export function stopAutosaveSession(): void {
+  const active = session;
+  session = null;
+  if (!active || active.stopped) return;
+  active.stopped = true;
+  window.clearInterval(active.timer);
+  document.removeEventListener('visibilitychange', active.onVisibility);
+  active.releaseLock?.();
+}
+
+/** The history row this session writes to, once one exists. */
+export function getAutosaveDocId(): string | null {
+  return session?.docId ?? null;
+}
+
+/** Test seam: inspect whether a session is running. */
+export function isAutosaveSessionActive(): boolean {
+  return session !== null;
+}

--- a/lib/history/autosave.ts
+++ b/lib/history/autosave.ts
@@ -24,7 +24,7 @@ import { requestSaveDocument } from '../onlyoffice/save-stream';
 import { getReadonlyMode } from '../onlyoffice/readonly';
 import { getLastEditAt, hasUnsavedChanges } from '../unsaved-guard';
 import { isEmbedMode } from '../embed-mode';
-import { extensionOf, findDocByTitle, markOpened, putSnapshot } from './store';
+import { extensionOf, markOpened, putSnapshot } from './store';
 import type { HistoryDoc, HistoryOrigin } from './types';
 
 /** Time between snapshots of a document that is being edited continuously. */
@@ -39,11 +39,20 @@ export const MAX_CONSECUTIVE_FAILURES = 3;
 const AUTOSAVE_PREF_KEY = 'document-autosave-enabled';
 
 export interface AutosaveSessionInput {
-  /** File name as shown to the user; also the key that reuses a history row. */
+  /**
+   * The document's identity for this editing session.
+   *
+   * Assigned by the caller before the editor even mounts, and put in the URL,
+   * so "which document is this?" has an answer that does not depend on the
+   * file name. Names collide -- two people both have a Report.docx, and one
+   * person has last year's too -- and an earlier version of this reused a row
+   * whenever the name matched, which quietly merged the history of unrelated
+   * documents.
+   */
+  docId: string;
+  /** File name as shown to the user. */
   title: string;
   origin: HistoryOrigin;
-  /** Set when the document was opened from history: keep appending to that row. */
-  docId?: string;
 }
 
 export interface SnapshotDecision {
@@ -84,7 +93,7 @@ export function setAutosaveEnabled(enabled: boolean): void {
 interface ActiveSession {
   title: string;
   origin: HistoryOrigin;
-  docId: string | null;
+  docId: string;
   ext: string;
   timer: number;
   lastSnapshotAt: number;
@@ -145,7 +154,7 @@ export async function takeSnapshot(): Promise<HistoryDoc | null> {
   try {
     const file = await requestSaveDocument(active.ext.toUpperCase());
     const doc = await putSnapshot({
-      id: active.docId ?? undefined,
+      id: active.docId,
       title: active.title,
       origin: active.origin,
       bytes: await file.arrayBuffer(),
@@ -209,12 +218,7 @@ export async function beginAutosaveSession(input: AutosaveSessionInput): Promise
   // other supported type do have one, so this is the pathological case only.)
   if (!ext) return;
 
-  // A blank document always starts its own row: every one of them is called
-  // New_Document.docx, and reusing that row would have them overwrite each
-  // other's history.
-  const existing = input.docId ?? (input.origin === 'new' ? null : (await findDocByTitle(input.title))?.id) ?? null;
-
-  const lockName = `document-history:${input.title.trim().toLowerCase()}`;
+  const lockName = `document-history:${input.docId}`;
   const { held, release } = await acquireLock(lockName);
   if (!held) {
     notify('warning', t('autosaveOtherTab'));
@@ -234,7 +238,7 @@ export async function beginAutosaveSession(input: AutosaveSessionInput): Promise
   session = {
     title: input.title,
     origin: input.origin,
-    docId: existing,
+    docId: input.docId,
     ext,
     // Not "now": a document that opens and is edited immediately should get
     // its first snapshot one interval in, not two.
@@ -249,7 +253,9 @@ export async function beginAutosaveSession(input: AutosaveSessionInput): Promise
   };
 
   document.addEventListener('visibilitychange', onVisibility);
-  if (existing) void markOpened(existing);
+  // No-op until this document has a row; from then on it restarts the
+  // seven-day clock every time the document is opened.
+  void markOpened(input.docId);
 }
 
 export function stopAutosaveSession(): void {
@@ -262,7 +268,7 @@ export function stopAutosaveSession(): void {
   active.releaseLock?.();
 }
 
-/** The history row this session writes to, once one exists. */
+/** The history row this session writes to. Known from the start, row or not. */
 export function getAutosaveDocId(): string | null {
   return session?.docId ?? null;
 }

--- a/lib/history/db.ts
+++ b/lib/history/db.ts
@@ -1,0 +1,138 @@
+/**
+ * The history database: the single place that knows the schema, and the single
+ * place that decides IndexedDB is unusable.
+ *
+ * Two stores, deliberately: `docs` holds small metadata rows the list view
+ * reads by the hundred, `blobs` holds the megabytes. A list that had to page
+ * through documents with their bytes attached would pull the whole library
+ * into memory to render ten rows.
+ *
+ * Every entry point resolves rather than throws when the database cannot be
+ * opened at all (private browsing, storage disabled, a corrupted profile).
+ * History is a safety net, and a safety net that breaks the editor when it is
+ * unavailable is worse than no net -- the same posture lib/pending-open.ts
+ * takes for the landing-page handoff.
+ */
+export const DB_NAME = 'document-history';
+export const DB_VERSION = 1;
+
+export const DOCS_STORE = 'docs';
+export const BLOBS_STORE = 'blobs';
+
+/** `docs` ordered by snapshot time -- the list view's default order. */
+export const DOCS_BY_UPDATED = 'by_updatedAt';
+/** All revisions of one document, for retention trimming and deletion. */
+export const BLOBS_BY_DOC = 'by_docId';
+
+let dbPromise: Promise<IDBDatabase | null> | null = null;
+
+function hasIndexedDb(): boolean {
+  return typeof indexedDB !== 'undefined';
+}
+
+export function openHistoryDb(): Promise<IDBDatabase | null> {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise<IDBDatabase | null>((resolve) => {
+    if (!hasIndexedDb()) {
+      resolve(null);
+      return;
+    }
+    let request: IDBOpenDBRequest;
+    try {
+      request = indexedDB.open(DB_NAME, DB_VERSION);
+    } catch {
+      resolve(null);
+      return;
+    }
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(DOCS_STORE)) {
+        const docs = db.createObjectStore(DOCS_STORE, { keyPath: 'id' });
+        docs.createIndex(DOCS_BY_UPDATED, 'updatedAt');
+      }
+      if (!db.objectStoreNames.contains(BLOBS_STORE)) {
+        const blobs = db.createObjectStore(BLOBS_STORE, { keyPath: ['docId', 'rev'] });
+        blobs.createIndex(BLOBS_BY_DOC, 'docId');
+      }
+    };
+    request.onsuccess = () => {
+      const db = request.result;
+      // Another tab opened a newer version: let go rather than block it, and
+      // stop serving reads from a connection whose schema is behind.
+      db.onversionchange = () => {
+        db.close();
+        dbPromise = null;
+      };
+      resolve(db);
+    };
+    request.onerror = () => resolve(null);
+    request.onblocked = () => resolve(null);
+  });
+  return dbPromise;
+}
+
+/** Promisify one IndexedDB request. Only ever called inside a live transaction. */
+export function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error('IndexedDB request failed'));
+  });
+}
+
+/**
+ * Run `work` inside one transaction and resolve when the transaction commits,
+ * not when the last request succeeds -- a value read back before the commit is
+ * not yet a value anyone else can see.
+ *
+ * Resolves `null` when there is no usable database. Rejects with the real
+ * error (`QuotaExceededError` in particular) when a transaction fails, because
+ * the write path has to tell "out of room, evict and retry" apart from
+ * "something is broken, give up quietly".
+ */
+export async function withStores<T>(
+  names: string[],
+  mode: IDBTransactionMode,
+  work: (tx: IDBTransaction) => Promise<T>,
+): Promise<T | null> {
+  const db = await openHistoryDb();
+  if (!db) return null;
+
+  return new Promise<T | null>((resolve, reject) => {
+    let tx: IDBTransaction;
+    try {
+      tx = db.transaction(names, mode);
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    let result: T;
+    let failure: unknown;
+
+    tx.oncomplete = () => resolve(result);
+    tx.onerror = () => reject(failure ?? tx.error ?? new Error('IndexedDB transaction failed'));
+    tx.onabort = () => reject(failure ?? tx.error ?? new DOMException('Transaction aborted', 'AbortError'));
+
+    work(tx).then(
+      (value) => {
+        result = value;
+      },
+      (error) => {
+        // Remember why: aborting replaces tx.error with a plain AbortError and
+        // the caller would lose the QuotaExceededError it needs to act on.
+        failure = error;
+        try {
+          tx.abort();
+        } catch {
+          // Already finished; the handlers above have the outcome.
+        }
+      },
+    );
+  });
+}
+
+/** Test seam: drop the cached connection so the next call reopens. */
+export function resetHistoryDbForTests(): void {
+  void dbPromise?.then((db) => db?.close());
+  dbPromise = null;
+}

--- a/lib/history/index.ts
+++ b/lib/history/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Wiring for the local history feature. Kept in one place so the editor entry
+ * has a single call, and so the pieces that must not import each other -- the
+ * save channel and the autosave scheduler -- stay uncoupled.
+ */
+import { setSavedToDiskListener } from '../onlyoffice/save-stream';
+import { getAutosaveDocId } from './autosave';
+import { markSavedToDisk } from './store';
+
+export function initDocumentHistory(): void {
+  setSavedToDiskListener(() => {
+    // The document now exists on disk, so its history row has nothing left to
+    // offer back. Without this the recovery bar would keep flagging a document
+    // the user already saved.
+    const id = getAutosaveDocId();
+    if (id) void markSavedToDisk(id);
+  });
+}
+
+export { beginAutosaveSession, isAutosaveEnabled, setAutosaveEnabled, stopAutosaveSession } from './autosave';
+export { clearAllHistory, deleteDoc, getLatestSnapshot, getRecoverableDoc, listDocs } from './store';
+export type { HistoryDoc } from './types';

--- a/lib/history/index.ts
+++ b/lib/history/index.ts
@@ -5,9 +5,14 @@
  */
 import { setSavedToDiskListener } from '../onlyoffice/save-stream';
 import { getAutosaveDocId } from './autosave';
-import { markSavedToDisk } from './store';
+import { markSavedToDisk, pruneExpired } from './store';
 
 export function initDocumentHistory(): void {
+  // Expiry has to happen on its own, not when someone thinks to visit the
+  // history page: "this browser forgets after seven days" is only a promise if
+  // nothing has to be done to collect on it.
+  void pruneExpired();
+
   setSavedToDiskListener(() => {
     // The document now exists on disk, so its history row has nothing left to
     // offer back. Without this the recovery bar would keep flagging a document

--- a/lib/history/recovery.ts
+++ b/lib/history/recovery.ts
@@ -76,7 +76,7 @@ export async function restoreDocument(doc: HistoryDoc): Promise<boolean> {
 
 function buildBar(doc: HistoryDoc): HTMLElement {
   const restore = View('r-button')
-    .class('recovery-bar-action')
+    .class('recovery-bar-action recovery-restore')
     .text(t('recoveryRestore'))
     .attr('type', 'primary')
     .on('click', () => {
@@ -86,7 +86,7 @@ function buildBar(doc: HistoryDoc): HTMLElement {
     .build();
 
   const discard = View('r-button')
-    .class('recovery-bar-action')
+    .class('recovery-bar-action recovery-dismiss')
     .text(t('recoveryDismiss'))
     .attr('variant', 'text')
     .attr('type', 'text')

--- a/lib/history/recovery.ts
+++ b/lib/history/recovery.ts
@@ -1,0 +1,134 @@
+/**
+ * The recovery offer.
+ *
+ * Snapshots are worthless if nobody is told they exist. A crash or a reload
+ * leaves the page open and obvious, but the common case is quieter: the user
+ * closes the tab and comes back tomorrow through the homepage, where nothing
+ * on screen hints that yesterday's edits were kept. So the editor asks on
+ * boot -- the same thing Office does with its Document Recovery pane and
+ * WordPress with "there is a more recent autosave, restore it?".
+ *
+ * The wording follows WordPress rather than "you have a backup": what matters
+ * is the comparison. This offer only appears for a document whose snapshot is
+ * newer than the last time its bytes reached the disk, and it says when those
+ * edits were made so the user can tell which copy is ahead.
+ */
+import { t } from '@ranuts/shared/i18n';
+import { Div, View } from 'ranui/builder';
+import { openLocalFile } from '../document';
+import { dismissRecovery, getLatestSnapshot, getRecoverableDoc } from './store';
+import type { HistoryDoc } from './types';
+
+/** Offers older than this belong on the history page, not in the user's way. */
+export const RECOVERY_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+const BAR_ID = 'recovery-bar';
+
+/** A short "5 minutes ago" for the offer's headline. */
+export function formatRelativeTime(timestamp: number, now = Date.now()): string {
+  const seconds = Math.round((timestamp - now) / 1000);
+  const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+    ['second', 60],
+    ['minute', 60],
+    ['hour', 24],
+    ['day', 7],
+    ['week', 5],
+  ];
+  let value = seconds;
+  let unit: Intl.RelativeTimeFormatUnit = 'second';
+  for (const [name, size] of units) {
+    unit = name;
+    if (Math.abs(value) < size) break;
+    value = Math.round(value / size);
+  }
+  try {
+    return new Intl.RelativeTimeFormat(document.documentElement.lang || undefined, { numeric: 'auto' }).format(
+      value,
+      unit,
+    );
+  } catch {
+    return new Date(timestamp).toLocaleString();
+  }
+}
+
+export function dismissRecoveryBar(): void {
+  document.getElementById(BAR_ID)?.remove();
+}
+
+/**
+ * Reopen the document from its newest snapshot.
+ *
+ * The bytes go back in through the ordinary local-file path, so everything
+ * downstream -- the editor mount, the store, the autosave session -- behaves
+ * exactly as it does for a file the user picked, with one difference: the
+ * session is told which history row this came from, so editing continues that
+ * row instead of starting a second one for the same document.
+ */
+export async function restoreDocument(doc: HistoryDoc): Promise<boolean> {
+  const snapshot = await getLatestSnapshot(doc.id);
+  if (!snapshot) return false;
+  // Records come back from IndexedDB as a whole buffer, never a view into a
+  // larger one, so handing over the buffer avoids copying tens of megabytes.
+  const file = new File([snapshot.bytes.buffer as ArrayBuffer], doc.title);
+  await openLocalFile(file, { historyId: doc.id });
+  return true;
+}
+
+function buildBar(doc: HistoryDoc): HTMLElement {
+  const restore = View('r-button')
+    .class('recovery-bar-action')
+    .text(t('recoveryRestore'))
+    .attr('type', 'primary')
+    .on('click', () => {
+      dismissRecoveryBar();
+      void restoreDocument(doc);
+    })
+    .build();
+
+  const discard = View('r-button')
+    .class('recovery-bar-action')
+    .text(t('recoveryDismiss'))
+    .attr('variant', 'text')
+    .attr('type', 'text')
+    .on('click', () => {
+      dismissRecoveryBar();
+      // Remembered, so the same offer does not greet every reload -- until the
+      // document changes again, which makes it news once more.
+      void dismissRecovery(doc.id);
+    })
+    .build();
+
+  const viewAll = View('r-link').class('recovery-bar-link').text(t('recoveryViewAll')).attr('href', '/history').build();
+
+  return Div()
+    .id(BAR_ID)
+    .class('recovery-bar')
+    .role('status')
+    .children(
+      Div()
+        .class('recovery-bar-text')
+        .children(
+          Div().class('recovery-bar-title').text(t('recoveryTitle')).build(),
+          Div()
+            .class('recovery-bar-body')
+            .text(t('recoveryBody', { title: doc.title, when: formatRelativeTime(doc.updatedAt) }))
+            .build(),
+        )
+        .build(),
+      Div().class('recovery-bar-actions').children(restore, discard, viewAll).build(),
+    )
+    .build();
+}
+
+/**
+ * Show the offer, if there is one worth showing. Safe to call on every boot:
+ * it does nothing when the history is empty, unavailable, or holds only
+ * documents that already reached the disk.
+ */
+export async function offerRecovery(options: { excludeId?: string } = {}): Promise<HistoryDoc | null> {
+  const doc = await getRecoverableDoc({ excludeId: options.excludeId, maxAgeMs: RECOVERY_MAX_AGE_MS });
+  if (!doc) return null;
+  dismissRecoveryBar();
+  document.body.appendChild(buildBar(doc));
+  return doc;
+}

--- a/lib/history/session.ts
+++ b/lib/history/session.ts
@@ -1,0 +1,45 @@
+/**
+ * Starting an editing session: give the document an identity, put it in the
+ * URL, and start taking recovery points.
+ *
+ * The identity comes first and comes from here, not from the history store,
+ * because it has to exist before there is anything to store. Two consequences
+ * worth stating:
+ *
+ * - The URL becomes `?doc=<id>`, so a reload lands back on the same document
+ *   instead of on a second blank one, and the history page's Open link is the
+ *   same URL the editor was already using.
+ * - Identity never depends on the file name. Names repeat -- two people each
+ *   have a Report.docx, one person has last year's as well -- and matching on
+ *   them merged unrelated documents into one row.
+ *
+ * A row is still only created when the first snapshot is taken, so opening a
+ * document and reading it leaves nothing behind.
+ */
+import { beginAutosaveSession } from './autosave';
+import type { HistoryOrigin } from './types';
+
+export function newDocumentId(): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  if (uuid) return uuid;
+  return `doc-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** Put `?doc=<id>` in the address bar, dropping the one-shot open parameters. */
+export function stampDocumentIdInUrl(docId: string): void {
+  if (typeof window === 'undefined') return;
+  const url = new URL(window.location.href);
+  if (url.searchParams.get('doc') === docId) return;
+  url.searchParams.set('doc', docId);
+  // `open=local` hands a file over exactly once; leaving it in the URL would
+  // make a reload look for a file that was already consumed.
+  url.searchParams.delete('open');
+  window.history.replaceState(null, '', url);
+}
+
+export function startDocumentSession(input: { title: string; origin: HistoryOrigin; docId?: string }): string {
+  const docId = input.docId || newDocumentId();
+  stampDocumentIdInUrl(docId);
+  void beginAutosaveSession({ docId, title: input.title, origin: input.origin });
+  return docId;
+}

--- a/lib/history/store.ts
+++ b/lib/history/store.ts
@@ -1,0 +1,435 @@
+/**
+ * Reading and writing the local document history.
+ *
+ * Two things make this more than a CRUD wrapper:
+ *
+ * Retention. Snapshots are taken automatically, so without a ceiling the
+ * database grows until the browser refuses a write -- and a write refused at
+ * the wrong moment is exactly the edit the user wanted back. Each document
+ * keeps a handful of revisions and the library as a whole keeps to a budget,
+ * evicting whole documents by least-recently-opened.
+ *
+ * Quota. `QuotaExceededError` is treated as "make room and try once more",
+ * never as a crash: browsers hand out very different amounts of room (a share
+ * of free disk on Chromium, far less on WebKit) and eviction can happen behind
+ * our back, so the write path has to cope rather than assume.
+ *
+ * Everything here resolves to a null/empty result when IndexedDB is missing;
+ * see lib/history/db.ts for why.
+ */
+import { BLOBS_BY_DOC, BLOBS_STORE, DOCS_STORE, requestToPromise, withStores } from './db';
+import type { HistoryDoc, HistoryOrigin, HistorySnapshot } from './types';
+import { hasUnsavedWork } from './types';
+
+/** Revisions kept per document: the newest plus two recovery points behind it. */
+export const MAX_REVS_PER_DOC = 3;
+/** Hard ceiling for the whole library, whatever the browser would allow. */
+export const MAX_TOTAL_BYTES = 500 * 1024 * 1024;
+/** Never claim more than this share of the origin's reported quota. */
+export const QUOTA_SHARE = 0.5;
+/** Default page size for the history list. */
+export const DEFAULT_PAGE_SIZE = 20;
+
+export interface SnapshotInput {
+  /** Existing document to append a revision to; omitted for a new one. */
+  id?: string;
+  title: string;
+  origin: HistoryOrigin;
+  bytes: Blob | ArrayBuffer | Uint8Array;
+}
+
+export interface DocListResult {
+  items: HistoryDoc[];
+  /** Rows matching the query, before paging. */
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+/**
+ * A strictly increasing timestamp.
+ *
+ * `updatedAt` is the list's sort key, and two snapshots taken inside the same
+ * millisecond -- which happens whenever anything writes in a loop -- would
+ * otherwise order arbitrarily and shuffle rows between pages. Nudging the
+ * clock forward keeps the order the user watched being created.
+ */
+let lastStamp = 0;
+function stamp(): number {
+  const now = Date.now();
+  lastStamp = now > lastStamp ? now : lastStamp + 1;
+  return lastStamp;
+}
+
+function newId(): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  if (uuid) return uuid;
+  return `doc-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function toBytes(bytes: Blob | ArrayBuffer | Uint8Array): Promise<Uint8Array> {
+  if (bytes instanceof Uint8Array) return bytes;
+  if (bytes instanceof ArrayBuffer) return new Uint8Array(bytes);
+  return new Uint8Array(await bytes.arrayBuffer());
+}
+
+export function extensionOf(title: string): string {
+  const match = /\.([a-z0-9]+)$/i.exec(title.trim());
+  return match ? match[1].toLowerCase() : '';
+}
+
+function isQuotaError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const name = (error as { name?: string }).name;
+  return name === 'QuotaExceededError' || name === 'NS_ERROR_FILE_NO_DEVICE_SPACE';
+}
+
+/** All metadata rows, newest snapshot first. */
+async function readAllDocs(tx: IDBTransaction): Promise<HistoryDoc[]> {
+  const rows = ((await requestToPromise(tx.objectStore(DOCS_STORE).getAll())) ?? []) as HistoryDoc[];
+  return rows.sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+/**
+ * How many bytes the library may occupy. Asks the browser first: a 500 MB
+ * ceiling means nothing on an origin that was only granted 100 MB, and holding
+ * back half of what we are given leaves room for the vendor caches the editor
+ * itself depends on.
+ */
+export async function storageBudget(): Promise<number> {
+  try {
+    const estimate = await navigator.storage?.estimate?.();
+    const quota = estimate?.quota;
+    if (typeof quota === 'number' && quota > 0) {
+      return Math.min(MAX_TOTAL_BYTES, Math.floor(quota * QUOTA_SHARE));
+    }
+  } catch {
+    // No Storage API (or it refused): fall back to the fixed ceiling.
+  }
+  return MAX_TOTAL_BYTES;
+}
+
+/** Delete every revision of one document. Caller owns the transaction. */
+async function deleteBlobsOf(tx: IDBTransaction, docId: string): Promise<void> {
+  const store = tx.objectStore(BLOBS_STORE);
+  const keys = await requestToPromise(store.index(BLOBS_BY_DOC).getAllKeys(IDBKeyRange.only(docId)));
+  for (const key of keys) store.delete(key);
+}
+
+/** Drop revisions past MAX_REVS_PER_DOC, oldest first. Returns bytes freed. */
+async function trimRevisions(tx: IDBTransaction, docId: string): Promise<number> {
+  const store = tx.objectStore(BLOBS_STORE);
+  const rows = ((await requestToPromise(store.index(BLOBS_BY_DOC).getAll(IDBKeyRange.only(docId)))) ??
+    []) as HistorySnapshot[];
+  if (rows.length <= MAX_REVS_PER_DOC) return 0;
+
+  const doomed = rows.sort((a, b) => a.rev - b.rev).slice(0, rows.length - MAX_REVS_PER_DOC);
+  let freed = 0;
+  for (const row of doomed) {
+    store.delete([row.docId, row.rev]);
+    freed += row.byteLength;
+  }
+  return freed;
+}
+
+/**
+ * Evict whole documents, least-recently-opened first, until the library fits
+ * the budget. `protectedId` is the document being written right now: evicting
+ * it to make room for itself would be a loop that ends in an empty database.
+ */
+async function enforceBudget(tx: IDBTransaction, budget: number, protectedId: string): Promise<void> {
+  const docs = await readAllDocs(tx);
+  let total = docs.reduce((sum, doc) => sum + (doc.totalBytes || 0), 0);
+  if (total <= budget) return;
+
+  const candidates = docs.filter((doc) => doc.id !== protectedId).sort((a, b) => a.lastOpenedAt - b.lastOpenedAt);
+
+  for (const doc of candidates) {
+    if (total <= budget) break;
+    await deleteBlobsOf(tx, doc.id);
+    tx.objectStore(DOCS_STORE).delete(doc.id);
+    total -= doc.totalBytes || 0;
+  }
+}
+
+async function writeSnapshot(payload: Uint8Array, input: SnapshotInput, budget: number): Promise<HistoryDoc | null> {
+  const byteLength = payload.byteLength;
+  const now = stamp();
+  const title = input.title.trim() || 'Untitled';
+
+  return withStores([DOCS_STORE, BLOBS_STORE], 'readwrite', async (tx) => {
+    const docs = tx.objectStore(DOCS_STORE);
+    const existing = input.id ? ((await requestToPromise(docs.get(input.id))) as HistoryDoc | undefined) : undefined;
+
+    const doc: HistoryDoc = existing
+      ? {
+          ...existing,
+          title,
+          titleLower: title.toLowerCase(),
+          ext: extensionOf(title),
+          size: byteLength,
+          totalBytes: existing.totalBytes + byteLength,
+          updatedAt: now,
+          revCount: existing.revCount + 1,
+          nextRev: existing.nextRev + 1,
+          // A fresh snapshot is fresh news: an offer the user dismissed was
+          // about work they have since added to.
+          dismissedAt: undefined,
+        }
+      : {
+          id: input.id ?? newId(),
+          title,
+          titleLower: title.toLowerCase(),
+          ext: extensionOf(title),
+          origin: input.origin,
+          size: byteLength,
+          totalBytes: byteLength,
+          createdAt: now,
+          updatedAt: now,
+          lastOpenedAt: now,
+          revCount: 1,
+          nextRev: 1,
+        };
+
+    const rev = existing ? existing.nextRev : 0;
+    const snapshot: HistorySnapshot = { docId: doc.id, rev, savedAt: now, bytes: payload, byteLength };
+    tx.objectStore(BLOBS_STORE).put(snapshot);
+
+    const freed = await trimRevisions(tx, doc.id);
+    doc.totalBytes -= freed;
+    doc.revCount = Math.min(doc.revCount, MAX_REVS_PER_DOC);
+    docs.put(doc);
+
+    await enforceBudget(tx, budget, doc.id);
+    return doc;
+  });
+}
+
+/**
+ * Append a snapshot, enforcing retention in the same transaction.
+ *
+ * Returns the stored metadata row, or null when the snapshot could not be
+ * kept -- the caller (the autosave scheduler) treats that as "stop trying and
+ * tell the user", because an autosave that fails in silence is worse than one
+ * that was never switched on.
+ */
+export async function putSnapshot(input: SnapshotInput): Promise<HistoryDoc | null> {
+  const budget = await storageBudget();
+  const payload = await toBytes(input.bytes);
+  try {
+    return await writeSnapshot(payload, input, budget);
+  } catch (error) {
+    if (!isQuotaError(error)) return null;
+    // Out of room: drop the coldest document and try once. Retrying forever
+    // would trade the user's whole library for one snapshot.
+    const evicted = await evictColdest(input.id);
+    if (!evicted) return null;
+    try {
+      return await writeSnapshot(payload, input, budget);
+    } catch {
+      return null;
+    }
+  }
+}
+
+/** Delete the least-recently-opened document. Returns false when there is none. */
+async function evictColdest(protectedId?: string): Promise<boolean> {
+  try {
+    return (
+      (await withStores([DOCS_STORE, BLOBS_STORE], 'readwrite', async (tx) => {
+        const docs = (await readAllDocs(tx)).filter((doc) => doc.id !== protectedId);
+        if (!docs.length) return false;
+        const coldest = docs.sort((a, b) => a.lastOpenedAt - b.lastOpenedAt)[0];
+        await deleteBlobsOf(tx, coldest.id);
+        tx.objectStore(DOCS_STORE).delete(coldest.id);
+        return true;
+      })) ?? false
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * One page of the history list, newest first, optionally filtered by title.
+ *
+ * Filtering happens in memory on purpose. IndexedDB can only range-scan a key,
+ * which gets prefix matching and nothing else -- no substring, no case
+ * folding, and nothing usable for Chinese titles. Metadata rows are well under
+ * a kilobyte, so reading them all and filtering is both simpler and more
+ * capable than a prefix index; the day a library is large enough for that to
+ * hurt, this is the one function that has to change.
+ */
+export async function listDocs(
+  options: { query?: string; page?: number; pageSize?: number } = {},
+): Promise<DocListResult> {
+  const pageSize = Math.max(1, options.pageSize ?? DEFAULT_PAGE_SIZE);
+  const query = (options.query ?? '').trim().toLowerCase();
+
+  let rows: HistoryDoc[] = [];
+  try {
+    rows = (await withStores([DOCS_STORE], 'readonly', (tx) => readAllDocs(tx))) ?? [];
+  } catch {
+    rows = [];
+  }
+
+  const matched = query ? rows.filter((doc) => doc.titleLower.includes(query)) : rows;
+  const pageCount = Math.max(1, Math.ceil(matched.length / pageSize));
+  // Clamp rather than return an empty page: deleting the last row of the last
+  // page would otherwise leave the user staring at nothing.
+  const page = Math.min(Math.max(1, options.page ?? 1), pageCount);
+  const start = (page - 1) * pageSize;
+
+  return { items: matched.slice(start, start + pageSize), total: matched.length, page, pageSize };
+}
+
+export async function getDoc(id: string): Promise<HistoryDoc | null> {
+  try {
+    return (
+      (await withStores([DOCS_STORE], 'readonly', async (tx) => {
+        return ((await requestToPromise(tx.objectStore(DOCS_STORE).get(id))) as HistoryDoc | undefined) ?? null;
+      })) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+/** The newest stored revision of one document, bytes included. */
+export async function getLatestSnapshot(id: string): Promise<HistorySnapshot | null> {
+  try {
+    return (
+      (await withStores([BLOBS_STORE], 'readonly', async (tx) => {
+        const rows = ((await requestToPromise(
+          tx.objectStore(BLOBS_STORE).index(BLOBS_BY_DOC).getAll(IDBKeyRange.only(id)),
+        )) ?? []) as HistorySnapshot[];
+        if (!rows.length) return null;
+        return rows.sort((a, b) => b.rev - a.rev)[0];
+      })) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+/** Remove one document and every revision of it. */
+export async function deleteDoc(id: string): Promise<boolean> {
+  try {
+    return (
+      (await withStores([DOCS_STORE, BLOBS_STORE], 'readwrite', async (tx) => {
+        await deleteBlobsOf(tx, id);
+        tx.objectStore(DOCS_STORE).delete(id);
+        return true;
+      })) ?? false
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Empty the library. This is the promise the UI makes to anyone on a shared
+ * machine, so it clears the bytes as well as the index -- a "clear" that only
+ * dropped metadata would leave every document sitting in the blob store.
+ */
+export async function clearAllHistory(): Promise<boolean> {
+  try {
+    return (
+      (await withStores([DOCS_STORE, BLOBS_STORE], 'readwrite', async (tx) => {
+        tx.objectStore(DOCS_STORE).clear();
+        tx.objectStore(BLOBS_STORE).clear();
+        return true;
+      })) ?? false
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function patchDoc(id: string, patch: Partial<HistoryDoc>): Promise<HistoryDoc | null> {
+  try {
+    return (
+      (await withStores([DOCS_STORE], 'readwrite', async (tx) => {
+        const store = tx.objectStore(DOCS_STORE);
+        const doc = (await requestToPromise(store.get(id))) as HistoryDoc | undefined;
+        if (!doc) return null;
+        const next = { ...doc, ...patch };
+        store.put(next);
+        return next;
+      })) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+/** The document was opened in the editor: it is the warmest thing in the library. */
+export function markOpened(id: string): Promise<HistoryDoc | null> {
+  return patchDoc(id, { lastOpenedAt: stamp() });
+}
+
+/** Bytes reached the user's disk, so this document has nothing left to recover. */
+export function markSavedToDisk(id: string): Promise<HistoryDoc | null> {
+  return patchDoc(id, { savedToDiskAt: stamp() });
+}
+
+/** The user turned down the recovery offer; do not ask again for this revision. */
+export function dismissRecovery(id: string): Promise<HistoryDoc | null> {
+  return patchDoc(id, { dismissedAt: stamp() });
+}
+
+/**
+ * Find an existing row for a file name.
+ *
+ * Reopening `Report.docx` continues the same history entry rather than
+ * starting a second one. Matching on the name is a judgement call: two
+ * different files with one name end up sharing a row, which costs a revision
+ * or two, while the alternative -- a new row per open -- fills the list with
+ * duplicates of the file the user works on every day, which is the case that
+ * actually happens.
+ */
+export async function findDocByTitle(title: string): Promise<HistoryDoc | null> {
+  const wanted = title.trim().toLowerCase();
+  if (!wanted) return null;
+  try {
+    const rows = (await withStores([DOCS_STORE], 'readonly', (tx) => readAllDocs(tx))) ?? [];
+    return rows.find((doc) => doc.titleLower === wanted) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The most recent document holding work that never reached the disk, ignoring
+ * offers the user already turned down. This is what the recovery bar and the
+ * landing page's "continue editing" line ask for.
+ */
+export async function getRecoverableDoc(
+  options: { excludeId?: string; maxAgeMs?: number } = {},
+): Promise<HistoryDoc | null> {
+  try {
+    const rows = (await withStores([DOCS_STORE], 'readonly', (tx) => readAllDocs(tx))) ?? [];
+    const cutoff = options.maxAgeMs ? stamp() - options.maxAgeMs : 0;
+    return (
+      rows.find(
+        (doc) =>
+          doc.id !== options.excludeId &&
+          hasUnsavedWork(doc) &&
+          doc.updatedAt > (doc.dismissedAt ?? 0) &&
+          doc.updatedAt >= cutoff,
+      ) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+/** Total bytes the library currently occupies, metadata only. */
+export async function historyUsage(): Promise<number> {
+  try {
+    const rows = (await withStores([DOCS_STORE], 'readonly', (tx) => readAllDocs(tx))) ?? [];
+    return rows.reduce((sum, doc) => sum + (doc.totalBytes || 0), 0);
+  } catch {
+    return 0;
+  }
+}

--- a/lib/history/store.ts
+++ b/lib/history/store.ts
@@ -19,7 +19,7 @@
  */
 import { BLOBS_BY_DOC, BLOBS_STORE, DOCS_STORE, requestToPromise, withStores } from './db';
 import type { HistoryDoc, HistoryOrigin, HistorySnapshot } from './types';
-import { hasUnsavedWork } from './types';
+import { MAX_AGE_MS, expiresAt, hasUnsavedWork } from './types';
 
 /** Revisions kept per document: the newest plus two recovery points behind it. */
 export const MAX_REVS_PER_DOC = 3;
@@ -27,6 +27,8 @@ export const MAX_REVS_PER_DOC = 3;
 export const MAX_TOTAL_BYTES = 500 * 1024 * 1024;
 /** Never claim more than this share of the origin's reported quota. */
 export const QUOTA_SHARE = 0.5;
+/** Re-exported so callers can state the retention window without importing types. */
+export { MAX_AGE_MS };
 /** Default page size for the history list. */
 export const DEFAULT_PAGE_SIZE = 20;
 
@@ -133,6 +135,21 @@ async function trimRevisions(tx: IDBTransaction, docId: string): Promise<number>
 }
 
 /**
+ * Delete everything past its seven days. Runs inside whatever transaction the
+ * caller already has: expiry has to be something the browser does on its own,
+ * not something that waits for the user to visit a page.
+ */
+async function sweepExpired(tx: IDBTransaction, now: number): Promise<string[]> {
+  const docs = await readAllDocs(tx);
+  const expired = docs.filter((doc) => expiresAt(doc) <= now);
+  for (const doc of expired) {
+    await deleteBlobsOf(tx, doc.id);
+    tx.objectStore(DOCS_STORE).delete(doc.id);
+  }
+  return expired.map((doc) => doc.id);
+}
+
+/**
  * Evict whole documents, least-recently-opened first, until the library fits
  * the budget. `protectedId` is the document being written right now: evicting
  * it to make room for itself would be a loop that ends in an empty database.
@@ -194,6 +211,10 @@ async function writeSnapshot(payload: Uint8Array, input: SnapshotInput, budget: 
     const rev = existing ? existing.nextRev : 0;
     const snapshot: HistorySnapshot = { docId: doc.id, rev, savedAt: now, bytes: payload, byteLength };
     tx.objectStore(BLOBS_STORE).put(snapshot);
+
+    // Expiry first: room freed by documents that were due to go anyway is room
+    // the budget does not have to take from documents that are still current.
+    await sweepExpired(tx, now);
 
     const freed = await trimRevisions(tx, doc.id);
     doc.totalBytes -= freed;
@@ -379,27 +400,6 @@ export function dismissRecovery(id: string): Promise<HistoryDoc | null> {
 }
 
 /**
- * Find an existing row for a file name.
- *
- * Reopening `Report.docx` continues the same history entry rather than
- * starting a second one. Matching on the name is a judgement call: two
- * different files with one name end up sharing a row, which costs a revision
- * or two, while the alternative -- a new row per open -- fills the list with
- * duplicates of the file the user works on every day, which is the case that
- * actually happens.
- */
-export async function findDocByTitle(title: string): Promise<HistoryDoc | null> {
-  const wanted = title.trim().toLowerCase();
-  if (!wanted) return null;
-  try {
-    const rows = (await withStores([DOCS_STORE], 'readonly', (tx) => readAllDocs(tx))) ?? [];
-    return rows.find((doc) => doc.titleLower === wanted) ?? null;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * The most recent document holding work that never reached the disk, ignoring
  * offers the user already turned down. This is what the recovery bar and the
  * landing page's "continue editing" line ask for.
@@ -421,6 +421,29 @@ export async function getRecoverableDoc(
     );
   } catch {
     return null;
+  }
+}
+
+/**
+ * Delete expired documents now. Called when the app starts and when the
+ * history page opens, so the seven days hold even for someone who edits
+ * nothing (a write would otherwise be the only thing that sweeps).
+ */
+/**
+ * Test seam. The monotonic clock is module-wide and only ever moves forward,
+ * which is right in a browser tab and wrong across tests: one case that winds
+ * the system clock forward would otherwise stamp every later case's records
+ * with a time in the future, and nothing would ever look expired again.
+ */
+export function resetHistoryClockForTests(): void {
+  lastStamp = 0;
+}
+
+export async function pruneExpired(): Promise<string[]> {
+  try {
+    return (await withStores([DOCS_STORE, BLOBS_STORE], 'readwrite', (tx) => sweepExpired(tx, Date.now()))) ?? [];
+  } catch {
+    return [];
   }
 }
 

--- a/lib/history/types.ts
+++ b/lib/history/types.ts
@@ -64,3 +64,30 @@ export interface HistorySnapshot {
 export function hasUnsavedWork(doc: HistoryDoc): boolean {
   return doc.updatedAt > (doc.savedToDiskAt ?? 0);
 }
+
+/**
+ * How long a document stays in the local history.
+ *
+ * Recovery points are for getting back to work you were in the middle of, not
+ * for keeping a library -- Office expires its AutoRecover files too. A fixed
+ * window is also the honest version of the privacy promise: "this browser
+ * forgets on its own" is something a user can rely on, in a way that "until
+ * some quota is reached" is not. Seven days is long enough to cover a holiday
+ * weekend and short enough that a shared machine does not accumulate a month
+ * of someone's documents.
+ */
+export const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * When this document is due to be deleted. The clock restarts on either kind
+ * of activity -- editing it or just opening it -- so a document someone keeps
+ * coming back to never expires under them.
+ */
+export function expiresAt(doc: HistoryDoc): number {
+  return Math.max(doc.updatedAt, doc.lastOpenedAt) + MAX_AGE_MS;
+}
+
+/** Whole days left before this document is deleted; 0 means "today". */
+export function daysUntilExpiry(doc: HistoryDoc, now = Date.now()): number {
+  return Math.max(0, Math.ceil((expiresAt(doc) - now) / (24 * 60 * 60 * 1000)));
+}

--- a/lib/history/types.ts
+++ b/lib/history/types.ts
@@ -1,0 +1,66 @@
+/** Shapes stored in the history database. Kept apart from the access layer so
+ *  the history page, the recovery bar and the autosave scheduler can talk about
+ *  records without pulling IndexedDB code into their bundles. */
+
+/** Where the document came from, for the history list's subtitle. */
+export type HistoryOrigin = 'local' | 'url' | 'new';
+
+/** One document's metadata row. Small on purpose: the list view reads these and
+ *  never touches the bytes, which is what keeps it fast with a full library. */
+export interface HistoryDoc {
+  id: string;
+  /** File name as the user sees it, e.g. `Report.docx`. */
+  title: string;
+  /** Lower-cased title, the search key (IndexedDB has no case-insensitive compare). */
+  titleLower: string;
+  /** Extension without the dot, lower-cased. */
+  ext: string;
+  origin: HistoryOrigin;
+  /** Byte length of the newest snapshot (what the list shows). */
+  size: number;
+  /**
+   * Byte length of every snapshot this document still has. Maintained here so
+   * the storage budget can be totalled by reading metadata alone -- summing the
+   * blob store would mean pulling every stored document into memory to add up
+   * its size.
+   */
+  totalBytes: number;
+  createdAt: number;
+  /** When the newest snapshot was taken. Drives ordering in the list. */
+  updatedAt: number;
+  lastOpenedAt: number;
+  /** How many snapshots this document currently has stored. */
+  revCount: number;
+  /** Next revision number to hand out; monotonic, never reused. */
+  nextRev: number;
+  /**
+   * When bytes for this document last reached the user's disk. Compared with
+   * `updatedAt` to answer the only question the recovery bar cares about:
+   * is there work here that never made it out of the browser?
+   */
+  savedToDiskAt?: number;
+  /** When the user dismissed the recovery offer for this document. */
+  dismissedAt?: number;
+}
+
+/**
+ * One snapshot's bytes, stored under `[docId, rev]`.
+ *
+ * A typed array rather than a Blob: the bytes arrive as an ArrayBuffer from the
+ * editor frame and go back to it as one, so a Blob would add a wrap on the way
+ * in and an async unwrap on the way out for no gain. Typed arrays are also the
+ * shape every structured-clone implementation round-trips faithfully, which a
+ * Blob is not.
+ */
+export interface HistorySnapshot {
+  docId: string;
+  rev: number;
+  savedAt: number;
+  bytes: Uint8Array;
+  byteLength: number;
+}
+
+/** A document that has edits which never reached the disk. */
+export function hasUnsavedWork(doc: HistoryDoc): boolean {
+  return doc.updatedAt > (doc.savedToDiskAt ?? 0);
+}

--- a/lib/onlyoffice-editor.ts
+++ b/lib/onlyoffice-editor.ts
@@ -18,6 +18,7 @@ import {
   releaseOpenAttemptBytes,
   setOpenRunner,
 } from './onlyoffice/open-failure';
+import { markDocumentDirty, markDocumentSaved, resetUnsavedChanges } from './unsaved-guard';
 import { getSdkEditorApi, ASC_RESTRICTION_VIEW } from './onlyoffice/sdk-api';
 import { getReadonlyMode, setReadonlyState } from './onlyoffice/readonly';
 import { resolveUiTheme } from './onlyoffice/ui-theme';
@@ -282,6 +283,20 @@ function createPersonalEditorInstance(config: {
         }
         console.log(`${t('documentLoaded')}${fileName}`);
       },
+      // The editor's modified flag. This is the only signal the app has that
+      // there is work worth protecting, and it has to be wired here: the
+      // serverless save guard routes Save/Ctrl+S to asc_DownloadAs, so the
+      // SDK's own "document saved" bookkeeping never runs.
+      onDocumentStateChange: (event: unknown) => {
+        const modified = (event as { data?: boolean } | null)?.data;
+        if (modified === false) {
+          // The SDK says there is nothing to save: a fresh document, or undo
+          // walked the history back to the state it was opened in.
+          markDocumentSaved();
+        } else {
+          markDocumentDirty();
+        }
+      },
       // Must be declared even as a no-op: the api layer only runs downloadAs
       // when this callback exists. Actual bytes arrive via the
       // onlyoffice-file-stream message, not through this event.
@@ -353,6 +368,9 @@ export function createEditorInstance(config: {
   isRetry?: boolean;
 }): Promise<void> {
   registerOpenAttempt(config);
+  // A new document is taking over the frame: whatever was unsaved belonged to
+  // the one being replaced.
+  resetUnsavedChanges();
   // Asked once per session, well before any failure needs to report it: the
   // answer is only read from the out-of-memory branch of the error toast.
   resolveBuildBitness();

--- a/lib/onlyoffice/guards/unload-prompt.ts
+++ b/lib/onlyoffice/guards/unload-prompt.ts
@@ -1,0 +1,44 @@
+/**
+ * 11. One unload prompt, and the right one.
+ *
+ * The vendor sets `window.onbeforeunload` inside the editor frame whenever the
+ * document is editable, so a same-origin frame plus the app's own guard means
+ * two handlers for one navigation. Chromium refuses the second ("Blocked
+ * attempt to show multiple 'beforeunload' confirmation panels") and logs it as
+ * an error, which is the visible symptom; the real problem is which of the two
+ * is telling the truth.
+ *
+ * The vendor's answer comes from the SDK's own "document modified" bookkeeping,
+ * and serverless save semantics (guard 5) route Save/Ctrl+S to asc_DownloadAs
+ * instead of the SDK's save path -- so that bookkeeping never learns the
+ * document was saved. Its prompt therefore keeps firing after the user has the
+ * file on disk, which is the way to teach someone to dismiss the prompt without
+ * reading it.
+ *
+ * The app's guard (lib/unsaved-guard.ts) tracks the same thing from the outside
+ * and is cleared by an actual export, so the frame's copy is dropped and the
+ * host window is left as the single source of the warning.
+ */
+export function installSingleUnloadPrompt(win: Window): boolean {
+  const target = win as Window & { __ooUnloadPromptPatched?: boolean };
+  if (target.__ooUnloadPromptPatched) return true;
+
+  try {
+    // A property, not an assignment: the vendor sets this from its own document
+    // lifecycle, which lands at times this guard's polling does not line up
+    // with. Swallowing the assignment covers every one of them.
+    Object.defineProperty(win, 'onbeforeunload', {
+      configurable: true,
+      get: () => null,
+      set: () => {
+        /* the host window owns the unsaved-changes prompt */
+      },
+    });
+    target.__ooUnloadPromptPatched = true;
+  } catch {
+    // Some engines refuse to redefine the handler property; the duplicate
+    // prompt is cosmetic next to losing the guard entirely, so carry on.
+    return false;
+  }
+  return true;
+}

--- a/lib/onlyoffice/iframe-guards.ts
+++ b/lib/onlyoffice/iframe-guards.ts
@@ -10,6 +10,7 @@ import { installFontLoadAcceleration } from './guards/font-loading';
 import { installCommentSelectionGuard } from './guards/comment-selection';
 import { installCanvasLossGuard } from './guards/canvas-loss';
 import { releaseWasmBinary } from './guards/wasm-binary-release';
+import { installSingleUnloadPrompt } from './guards/unload-prompt';
 
 /**
  * Same-origin preparation of the editor iframe, applied from onAppReady and
@@ -50,6 +51,7 @@ export function prepareEditorIframe(): boolean {
       installFontLoadAcceleration(win);
       installCommentSelectionGuard(win);
       installCanvasLossGuard(win, doc);
+      installSingleUnloadPrompt(win);
       const wasmBinaryHandled = releaseWasmBinary(win);
 
       if (

--- a/lib/onlyoffice/save-stream.ts
+++ b/lib/onlyoffice/save-stream.ts
@@ -5,6 +5,8 @@ import { oAscFileType } from '../file-types';
 import { getFileExtension, getNormalizedFile, getSavedFileMimeType } from './file-helpers';
 import { getDocumentOpenError, waitForDocumentContentReady } from './open-state';
 import { getReadonlyMode } from './readonly';
+import { isEmbedMode } from '../embed-mode';
+import { markDocumentSaved } from '../unsaved-guard';
 
 /**
  * The v9 save channel end to end: the request the caller holds, the export
@@ -31,16 +33,6 @@ let embeddedSaveRequest: EmbeddedSaveRequest | null = null;
 export const SAVE_READY_WAIT_MS = 150_000;
 export const SAVE_RETRY_WINDOW_MS = 25_000;
 export const SAVE_REQUEST_TIMEOUT_MS = 180_000;
-
-function isEmbedMode(): boolean {
-  if (typeof window === 'undefined') {
-    return false;
-  }
-
-  const params = new URLSearchParams(window.location.search);
-  const embed = params.get('embed') || params.get('embedded');
-  return window.parent !== window || embed === '' || embed === '1' || embed === 'true';
-}
 
 function resolveEmbeddedSaveRequest(request: EmbeddedSaveRequest, file: File): void {
   if (request.settled) {
@@ -107,7 +99,9 @@ function routeSavedFile(file: File): void {
     return;
   }
 
-  saveFileToDisk(file, file.name).catch(notifyOperationFailed);
+  // Reaching the user's disk is the only thing that clears the unsaved-changes
+  // warning: an autosave snapshot lives in this browser, a saved file does not.
+  saveFileToDisk(file, file.name).then(markDocumentSaved).catch(notifyOperationFailed);
 }
 
 function handleFileStreamMessage(event: MessageEvent): void {

--- a/lib/onlyoffice/save-stream.ts
+++ b/lib/onlyoffice/save-stream.ts
@@ -9,6 +9,19 @@ import { isEmbedMode } from '../embed-mode';
 import { markDocumentSaved } from '../unsaved-guard';
 
 /**
+ * Notified when bytes actually reach the user's disk.
+ *
+ * Injected rather than imported: the history layer exports through this
+ * module, so importing it back would close a cycle. Same shape as
+ * setConverterCallbacks elsewhere in the app.
+ */
+let savedToDiskListener: (() => void) | null = null;
+
+export function setSavedToDiskListener(listener: (() => void) | null): void {
+  savedToDiskListener = listener;
+}
+
+/**
  * The v9 save channel end to end: the request the caller holds, the export
  * trigger on the editor frame, and the 'onlyoffice-file-stream' message the
  * finished bytes come back on.
@@ -101,7 +114,12 @@ function routeSavedFile(file: File): void {
 
   // Reaching the user's disk is the only thing that clears the unsaved-changes
   // warning: an autosave snapshot lives in this browser, a saved file does not.
-  saveFileToDisk(file, file.name).then(markDocumentSaved).catch(notifyOperationFailed);
+  saveFileToDisk(file, file.name)
+    .then(() => {
+      markDocumentSaved();
+      savedToDiskListener?.();
+    })
+    .catch(notifyOperationFailed);
 }
 
 function handleFileStreamMessage(event: MessageEvent): void {

--- a/lib/unsaved-guard.ts
+++ b/lib/unsaved-guard.ts
@@ -24,10 +24,21 @@ import { isEmbedMode } from './embed-mode';
 
 let dirty = false;
 let installed = false;
+let lastEditAt = 0;
 
 /** The editor reported an edit (`onDocumentStateChange` with modified = true). */
 export function markDocumentDirty(): void {
   dirty = true;
+  lastEditAt = Date.now();
+}
+
+/**
+ * When the editor last reported an edit. The autosave scheduler waits for a
+ * short lull before exporting: the export runs a full conversion in the editor
+ * frame, and starting one on top of active typing is felt.
+ */
+export function getLastEditAt(): number {
+  return lastEditAt;
 }
 
 /** The document's bytes reached the user's disk: nothing is at risk any more. */
@@ -67,6 +78,7 @@ export function installUnsavedChangesGuard(): void {
  */
 export function resetUnsavedGuardForTests(): void {
   dirty = false;
+  lastEditAt = 0;
   if (installed && typeof window !== 'undefined') {
     window.removeEventListener('beforeunload', handleBeforeUnload);
   }

--- a/lib/unsaved-guard.ts
+++ b/lib/unsaved-guard.ts
@@ -1,0 +1,74 @@
+/**
+ * "You have unsaved changes" -- the cheapest layer of loss protection, and the
+ * one this app was missing entirely.
+ *
+ * Everything else in the history stack (autosave snapshots, the recovery bar)
+ * recovers work *after* it is lost. This one stops the most common loss from
+ * happening at all: the accidental Cmd+W / Ctrl+R on a document that has never
+ * been exported. It costs no storage and touches no user data.
+ *
+ * What it deliberately does NOT do:
+ * - It is not armed in embed mode. The document belongs to the host page and
+ *   the host owns its own unload UX.
+ * - An autosave snapshot does not disarm it. A snapshot lives in this browser;
+ *   the user still has no file on disk, which is exactly what they are about
+ *   to walk away from. Only a real export to disk clears the flag (this is the
+ *   same split Office draws between AutoRecover and Save).
+ *
+ * Browser limits worth knowing: the prompt's wording is the browser's, not
+ * ours; the page must have been interacted with (sticky activation) for the
+ * prompt to appear at all; and mobile task-switching never fires it. So this
+ * layer catches slips, not crashes -- crashes are what the snapshots are for.
+ */
+import { isEmbedMode } from './embed-mode';
+
+let dirty = false;
+let installed = false;
+
+/** The editor reported an edit (`onDocumentStateChange` with modified = true). */
+export function markDocumentDirty(): void {
+  dirty = true;
+}
+
+/** The document's bytes reached the user's disk: nothing is at risk any more. */
+export function markDocumentSaved(): void {
+  dirty = false;
+}
+
+/** A different document is taking over the editor; its edit history is not ours. */
+export function resetUnsavedChanges(): void {
+  dirty = false;
+}
+
+export function hasUnsavedChanges(): boolean {
+  return dirty;
+}
+
+function handleBeforeUnload(event: BeforeUnloadEvent): void {
+  if (!dirty) return;
+  // Both spellings on purpose: preventDefault() is what the spec asks for,
+  // returnValue is what older WebKit still checks. The string is never shown --
+  // every browser prints its own wording.
+  event.preventDefault();
+  event.returnValue = '';
+}
+
+export function installUnsavedChangesGuard(): void {
+  if (installed || typeof window === 'undefined' || isEmbedMode()) return;
+  installed = true;
+  window.addEventListener('beforeunload', handleBeforeUnload);
+}
+
+/**
+ * Test seam. In production the listener is installed once and lives as long as
+ * the page does; tests need to put the window back the way they found it,
+ * because a stale listener from a previous case answers for a module instance
+ * the current case cannot see (the same trap documented for embed-api).
+ */
+export function resetUnsavedGuardForTests(): void {
+  dirty = false;
+  if (installed && typeof window !== 'undefined') {
+    window.removeEventListener('beforeunload', handleBeforeUnload);
+  }
+  installed = false;
+}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@playwright/test": "^1.62.1",
     "@types/node": "^26.2.0",
     "@vitest/coverage-v8": "^4.1.10",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^30.0.1",
     "marked": "16.4.2",
     "oxlint": "^1.78.0",

--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -207,6 +207,38 @@ export interface I18nMessages {
   agentMaxSteps: string;
   agentToolCallPrefix: string;
   agentToolErrorPrefix: string;
+
+  // Local history: autosave, the recovery offer, and the history page
+  autosaveStopped: string;
+  autosaveOtherTab: string;
+  recoveryTitle: string;
+  /** `{title}` is the file name, `{when}` a relative time such as "5 minutes ago". */
+  recoveryBody: string;
+  recoveryRestore: string;
+  recoveryDismiss: string;
+  recoveryViewAll: string;
+  historyTitle: string;
+  historyIntro: string;
+  historyNotBackup: string;
+  historySearchPlaceholder: string;
+  historyEmpty: string;
+  historyEmptySearch: string;
+  historyOpen: string;
+  historyDelete: string;
+  /** `{title}` is the file name. */
+  historyDeleteConfirm: string;
+  historyClearAll: string;
+  historyClearConfirm: string;
+  historyUnsaved: string;
+  /** `{size}` is a human-readable byte size. */
+  historyUsage: string;
+  /** `{page}` and `{pages}` are 1-based page numbers. */
+  historyPageInfo: string;
+  historyPrev: string;
+  historyNext: string;
+  historyBack: string;
+  historyAutosaveLabel: string;
+  historyAutosaveOff: string;
 }
 
 /**
@@ -275,6 +307,33 @@ const completeMessages: Record<LanguageCode.ZH | LanguageCode.EN, I18nMessages> 
     agentMaxSteps: '已达到最大执行步数，已停止。',
     agentToolCallPrefix: '调用工具：',
     agentToolErrorPrefix: '工具出错：',
+
+    autosaveStopped: '自动保存已停止：浏览器没有可用的存储空间了。',
+    autosaveOtherTab: '另一个标签页正在编辑这个文档，本页不会自动保存。',
+    recoveryTitle: '有未保存到磁盘的编辑',
+    recoveryBody: '「{title}」在 {when} 还有没有保存到磁盘的编辑。',
+    recoveryRestore: '恢复',
+    recoveryDismiss: '丢弃',
+    recoveryViewAll: '查看全部',
+    historyTitle: '本地历史',
+    historyIntro: '自动保存的文档只留在这台设备的浏览器里，从未上传。随时可以删除。',
+    historyNotBackup: '这些是恢复点，不是备份——重要文档请照常导出保存到磁盘。',
+    historySearchPlaceholder: '搜索标题',
+    historyEmpty: '还没有自动保存的文档。',
+    historyEmptySearch: '没有匹配的文档。',
+    historyOpen: '打开',
+    historyDelete: '删除',
+    historyDeleteConfirm: '删除「{title}」及其全部快照？此操作不可撤销。',
+    historyClearAll: '清空全部',
+    historyClearConfirm: '删除这台设备上保存的全部文档？此操作不可撤销。',
+    historyUnsaved: '未存盘',
+    historyUsage: '已占用 {size}',
+    historyPageInfo: '第 {page} / {pages} 页',
+    historyPrev: '上一页',
+    historyNext: '下一页',
+    historyBack: '返回编辑器',
+    historyAutosaveLabel: '自动保存',
+    historyAutosaveOff: '自动保存已关闭，不会再产生新的恢复点。',
   },
   [LanguageCode.EN]: {
     webOffice: 'Web Office',
@@ -336,6 +395,34 @@ const completeMessages: Record<LanguageCode.ZH | LanguageCode.EN, I18nMessages> 
     agentMaxSteps: 'Reached the maximum number of steps; stopped.',
     agentToolCallPrefix: 'Tool call: ',
     agentToolErrorPrefix: 'Tool error: ',
+
+    autosaveStopped: 'Autosave stopped: this browser has no storage room left.',
+    autosaveOtherTab: 'Another tab is editing this document, so this tab will not autosave it.',
+    recoveryTitle: 'Unsaved changes from last time',
+    recoveryBody: '"{title}" has edits from {when} that never reached your disk.',
+    recoveryRestore: 'Restore',
+    recoveryDismiss: 'Discard',
+    recoveryViewAll: 'View all',
+    historyTitle: 'Local history',
+    historyIntro:
+      'Autosaved documents stay in this browser on this device and are never uploaded. Delete them any time.',
+    historyNotBackup: 'These are recovery points, not backups -- keep exporting anything important to disk.',
+    historySearchPlaceholder: 'Search by title',
+    historyEmpty: 'Nothing has been autosaved yet.',
+    historyEmptySearch: 'No documents match that search.',
+    historyOpen: 'Open',
+    historyDelete: 'Delete',
+    historyDeleteConfirm: 'Delete "{title}" and all of its snapshots? This cannot be undone.',
+    historyClearAll: 'Clear everything',
+    historyClearConfirm: 'Delete every document saved in this browser? This cannot be undone.',
+    historyUnsaved: 'not on disk',
+    historyUsage: '{size} stored',
+    historyPageInfo: 'Page {page} of {pages}',
+    historyPrev: 'Previous',
+    historyNext: 'Next',
+    historyBack: 'Back to the editor',
+    historyAutosaveLabel: 'Autosave',
+    historyAutosaveOff: 'Autosave is off; no new recovery points are being made.',
   },
 };
 

--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -239,6 +239,10 @@ export interface I18nMessages {
   historyBack: string;
   historyAutosaveLabel: string;
   historyAutosaveOff: string;
+  historyRetention: string;
+  /** `{days}` is a whole number of days, always 1 or more. */
+  historyExpiresIn: string;
+  historyExpiresToday: string;
 }
 
 /**
@@ -334,6 +338,9 @@ const completeMessages: Record<LanguageCode.ZH | LanguageCode.EN, I18nMessages> 
     historyBack: '返回编辑器',
     historyAutosaveLabel: '自动保存',
     historyAutosaveOff: '自动保存已关闭，不会再产生新的恢复点。',
+    historyRetention: '自动清除：每个文档在最后一次编辑或打开的 7 天后被删除。',
+    historyExpiresIn: '{days} 天后清除',
+    historyExpiresToday: '今天清除',
   },
   [LanguageCode.EN]: {
     webOffice: 'Web Office',
@@ -423,6 +430,9 @@ const completeMessages: Record<LanguageCode.ZH | LanguageCode.EN, I18nMessages> 
     historyBack: 'Back to the editor',
     historyAutosaveLabel: 'Autosave',
     historyAutosaveOff: 'Autosave is off; no new recovery points are being made.',
+    historyRetention: 'Cleared automatically: each document is deleted 7 days after you last edit or open it.',
+    historyExpiresIn: 'deleted in {days} days',
+    historyExpiresToday: 'deleted today',
   },
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       jsdom:
         specifier: ^30.0.1
         version: 30.0.1
@@ -1152,6 +1155,10 @@ packages:
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2685,6 +2692,8 @@ snapshots:
   events@3.3.0: {}
 
   expect-type@1.4.0: {}
+
+  fake-indexeddb@6.2.5: {}
 
   fast-deep-equal@3.1.3: {}
 

--- a/public/_headers
+++ b/public/_headers
@@ -34,6 +34,8 @@
   Cache-Control: no-cache
 /landing-prefetch.js
   Cache-Control: no-cache
+/history-recent.js
+  Cache-Control: no-cache
 /ranui-iife/*
   Cache-Control: no-cache
 

--- a/public/history-recent.js
+++ b/public/history-recent.js
@@ -1,0 +1,91 @@
+// "Continue last time" on the static landing pages.
+//
+// The landing pages ship no app bundle, but a recovery point nobody is told
+// about is not a recovery: the common way back to this site is the homepage,
+// the day after, with the editor tab long closed. Reading one metadata row out
+// of IndexedDB costs a couple of kilobytes of plain script -- the same shape as
+// open-local.js next door -- and gives that visit a way back to the work.
+//
+// Bytes are never touched here, only the row: the file name, when it changed,
+// and whether it ever reached the disk. The DB/store names must stay in step
+// with lib/history/db.ts, which owns the schema.
+(function () {
+  var DB_NAME = 'document-history';
+  var STORE = 'docs';
+
+  function readNewest(callback) {
+    if (typeof indexedDB === 'undefined') return callback(null);
+    var request;
+    try {
+      request = indexedDB.open(DB_NAME);
+    } catch (error) {
+      return callback(null);
+    }
+    // Never create or upgrade from here: a landing page that has never opened a
+    // document should leave no database behind at all.
+    request.onupgradeneeded = function () {
+      try {
+        request.transaction.abort();
+      } catch (error) {
+        /* the open below resolves with an error either way */
+      }
+      callback(null);
+    };
+    request.onerror = function () {
+      callback(null);
+    };
+    request.onsuccess = function () {
+      var db = request.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        db.close();
+        return callback(null);
+      }
+      try {
+        var tx = db.transaction(STORE, 'readonly');
+        var all = tx.objectStore(STORE).getAll();
+        all.onsuccess = function () {
+          var rows = all.result || [];
+          rows.sort(function (a, b) {
+            return b.updatedAt - a.updatedAt;
+          });
+          db.close();
+          callback(rows[0] || null);
+        };
+        all.onerror = function () {
+          db.close();
+          callback(null);
+        };
+      } catch (error) {
+        db.close();
+        callback(null);
+      }
+    };
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var slot = document.querySelector('[data-recent-slot]');
+    if (!slot) return;
+
+    readNewest(function (doc) {
+      if (!doc || !doc.id || !doc.title) return;
+
+      var locale = slot.getAttribute('data-recent-locale') || '';
+      var suffix = locale ? '&locale=' + encodeURIComponent(locale) : '';
+
+      var resume = document.createElement('a');
+      resume.className = 'recent-resume';
+      resume.href = '/editor?open=history&id=' + encodeURIComponent(doc.id) + suffix;
+      resume.textContent = (slot.getAttribute('data-recent-label') || 'Continue') + ' ' + doc.title;
+
+      var all = document.createElement('a');
+      all.className = 'recent-all';
+      all.href = '/history' + (locale ? '?locale=' + encodeURIComponent(locale) : '');
+      all.textContent = slot.getAttribute('data-recent-all') || 'Local history';
+
+      slot.appendChild(resume);
+      slot.appendChild(document.createTextNode(' · '));
+      slot.appendChild(all);
+      slot.hidden = false;
+    });
+  });
+})();

--- a/public/history-recent.js
+++ b/public/history-recent.js
@@ -72,19 +72,16 @@
       var locale = slot.getAttribute('data-recent-locale') || '';
       var suffix = locale ? '&locale=' + encodeURIComponent(locale) : '';
 
+      // Only the resume link is drawn here. The retention note and the link to
+      // /history are in the served HTML: they are true whether or not this
+      // browser is holding anything, and a promise about someone's data should
+      // not depend on a script having run.
       var resume = document.createElement('a');
       resume.className = 'recent-resume';
-      resume.href = '/editor?open=history&id=' + encodeURIComponent(doc.id) + suffix;
+      resume.href = '/editor?doc=' + encodeURIComponent(doc.id) + suffix;
       resume.textContent = (slot.getAttribute('data-recent-label') || 'Continue') + ' ' + doc.title;
 
-      var all = document.createElement('a');
-      all.className = 'recent-all';
-      all.href = '/history' + (locale ? '?locale=' + encodeURIComponent(locale) : '');
-      all.textContent = slot.getAttribute('data-recent-all') || 'Local history';
-
       slot.appendChild(resume);
-      slot.appendChild(document.createTextNode(' · '));
-      slot.appendChild(all);
       slot.hidden = false;
     });
   });

--- a/public/home.css
+++ b/public/home.css
@@ -917,3 +917,26 @@
     justify-self: start;
   }
 }
+
+/* "Continue editing <file>" — only ever visible when this browser is holding
+   autosaved work (see /history-recent.js, which unhides it). It sits with the
+   trust row rather than in the CTA cluster: it is a return path for someone who
+   was already here, not one of the three things a first-time visitor chooses
+   between. */
+#landing-hero .recent {
+  margin-top: var(--ran-space-5);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--ran-space-1) var(--ran-space-2);
+  font-size: 14px;
+  color: var(--ran-color-text-secondary);
+}
+#landing-hero .recent a {
+  color: var(--ran-color-text);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+#landing-hero .recent a:hover {
+  color: var(--ran-color-primary);
+}

--- a/public/home.css
+++ b/public/home.css
@@ -940,3 +940,19 @@
 #landing-hero .recent a:hover {
   color: var(--ran-color-primary);
 }
+#landing-hero .recent-note {
+  /* The retention window is the load-bearing half of this line: it is the
+     difference between "the browser keeps my documents" and "the browser keeps
+     my documents for a week". */
+  color: var(--ran-color-text-secondary);
+}
+#landing-hero .recent-resume {
+  font-weight: 500;
+}
+#landing-hero .recent-resume::after {
+  content: '·';
+  margin-left: var(--ran-space-2);
+  color: var(--ran-color-text-disabled);
+  text-decoration: none;
+  display: inline-block;
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -38,7 +38,7 @@ const ASSETS_TO_CACHE = ['./', './index.html', './editor', './editor.html', './m
 // its content changed.) Network-first with `cache: 'no-cache'` is what the HTML branch already
 // does, for exactly the same reason.
 const DEPLOY_COUPLED =
-  /^\/(?:home|landing)\.css$|^\/(?:lang-switch|sw-register|open-local|landing-prefetch)\.js$|^\/ranui-iife\//;
+  /^\/(?:home|landing)\.css$|^\/(?:lang-switch|sw-register|open-local|landing-prefetch|history-recent)\.js$|^\/ranui-iife\//;
 
 // The OnlyOffice 9 tree is ~2600 files, but most of that is per-locale help
 // and on-demand font duplication a single session in one language never

--- a/public/zh-CN/index.html
+++ b/public/zh-CN/index.html
@@ -43,6 +43,7 @@
          purpose: './sw.js' would scope the worker to /zh-CN/. -->
     <script src="/sw-register.js" defer></script>
     <script src="/open-local.js" defer></script>
+    <script src="/history-recent.js" defer></script>
 
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="在线文档编辑器" />
@@ -180,6 +181,15 @@
             <a href="/editor?locale=zh-CN&amp;new=xlsx"><r-button>新建 Excel</r-button></a>
             <a href="/editor?locale=zh-CN&amp;new=pptx"><r-button>新建 PPT</r-button></a>
           </div>
+          <!-- 由 /history-recent.js 在本机存有自动保存内容时填充；首次访问保持隐藏 -->
+          <div
+            class="recent reveal d5"
+            data-recent-slot
+            data-recent-locale="zh-CN"
+            data-recent-label="继续编辑"
+            data-recent-all="本地历史"
+            hidden
+          ></div>
           <div class="trust reveal d5">
             <span>不传服务器</span><span class="sep">·</span><span>免注册</span><span class="sep">·</span
             ><span>可离线</span><span class="sep">·</span><span>.docx .xlsx .pptx .csv</span>

--- a/public/zh-CN/index.html
+++ b/public/zh-CN/index.html
@@ -181,15 +181,14 @@
             <a href="/editor?locale=zh-CN&amp;new=xlsx"><r-button>新建 Excel</r-button></a>
             <a href="/editor?locale=zh-CN&amp;new=pptx"><r-button>新建 PPT</r-button></a>
           </div>
-          <!-- 由 /history-recent.js 在本机存有自动保存内容时填充；首次访问保持隐藏 -->
-          <div
-            class="recent reveal d5"
-            data-recent-slot
-            data-recent-locale="zh-CN"
-            data-recent-label="继续编辑"
-            data-recent-all="本地历史"
-            hidden
-          ></div>
+          <!-- 自动保存是对用户数据的承诺，所以保留期限和"查看/删除"的入口写在 HTML 里，
+               而不是由脚本画出来：首次访问、爬虫、关掉 JavaScript 都能看到。
+               /history-recent.js 只负责填"继续编辑"那一段，且只在本机确实存有内容时。 -->
+          <div class="recent reveal d5">
+            <span data-recent-slot data-recent-locale="zh-CN" data-recent-label="继续编辑" hidden></span>
+            <span class="recent-note">编辑内容会自动保存在本机 7 天，到期自动清除。</span>
+            <a class="recent-all" href="/history?locale=zh-CN">本地历史</a>
+          </div>
           <div class="trust reveal d5">
             <span>不传服务器</span><span class="sep">·</span><span>免注册</span><span class="sep">·</span
             ><span>可离线</span><span class="sep">·</span><span>.docx .xlsx .pptx .csv</span>

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# OnlyOffice Web
+# Online Document Editor
 
 <p align="center">
   <a href="https://github.com/ranuts/document/actions/workflows/ci.yml">
@@ -11,7 +11,7 @@
     <img src="https://img.shields.io/github/v/release/ranuts/document" alt="Version">
   </a>
   <a href="https://edit.chaxus.com/">
-    <img src="https://img.shields.io/badge/Live-Demo-brightgreen" alt="Live Demo">
+    <img src="https://img.shields.io/badge/Live-edit.chaxus.com-brightgreen" alt="Live site">
   </a>
 </p>
 
@@ -19,33 +19,38 @@
   <b>English</b> | <a href="readme.zh.md">中文</a>
 </p>
 
-A privacy-first, browser-based document editor powered by OnlyOffice. Edit DOCX, XLSX, PPTX, and CSV files directly in your browser — no server, no uploads, no account required.
+Open and edit Word, Excel and PowerPoint files in a browser tab. There is no
+server: the OnlyOffice engine and its WASM converter run on the visitor's own
+device, so documents are never uploaded, and no account is involved.
+
+**Live site: [edit.chaxus.com](https://edit.chaxus.com/)**
 
 ---
 
 ## ✨ Features
 
-- 🔒 **Privacy-first** — all processing happens locally, nothing is uploaded
-- 📝 **Multi-format** — DOCX, XLSX, PPTX, CSV editing plus PDF opening, and more
-- 🚀 **No server required** — pure frontend, deploy anywhere
-- 🌐 **Open from URL** — load documents via `/editor?src=` or `/editor?file=` (legacy `/?src=` redirects)
-- 📦 **PWA support** — install and use offline
-- 🌍 **Multi-language** — English, Chinese, and more
+- 🔒 **Nothing is uploaded** — every conversion, edit and export happens in the tab
+- 📝 **Real editing, not preview** — DOCX, XLSX, PPTX and CSV, plus ODF, RTF, TXT and the legacy binary formats; PDFs open and can be annotated
+- 🕓 **Autosave and local history** — recovery points in your own browser, cleared after seven days ([details](#-your-data-stays-on-your-device))
+- 📴 **Works offline** — installable as a PWA; after the first visit no network is needed
+- 🌍 **Multi-language** — 8 interface languages for the site, 45 for the editor itself
 - 🧩 **Embeddable** — full postMessage API for iframe integration
+- 🤖 **Agent-ready** — exposes WebMCP tools so a browser AI agent can open, convert and read documents
+- 🚀 **Deploy anywhere** — a static build; a directory of files behind any web server
 
 ---
 
-## 🚀 Quick Start
+## 🚀 Quick start
 
-**Try it online:** [edit.chaxus.com](https://edit.chaxus.com/)
+**Use it:** [edit.chaxus.com](https://edit.chaxus.com/) — nothing to install.
 
-**Run with Docker:**
+**Self-host with Docker:**
 
 ```bash
 docker run -d --name document -p 8080:80 ghcr.io/ranuts/document:latest
 ```
 
-**Run locally:**
+**Run from source:**
 
 ```bash
 git clone https://github.com/ranuts/document.git
@@ -56,42 +61,65 @@ pnpm run dev
 
 ---
 
-## 📖 Usage
+## 📄 Formats
 
-### Open a document
+| Kind          | Edit                   | Also opens                  |
+| ------------- | ---------------------- | --------------------------- |
+| Documents     | `.docx`                | `.doc` `.odt` `.rtf` `.txt` |
+| Spreadsheets  | `.xlsx` `.csv`         | `.xls` `.ods`               |
+| Presentations | `.pptx`                | `.ppt` `.odp`               |
+| PDF           | annotate, fill, export | `.pdf`                      |
 
-1. Click the upload button to open a local file, or
-2. Pass a URL via query parameter: `/editor?src=https://example.com/document.docx`
+Any of them can be exported to PDF. CSV keeps its encoding on the way back out
+(UTF-8, GB18030 and Latin-1 are sniffed on open).
 
-> Remote URLs must support CORS.
+---
 
-### URL parameters
+## 🔗 Routes and URL parameters
 
-| Parameter | Description                          | Priority |
-| --------- | ------------------------------------ | -------- |
-| `src`     | Open document from URL (recommended) | Low      |
-| `file`    | Open document from URL (legacy)      | High     |
-| `locale`  | Set interface language (`en`, `zh`)  | —        |
+| Route                 | What it is                                                         |
+| --------------------- | ------------------------------------------------------------------ |
+| `/`                   | Landing page. No editor bundle is loaded until you open something. |
+| `/editor`             | The editor.                                                        |
+| `/history`            | Documents this browser is holding (see below).                     |
+| `/help`, `/changelog` | Generated from the markdown under `content/`.                      |
 
-When both `src` and `file` are present, `file` takes priority.
+Parameters on `/editor`:
 
-### PWA offline usage
+| Parameter      | Description                                                                                                               |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `src=<url>`    | Open a document from a URL (the URL must allow CORS)                                                                      |
+| `file=<url>`   | Same, legacy spelling; wins if both are present                                                                           |
+| `new=docx`     | Start a blank document (`docx`, `xlsx`, `pptx`)                                                                           |
+| `doc=<id>`     | Reopen a document from this browser's history — the editor puts its own id here, so a reload returns to the same document |
+| `readonly=1`   | Open for viewing: editing and export are disabled                                                                         |
+| `embed=1`      | Embed mode; the host page drives the editor over postMessage                                                              |
+| `locale=zh-CN` | Interface language                                                                                                        |
 
-Visit the editor over HTTPS (or localhost), then click the **Install** icon in the address bar. Once installed, the editor works without an internet connection.
+---
 
-> Service Workers don't work over `file://`. Use a local server or the installed PWA.
+## 🔐 Your data stays on your device
 
-### As a component library
+Documents are never sent anywhere. Two things are kept locally, and both are
+yours to remove:
 
-This project powers the document preview component in [@ranui/preview](https://www.npmjs.com/package/@ranui/preview).
+- **Recovery points.** While you edit, the editor saves snapshots into this
+  browser's IndexedDB so a closed tab or a crash does not cost you the work.
+  They are recovery points, not backups — keep exporting anything important to
+  disk.
+- **A seven-day window.** Each document is deleted seven days after you last
+  edited or opened it, automatically, whether or not you come back.
 
-📚 [Preview component docs](https://chaxus.github.io/ran/src/ranui/preview/)
+[`/history`](https://edit.chaxus.com/history) lists everything being held, with
+a delete on each row and a "clear everything" button; autosave itself can be
+switched off there. On a shared machine, that page is the one to visit.
 
 ---
 
 ## 🧩 Embedding via iframe
 
-Embed the editor in your application and control it via postMessage. The recommended pattern is: the parent system handles auth and file upload; the iframe handles editing only.
+Embed the editor and drive it over postMessage. The usual split is: your system
+handles auth and storage, the iframe handles editing.
 
 ```html
 <iframe
@@ -115,27 +143,43 @@ window.addEventListener('message', (e) => {
 });
 ```
 
-→ **[Full API reference](docs/embed-api.md)** — all message types, options, and examples including auth, read-only mode, and save flow.
+Embedded editors keep no local history — the document belongs to the host page.
+
+→ **[Full API reference](docs/embed-api.md)** — every message type, the origin
+allowlist, read-only mode and the save flow.
+
+Also available as a component: this project powers the document preview in
+[@ranui/preview](https://www.npmjs.com/package/@ranui/preview)
+([docs](https://chaxus.github.io/ran/src/ranui/preview/)).
+
+---
+
+## 🤖 Browser AI agents (WebMCP)
+
+Where the browser supports it, the page registers tools an in-browser agent can
+call directly instead of driving the UI: `open_document_url`,
+`open_document_buffer`, `create_document`, `save_document`, `get_document_text`,
+`set_readonly`, `get_document_state`. Documents still never leave the device —
+the browser fetches and converts them itself. Where the API is absent, this is
+a no-op.
 
 ---
 
 ## 🚀 Deployment
 
-This is a pure static app — build once, deploy anywhere.
+A static build — no runtime, no database.
 
 ```bash
 pnpm build   # outputs to dist/
 ```
 
-### GitHub Pages
+### Static hosting (Cloudflare Pages, Nginx, Vercel, Netlify…)
 
-Push to `main` and the included workflow (`.github/workflows/pages-build-site.yml`) builds and deploys automatically. Enable GitHub Pages in your repo settings and set the source to **GitHub Actions**.
+Upload `dist/`. `public/_headers` carries the caching contract the site expects
+(hashed assets immutable, service worker never cached); hosts that ignore it
+still work, they just revalidate more.
 
-### Static hosting (Nginx, Vercel, Netlify, Cloudflare Pages…)
-
-Upload the contents of `dist/` to any static host. No server-side runtime needed.
-
-For Nginx, serve `index.html` as the fallback for all routes:
+For Nginx, serve `index.html` as the fallback for unknown routes:
 
 ```nginx
 location / {
@@ -143,6 +187,11 @@ location / {
   try_files $uri $uri/ /index.html;
 }
 ```
+
+### GitHub Pages
+
+`.github/workflows/pages-build-site.yml` builds and deploys on push to `main`.
+Enable Pages in the repository settings with **GitHub Actions** as the source.
 
 ### Docker
 
@@ -160,29 +209,52 @@ docker run -d --name document -p 443:443 \
   ghcr.io/ranuts/document:latest
 ```
 
-`SERVER_BASIC_AUTH` uses BCrypt-hashed passwords. Replace `$` with `$$` in the hash for shell escaping.
+`SERVER_BASIC_AUTH` takes a BCrypt hash; double the `$` characters for shell
+escaping. Caching for the image is configured in `sws.toml`.
 
 ---
 
 ## 🔤 Fonts
 
-The editor ships with the font library bundled in the vendored OnlyOffice build (`public/fonts/`, indexed by `public/sdkjs/common/AllFonts.js`). Fonts are fetched on demand — only the ones a document actually uses are downloaded.
+The vendored OnlyOffice build ships its font library in `public/fonts/`, indexed
+by `public/sdkjs/common/AllFonts.js`. Fonts are fetched on demand — a document
+only pulls the ones it actually uses.
 
-→ **[Font management guide](docs/fonts.md)** — the indexed font catalog: wire format, registries, and how to add fonts with `bin/font-catalog.mjs`.
+→ **[Font management guide](docs/fonts.md)** — the indexed catalog's wire
+format, the registries, and adding fonts with `bin/font-catalog.mjs`.
 
 ---
 
-## 📚 References
+## 🛠 Development
 
-- [onlyoffice-x2t-wasm](https://github.com/cryptpad/onlyoffice-x2t-wasm) — WASM document converter
-- [web-apps](https://github.com/ONLYOFFICE/web-apps) — OnlyOffice web applications
-- [sdkjs](https://github.com/ONLYOFFICE/sdkjs) — OnlyOffice JavaScript SDK
-- [se-office](https://github.com/Qihoo360/se-office) — Secure document editor
-- [onlyoffice-web-local](https://github.com/sweetwisdom/onlyoffice-web-local) — Local OnlyOffice implementation
+```bash
+pnpm install --frozen-lockfile
+pnpm run dev            # dev server
+pnpm run build          # production build (bin/build.sh)
+pnpm run lint           # oxlint + tsc + docker config
+pnpm run test           # unit tests (Vitest)
+pnpm run test:e2e       # end-to-end tests (Playwright, real editor + real WASM)
+```
+
+The end-to-end suite drives the real editor and the real converter rather than
+mocks, including document round trips, the embed protocol and the recovery
+flow. `docs/explorations/` records why each non-obvious piece is the way it is —
+worth a look before changing the editor integration.
+
+---
+
+## 📚 Built on
+
+- [sdkjs](https://github.com/ONLYOFFICE/sdkjs) and [web-apps](https://github.com/ONLYOFFICE/web-apps) — the OnlyOffice editors
+- [onlyoffice-x2t-wasm](https://github.com/cryptpad/onlyoffice-x2t-wasm) — the WASM document converter
+- [ranui / ranuts](https://github.com/chaxus/ran) — the design system and utilities this site is built with
+- [se-office](https://github.com/Qihoo360/se-office), [onlyoffice-web-local](https://github.com/sweetwisdom/onlyoffice-web-local) — prior art for running OnlyOffice without a document server
 
 ## 🤝 Contributing
 
-Issues and pull requests are welcome!
+Issues and pull requests are welcome. `main` is protected: work on a branch and
+open a PR, which runs lint, unit tests and three end-to-end suites (dev server,
+Cloudflare Pages semantics, and the production Docker image).
 
 ## 📄 License
 

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -1,4 +1,4 @@
-# OnlyOffice Web
+# 在线文档编辑器
 
 <p align="center">
   <a href="https://github.com/ranuts/document/actions/workflows/ci.yml">
@@ -11,7 +11,7 @@
     <img src="https://img.shields.io/github/v/release/ranuts/document" alt="版本">
   </a>
   <a href="https://edit.chaxus.com/">
-    <img src="https://img.shields.io/badge/在线-体验-brightgreen" alt="在线体验">
+    <img src="https://img.shields.io/badge/在线-edit.chaxus.com-brightgreen" alt="在线站点">
   </a>
 </p>
 
@@ -19,33 +19,37 @@
   <a href="readme.md">English</a> | <b>中文</b>
 </p>
 
-基于 OnlyOffice 的隐私优先浏览器文档编辑器。直接在浏览器中编辑 DOCX、XLSX、PPTX、CSV 文件——无需服务器、无需上传、无需注册账号。
+在浏览器标签页里打开和编辑 Word、Excel、PPT 文件。没有服务器：OnlyOffice 引擎和它的
+WASM 转换器都跑在访问者自己的设备上，文档不会被上传，也不需要注册账号。
+
+**线上地址：[edit.chaxus.com](https://edit.chaxus.com/)**
 
 ---
 
 ## ✨ 主要特性
 
-- 🔒 **隐私优先** — 所有处理在本地完成，不上传任何数据
-- 📝 **多格式支持** — DOCX、XLSX、PPTX、CSV 等
-- 🚀 **无需服务器** — 纯前端实现，可部署到任意静态托管
-- 🌐 **URL 打开** — 通过 `/editor?src=` 或 `/editor?file=` 参数直接加载远程文档（旧的 `/?src=` 会跳转）
-- 📦 **PWA 支持** — 可安装，支持离线使用
-- 🌍 **多语言** — 中文、英文及更多语言
-- 🧩 **可嵌入** — 完整的 postMessage API 支持 iframe 集成
+- 🔒 **不上传任何文件** — 转换、编辑、导出全部发生在这个标签页里
+- 📝 **是编辑，不是预览** — DOCX、XLSX、PPTX、CSV，另支持 ODF、RTF、TXT 与旧版二进制格式；PDF 可打开并批注
+- 🕓 **自动保存与本地历史** — 恢复点存在你自己的浏览器里，七天后自动清除（[说明](#-数据只留在你的设备上)）
+- 📴 **可离线使用** — 可安装为 PWA，首次访问之后无需联网
+- 🌍 **多语言** — 站点界面 8 种语言，编辑器界面 45 种
+- 🧩 **可嵌入** — 完整的 iframe postMessage API
+- 🤖 **面向 Agent** — 提供 WebMCP 工具，浏览器内的 AI Agent 可直接打开、转换、读取文档
+- 🚀 **随处部署** — 纯静态产物，放在任意 Web 服务器后面即可
 
 ---
 
 ## 🚀 快速开始
 
-**在线体验：** [edit.chaxus.com](https://edit.chaxus.com/)
+**直接使用：**[edit.chaxus.com](https://edit.chaxus.com/)，无需安装。
 
-**Docker 运行：**
+**用 Docker 自建：**
 
 ```bash
 docker run -d --name document -p 8080:80 ghcr.io/ranuts/document:latest
 ```
 
-**本地开发：**
+**从源码运行：**
 
 ```bash
 git clone https://github.com/ranuts/document.git
@@ -56,42 +60,58 @@ pnpm run dev
 
 ---
 
-## 📖 使用方法
+## 📄 支持的格式
 
-### 打开文档
+| 类型 | 可编辑           | 也能打开                    |
+| ---- | ---------------- | --------------------------- |
+| 文档 | `.docx`          | `.doc` `.odt` `.rtf` `.txt` |
+| 表格 | `.xlsx` `.csv`   | `.xls` `.ods`               |
+| 演示 | `.pptx`          | `.ppt` `.odp`               |
+| PDF  | 批注、填写、导出 | `.pdf`                      |
 
-1. 点击上传按钮选择本地文件，或
-2. 通过 URL 参数传入：`/editor?src=https://example.com/document.docx`
-
-> 远程 URL 需支持 CORS。
-
-### URL 参数
-
-| 参数     | 说明                        | 优先级 |
-| -------- | --------------------------- | ------ |
-| `src`    | 从 URL 打开文档（推荐）     | 低     |
-| `file`   | 从 URL 打开文档（向后兼容） | 高     |
-| `locale` | 设置界面语言（`en`、`zh`）  | —      |
-
-同时提供 `src` 和 `file` 时，`file` 优先。
-
-### 离线使用（PWA）
-
-通过 HTTPS（或 localhost）访问编辑器，点击地址栏中的**安装**图标。安装后可在无网络环境下正常使用。
-
-> Service Worker 在 `file://` 协议下无法工作，请使用本地服务器或已安装的 PWA。
-
-### 作为组件库使用
-
-本项目为 [@ranui/preview](https://www.npmjs.com/package/@ranui/preview) WebComponent 组件库提供文档预览能力。
-
-📚 [预览组件文档](https://chaxus.github.io/ran/src/ranui/preview/)
+以上都可以导出为 PDF。CSV 存回时保持原编码（打开时会依次嗅探 UTF-8、GB18030、Latin-1）。
 
 ---
 
-## 🧩 iframe 嵌入
+## 🔗 路由与 URL 参数
 
-将编辑器嵌入到你的应用中，通过 postMessage 控制。推荐架构：父系统负责鉴权和文件上传，iframe 只负责编辑。
+| 路由                  | 说明                                     |
+| --------------------- | ---------------------------------------- |
+| `/`                   | 落地页。不打开文档就不会加载编辑器代码。 |
+| `/editor`             | 编辑器。                                 |
+| `/history`            | 本机浏览器当前保存的文档（见下）。       |
+| `/help`、`/changelog` | 由 `content/` 下的 markdown 生成。       |
+
+`/editor` 的参数：
+
+| 参数           | 说明                                                                     |
+| -------------- | ------------------------------------------------------------------------ |
+| `src=<url>`    | 从 URL 打开文档（该 URL 需允许 CORS）                                    |
+| `file=<url>`   | 同上，旧写法；两者同时存在时以它为准                                     |
+| `new=docx`     | 新建空白文档（`docx`、`xlsx`、`pptx`）                                   |
+| `doc=<id>`     | 从本机历史打开某一篇——编辑器会把自己的 id 写在这里，因此刷新会回到同一篇 |
+| `readonly=1`   | 只读打开：禁用编辑与导出                                                 |
+| `embed=1`      | 嵌入模式，由宿主页面通过 postMessage 驱动                                |
+| `locale=zh-CN` | 界面语言                                                                 |
+
+---
+
+## 🔐 数据只留在你的设备上
+
+文档不会被发送到任何地方。本机会保留两样东西，且都可以由你删除：
+
+- **恢复点**：编辑过程中，编辑器会把快照写进本浏览器的 IndexedDB，这样关掉标签页或
+  浏览器崩溃都不会让工作白做。它们是恢复点，不是备份——重要文档请照常导出保存到磁盘。
+- **七天窗口**：每篇文档在你最后一次编辑或打开的七天后自动删除，不需要你做任何事。
+
+[`/history`](https://edit.chaxus.com/history) 列出当前保存的全部内容，每一行都有删除，
+顶部有"清空全部"，自动保存本身也可以在那里关掉。共用电脑上，先看这一页。
+
+---
+
+## 🧩 通过 iframe 嵌入
+
+嵌入编辑器并用 postMessage 驱动。常见分工是：你的系统负责鉴权与存储，iframe 只负责编辑。
 
 ```html
 <iframe
@@ -110,32 +130,44 @@ iframe.contentWindow.postMessage(
 
 // 监听结果
 window.addEventListener('message', (e) => {
-  if (e.data?.type === 'document:opened') console.log('可以开始编辑');
+  if (e.data?.type === 'document:opened') console.log('可以编辑了');
   if (e.data?.type === 'document:saved') uploadFile(e.data.payload.file);
 });
 ```
 
-→ **[完整 API 文档](docs/embed-api.zh.md)** — 所有消息类型、参数说明及示例，包含鉴权、只读模式、保存流程等。
+嵌入模式下不会写入本地历史——那份文档属于宿主页面。
+
+→ **[完整 API 文档](docs/embed-api.zh.md)** — 全部消息类型、来源白名单、只读模式与保存流程。
+
+也可以作为组件使用：本项目为
+[@ranui/preview](https://www.npmjs.com/package/@ranui/preview)
+提供文档预览能力（[组件文档](https://chaxus.github.io/ran/src/ranui/preview/)）。
+
+---
+
+## 🤖 浏览器 AI Agent（WebMCP）
+
+在支持该能力的浏览器上，页面会注册一组工具，浏览器内的 Agent 可以直接调用，而不必去"看"和"点"
+界面：`open_document_url`、`open_document_buffer`、`create_document`、`save_document`、
+`get_document_text`、`set_readonly`、`get_document_state`。文档同样不会离开设备——由浏览器
+自己抓取和转换。浏览器没有这套 API 时整体无操作，对普通用户零影响。
 
 ---
 
 ## 🚀 部署
 
-这是纯静态应用，构建一次即可部署到任意平台。
+纯静态产物——没有运行时，没有数据库。
 
 ```bash
-pnpm build   # 输出到 dist/
+pnpm build   # 产物在 dist/
 ```
 
-### GitHub Pages
+### 静态托管（Cloudflare Pages、Nginx、Vercel、Netlify……）
 
-推送到 `main` 分支后，内置工作流（`.github/workflows/pages-build-site.yml`）会自动构建并部署。在仓库 Settings → Pages 中将 Source 设置为 **GitHub Actions** 即可。
+上传 `dist/` 即可。`public/_headers` 里写着本站期望的缓存契约（带哈希的资源永久缓存、
+service worker 永不缓存）；不支持该文件的托管也能跑，只是会多做校验。
 
-### 静态托管（Nginx、Vercel、Netlify、Cloudflare Pages 等）
-
-将 `dist/` 目录上传到任意静态托管服务，无需服务端运行时。
-
-Nginx 参考配置（将所有路由回退到 `index.html`）：
+Nginx 需要把 `index.html` 作为未知路由的兜底：
 
 ```nginx
 location / {
@@ -144,45 +176,69 @@ location / {
 }
 ```
 
+### GitHub Pages
+
+`.github/workflows/pages-build-site.yml` 会在推送到 `main` 时构建并部署。
+在仓库设置里启用 Pages，来源选 **GitHub Actions**。
+
 ### Docker
 
 ```bash
-# 基础部署
+# 基础用法
 docker run -d --name document -p 8080:80 ghcr.io/ranuts/document:latest
 
-# 启用 HTTPS 和基础认证
+# 带 HTTPS 与基础认证
 docker run -d --name document -p 443:443 \
-  -v /证书路径:/ssl \
-  -e SERVER_BASIC_AUTH='用户名:BCrypt加密密码' \
+  -v /path/to/certs:/ssl \
+  -e SERVER_BASIC_AUTH='user:$2y$...' \
   -e SERVER_HTTP2_TLS=true \
   -e SERVER_HTTP2_TLS_CERT=/ssl/cert.pem \
   -e SERVER_HTTP2_TLS_KEY=/ssl/key.pem \
   ghcr.io/ranuts/document:latest
 ```
 
-`SERVER_BASIC_AUTH` 使用 BCrypt 加密密码，加密结果中的 `$` 需替换为 `$$` 进行转义。
+`SERVER_BASIC_AUTH` 接受 BCrypt 哈希；shell 里需要把 `$` 写成 `$$` 转义。
+镜像自身的缓存策略在 `sws.toml`。
 
 ---
 
 ## 🔤 字体
 
-编辑器字体库随内置的 OnlyOffice 编译产物一起提供（`public/fonts/`，由 `public/sdkjs/common/AllFonts.js` 索引），按需加载——文档用到哪个字体才会下载哪个。
+随附的 OnlyOffice 构建把字体库放在 `public/fonts/`，由
+`public/sdkjs/common/AllFonts.js` 建立索引。字体按需拉取——一篇文档只会下载它真正用到的那些。
 
-→ **[字体管理指南](docs/fonts.zh.md)** — 注意：该指南描述的是旧版（v7）字体机制，待按新的索引字体布局重写。
+→ **[字体管理指南](docs/fonts.zh.md)** — 索引字体目录的线格式、各处注册表，
+以及如何用 `bin/font-catalog.mjs` 添加字体。
 
 ---
 
-## 📚 参考资料
+## 🛠 开发
 
-- [onlyoffice-x2t-wasm](https://github.com/cryptpad/onlyoffice-x2t-wasm) — 基于 WASM 的文档转换器
-- [web-apps](https://github.com/ONLYOFFICE/web-apps) — OnlyOffice 网页应用
-- [sdkjs](https://github.com/ONLYOFFICE/sdkjs) — OnlyOffice JavaScript SDK
-- [se-office](https://github.com/Qihoo360/se-office) — 安全文档编辑器
-- [onlyoffice-web-local](https://github.com/sweetwisdom/onlyoffice-web-local) — 本地网页版 OnlyOffice
+```bash
+pnpm install --frozen-lockfile
+pnpm run dev            # 开发服务器
+pnpm run build          # 生产构建（bin/build.sh）
+pnpm run lint           # oxlint + tsc + docker 配置检查
+pnpm run test           # 单元测试（Vitest）
+pnpm run test:e2e       # 端到端测试（Playwright，真实编辑器 + 真实 WASM）
+```
+
+端到端测试跑的是真实编辑器和真实转换器，不是 mock，覆盖文档往返、嵌入协议与恢复流程。
+`docs/explorations/` 记录了每一处不显然的设计为什么是现在这样——改编辑器集成之前值得先读。
+
+---
+
+## 📚 基于这些项目
+
+- [sdkjs](https://github.com/ONLYOFFICE/sdkjs) 与 [web-apps](https://github.com/ONLYOFFICE/web-apps) — OnlyOffice 编辑器本体
+- [onlyoffice-x2t-wasm](https://github.com/cryptpad/onlyoffice-x2t-wasm) — WASM 文档转换器
+- [ranui / ranuts](https://github.com/chaxus/ran) — 本站使用的设计体系与工具库
+- [se-office](https://github.com/Qihoo360/se-office)、[onlyoffice-web-local](https://github.com/sweetwisdom/onlyoffice-web-local) — 无文档服务器运行 OnlyOffice 的先行方案
 
 ## 🤝 贡献
 
-欢迎提交 Issue 和 Pull Request！
+欢迎提 Issue 和 PR。`main` 受保护：请在分支上开发并提 PR，CI 会跑 lint、单元测试，
+以及三套端到端测试（开发服务器、Cloudflare Pages 语义、生产 Docker 镜像）。
 
 ## 📄 许可证
 

--- a/styles/base.css
+++ b/styles/base.css
@@ -366,3 +366,44 @@ r-dropdown[role='listbox'] {
     animation-iteration-count: 1 !important;
   }
 }
+
+/* Recovery offer: the boot-time "there are unsaved edits from last time" bar.
+   Sits over the editor rather than pushing it down -- the editor iframe is
+   sized to the viewport, and a bar in the flow would reflow the whole
+   document just to say something the user may dismiss in a second. */
+.recovery-bar {
+  position: fixed;
+  top: var(--ran-space-4);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10000;
+  display: flex;
+  gap: var(--ran-space-6);
+  align-items: center;
+  flex-wrap: wrap;
+  max-width: min(680px, calc(100vw - 2 * var(--ran-space-4)));
+  padding: var(--ran-space-3) var(--ran-space-4);
+  border: 1px solid var(--ran-color-border);
+  border-radius: var(--ran-radius-lg);
+  background: var(--ran-color-bg-elevated);
+  box-shadow: var(--ran-shadow-menu);
+  color: var(--ran-color-text);
+}
+.recovery-bar-title {
+  font-weight: 600;
+}
+.recovery-bar-body {
+  color: var(--ran-color-text-secondary);
+  font-size: 14px;
+}
+.recovery-bar-actions {
+  display: flex;
+  gap: var(--ran-space-2);
+  align-items: center;
+  margin-left: auto;
+}
+/* The editor owns the whole viewport in embed mode; a host page's iframe is
+   not the place to interrupt with our own recovery UI. */
+body.embed-mode .recovery-bar {
+  display: none;
+}

--- a/styles/history.css
+++ b/styles/history.css
@@ -1,0 +1,140 @@
+/* /history -- the local document library. ranui tokens only: this page is as
+   much a part of the product's face as the landing pages are (CLAUDE.md
+   convention 4), and it has to follow the theme the editor was left in. */
+body {
+  margin: 0;
+  background: var(--ran-color-bg);
+  color: var(--ran-color-text);
+  font-family: var(--ran-font-family);
+  line-height: var(--ran-line-height);
+}
+
+.history-page {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: var(--ran-space-8) var(--ran-space-4) var(--ran-space-10);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ran-space-6);
+}
+
+.history-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ran-space-2);
+}
+.history-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--ran-space-4);
+  flex-wrap: wrap;
+}
+.history-title {
+  margin: 0;
+  font-size: 28px;
+  font-weight: 600;
+}
+.history-back {
+  margin-left: auto;
+}
+.history-intro,
+.history-notice {
+  margin: 0;
+  color: var(--ran-color-text-secondary);
+  font-size: 14px;
+}
+
+.history-toolbar {
+  display: flex;
+  gap: var(--ran-space-3);
+  align-items: center;
+  flex-wrap: wrap;
+}
+.history-search {
+  flex: 1 1 240px;
+  min-width: 180px;
+  padding: var(--ran-space-2) var(--ran-space-3);
+  border: 1px solid var(--ran-color-border);
+  border-radius: var(--ran-radius-md);
+  background: var(--ran-color-bg-elevated);
+  color: var(--ran-color-text);
+  font: inherit;
+  font-size: 14px;
+}
+.history-usage {
+  color: var(--ran-color-text-secondary);
+  font-size: 13px;
+}
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--ran-color-border);
+  border-radius: var(--ran-radius-lg);
+  overflow: hidden;
+}
+.history-row {
+  display: flex;
+  gap: var(--ran-space-4);
+  align-items: center;
+  padding: var(--ran-space-3) var(--ran-space-4);
+  border-bottom: 1px solid var(--ran-color-border);
+}
+.history-row:last-child {
+  border-bottom: none;
+}
+.history-row-main {
+  min-width: 0;
+  flex: 1;
+}
+.history-row-title {
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.history-row-meta {
+  color: var(--ran-color-text-secondary);
+  font-size: 13px;
+  display: flex;
+  gap: var(--ran-space-2);
+  flex-wrap: wrap;
+}
+/* "Not on disk" is the whole point of the list: it marks the rows that hold
+   the only copy of that work. */
+.history-badge {
+  padding: 0 var(--ran-space-2);
+  border: 1px solid var(--ran-color-border);
+  border-radius: var(--ran-radius-sm);
+}
+.history-row-actions {
+  display: flex;
+  gap: var(--ran-space-2);
+  flex-shrink: 0;
+}
+
+.history-empty {
+  padding: var(--ran-space-8);
+  text-align: center;
+  color: var(--ran-color-text-secondary);
+  border: 1px dashed var(--ran-color-border);
+  border-radius: var(--ran-radius-lg);
+}
+
+.history-pager {
+  display: flex;
+  gap: var(--ran-space-3);
+  align-items: center;
+  justify-content: center;
+}
+.history-page-info {
+  color: var(--ran-color-text-secondary);
+  font-size: 13px;
+}
+
+.history-autosave {
+  display: flex;
+  gap: var(--ran-space-2);
+  align-items: center;
+  font-size: 14px;
+}

--- a/test/e2e/autosave-recovery.spec.ts
+++ b/test/e2e/autosave-recovery.spec.ts
@@ -145,6 +145,44 @@ test.describe('autosave and recovery (real editor)', () => {
     await expect.poll(async () => (await readHistory(page))[0]?.savedToDiskAt, { timeout: 30_000 }).toBeGreaterThan(0);
   });
 
+  test('a reload comes back to the same document, not a fresh one', async ({ page }) => {
+    // What the id in the URL buys. Before it, a reload of a blank document
+    // opened a second blank document and the edits could only be found through
+    // the recovery bar; now the address itself names the document.
+    await page.goto('/editor?new=docx');
+    await waitForEditorReady(page);
+    const sdk = page.frameLocator('iframe[name="frameEditor"]').locator('#editor_sdk');
+    await sdk.waitFor({ state: 'visible', timeout: 30_000 });
+    await sdk.click({ position: { x: 300, y: 200 } });
+    await page.keyboard.type('typed before the reload', { delay: 60 });
+
+    // The editor stamped its identity into the address bar on open.
+    const docId = new URL(page.url()).searchParams.get('doc');
+    expect(docId).toBeTruthy();
+
+    await hidePage(page);
+    await expect
+      .poll(async () => (await readHistory(page)).length, { timeout: 45_000, message: 'a snapshot was stored' })
+      .toBe(1);
+
+    await page.reload();
+    await waitForEditorReady(page);
+    const reloadedSdk = page.frameLocator('iframe[name="frameEditor"]').locator('#editor_sdk');
+    await reloadedSdk.waitFor({ state: 'visible', timeout: 30_000 });
+    // Same document, same row: no second id, no duplicate history entry.
+    expect(new URL(page.url()).searchParams.get('doc')).toBe(docId);
+    expect(await readHistory(page)).toHaveLength(1);
+
+    await reloadedSdk.click({ position: { x: 300, y: 200 } });
+    const downloadPromise = page.waitForEvent('download', { timeout: 120_000 });
+    await page.keyboard.press('Control+s');
+    const bytes = new Uint8Array(readFileSync(await (await downloadPromise).path()));
+    const text = ooxmlText((await zipEntryText(bytes, 'word/document.xml')) || '');
+    // Case-insensitive: a blank document's autocorrect capitalises the first
+    // letter of the sentence, which is the editor being an editor.
+    expect(text).toMatch(/typed before the reload/i);
+  });
+
   test('an embedded editor writes nothing to the local history', async ({ page }) => {
     // The document on screen belongs to the host page. Keeping a copy of it in
     // this origin's storage would be us retaining someone else's user's file.

--- a/test/e2e/autosave-recovery.spec.ts
+++ b/test/e2e/autosave-recovery.spec.ts
@@ -1,0 +1,182 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Page } from '@playwright/test';
+import { buildDocx, ooxmlText, zipEntryText } from './lib/ooxml';
+import { expect, test } from './lib/l0';
+
+declare const XLSX: any;
+declare function post(type: string, payload?: Record<string, unknown>): Promise<any>;
+
+/**
+ * The whole loss-protection path with the real editor and real x2t behind it:
+ * edit a document, let the tab go away, and get the work back on the next
+ * visit -- through the recovery bar, with the bytes intact.
+ *
+ * The snapshot is triggered by hiding the page rather than by waiting out the
+ * interval. That is not a shortcut around the schedule: visibilitychange is
+ * the branch that matters most in production (it is the last moment that
+ * reliably gets time to run before a tab goes away), and waiting 90 s of wall
+ * clock in CI to exercise the same export would only buy a slower suite.
+ */
+const waitForEditorReady = (page: Page) =>
+  page.waitForFunction(
+    () => {
+      const visit = (win: Window): boolean => {
+        try {
+          const api = (
+            win as unknown as { Asc?: { editor?: { isDocumentLoadComplete?: boolean; isLoadFullApi?: boolean } } }
+          ).Asc?.editor;
+          if (api && api.isDocumentLoadComplete && api.isLoadFullApi) return true;
+        } catch {
+          /* cross-origin */
+        }
+        for (let i = 0; i < win.frames.length; i++) if (visit(win.frames[i])) return true;
+        return false;
+      };
+      return visit(window);
+    },
+    undefined,
+    { timeout: 90_000 },
+  );
+
+/** Metadata rows currently in the history database. */
+const readHistory = (page: Page) =>
+  page.evaluate(
+    () =>
+      new Promise<Array<{ id: string; title: string; size: number; savedToDiskAt?: number }>>((resolve) => {
+        const request = indexedDB.open('document-history', 1);
+        request.onsuccess = () => {
+          const db = request.result;
+          if (!db.objectStoreNames.contains('docs')) {
+            db.close();
+            resolve([]);
+            return;
+          }
+          const all = db.transaction('docs', 'readonly').objectStore('docs').getAll();
+          all.onsuccess = () => {
+            db.close();
+            resolve(all.result);
+          };
+          all.onerror = () => {
+            db.close();
+            resolve([]);
+          };
+        };
+        request.onerror = () => resolve([]);
+        request.onupgradeneeded = () => resolve([]);
+      }),
+  );
+
+async function hidePage(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+}
+
+test.describe('autosave and recovery (real editor)', () => {
+  test.describe.configure({ timeout: 240_000 });
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(window, 'showSaveFilePicker', { value: undefined, configurable: true });
+    });
+  });
+
+  test('edits survive the tab going away and come back through the recovery bar', async ({ page }) => {
+    const dir = join('test-results', 'autosave-recovery');
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, 'Recovery.docx');
+    writeFileSync(path, buildDocx('original paragraph'));
+
+    await page.goto('/');
+    const chooserPromise = page.waitForEvent('filechooser');
+    await page.locator('#hero-open').click();
+    (await chooserPromise).setFiles(path);
+
+    await waitForEditorReady(page);
+    const sdk = page.frameLocator('iframe[name="frameEditor"]').locator('#editor_sdk');
+    await sdk.waitFor({ state: 'visible', timeout: 30_000 });
+    await sdk.click({ position: { x: 300, y: 200 } });
+    await page.keyboard.press('End');
+    await page.keyboard.type(' never saved to disk', { delay: 60 });
+
+    // The tab goes away without the user ever exporting.
+    await hidePage(page);
+
+    // Well inside SNAPSHOT_INTERVAL_MS (90 s) on purpose: with a longer window
+    // the periodic tick would eventually take a snapshot too, and the test
+    // would pass whether or not hiding the page did anything -- which is
+    // exactly what it looked like before this bound was tightened.
+    await expect
+      .poll(async () => (await readHistory(page)).length, { timeout: 45_000, message: 'a snapshot was stored' })
+      .toBe(1);
+    const [stored] = await readHistory(page);
+    expect(stored.title).toBe('Recovery.docx');
+    expect(stored.size).toBeGreaterThan(0);
+    // Never exported, so the browser holds the only copy of that sentence.
+    expect(stored.savedToDiskAt).toBeUndefined();
+
+    // Coming back the next day: a blank editor, nothing on screen about
+    // yesterday's work until the offer appears.
+    await page.goto('/editor?new=docx');
+    const bar = page.locator('#recovery-bar');
+    await expect(bar).toBeVisible({ timeout: 30_000 });
+    await expect(bar).toContainText('Recovery.docx');
+
+    await bar.locator('.recovery-restore').click();
+    await waitForEditorReady(page);
+    const restoredSdk = page.frameLocator('iframe[name="frameEditor"]').locator('#editor_sdk');
+    await restoredSdk.waitFor({ state: 'visible', timeout: 30_000 });
+    // Ctrl+S goes to whatever has focus, and after a navigation that is the
+    // page, not the editor inside the frame.
+    await restoredSdk.click({ position: { x: 300, y: 200 } });
+
+    // The proof is the bytes: export what was restored and read it back.
+    const downloadPromise = page.waitForEvent('download', { timeout: 120_000 });
+    await page.keyboard.press('Control+s');
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toBe('Recovery.docx');
+    const bytes = new Uint8Array(readFileSync(await download.path()));
+    const text = ooxmlText((await zipEntryText(bytes, 'word/document.xml')) || '');
+    expect(text).toContain('original paragraph never saved to disk');
+
+    // Saved at last: the offer has nothing left to make.
+    await expect.poll(async () => (await readHistory(page))[0]?.savedToDiskAt, { timeout: 30_000 }).toBeGreaterThan(0);
+  });
+
+  test('an embedded editor writes nothing to the local history', async ({ page }) => {
+    // The document on screen belongs to the host page. Keeping a copy of it in
+    // this origin's storage would be us retaining someone else's user's file.
+    await page.goto('/embed-demo.html');
+    await expect(page.locator('#status')).toHaveText('ready', { timeout: 60_000 });
+
+    await page.evaluate(async () => {
+      const wb = XLSX.utils.book_new();
+      XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet([['embedded', 1]]), 'Sheet1');
+      const data = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
+      await post('document:open-buffer', {
+        fileName: 'embedded.xlsx',
+        buffer: new Uint8Array(data).buffer,
+        readonly: false,
+      });
+      await post('document:save', {});
+    });
+
+    // Hide the editor frame itself: that is the branch a snapshot would come
+    // through if the embed check were missing.
+    for (const frame of page.frames()) {
+      await frame
+        .evaluate(() => {
+          Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+          document.dispatchEvent(new Event('visibilitychange'));
+        })
+        .catch(() => {
+          /* cross-origin frames are not ours to poke */
+        });
+    }
+    await page.waitForTimeout(3_000);
+
+    expect(await readHistory(page)).toHaveLength(0);
+  });
+});

--- a/test/e2e/history-page.spec.ts
+++ b/test/e2e/history-page.spec.ts
@@ -10,7 +10,7 @@ import type { Page } from '@playwright/test';
  * fill two pages would make it one of the slowest in the suite. The full
  * editor -> snapshot -> recovery path is covered by autosave-recovery.spec.ts.
  */
-type SeedRow = { id: string; title: string; savedToDisk?: boolean };
+type SeedRow = { id: string; title: string; savedToDisk?: boolean; ageMs?: number };
 
 async function seed(page: Page, rows: SeedRow[]): Promise<void> {
   await page.evaluate(async (seedRows: SeedRow[]) => {
@@ -32,7 +32,7 @@ async function seed(page: Page, rows: SeedRow[]): Promise<void> {
     await new Promise<void>((resolve, reject) => {
       const tx = db.transaction(['docs', 'blobs'], 'readwrite');
       seedRows.forEach((row, index) => {
-        const now = Date.now() - (seedRows.length - index) * 1000;
+        const now = Date.now() - (row.ageMs ?? 0) - (seedRows.length - index) * 1000;
         tx.objectStore('docs').put({
           id: row.id,
           title: row.title,
@@ -182,6 +182,60 @@ test.describe('local history page', () => {
     expect(remaining).toBe(1);
   });
 
+  test('says how long each document has left', async ({ page }) => {
+    await seed(page, [
+      { id: 'fresh', title: 'Fresh.docx' },
+      { id: 'old', title: 'Old.docx', ageMs: 6.5 * 24 * 60 * 60 * 1000 },
+    ]);
+    await page.reload();
+
+    await expect(page.locator('.history-row', { hasText: 'Fresh.docx' })).toContainText('7 days');
+    await expect(page.locator('.history-row', { hasText: 'Old.docx' })).toContainText('1 day');
+    // And the rule itself, not just its consequence.
+    await expect(page.locator('.history-notice').first()).toContainText('7 days');
+  });
+
+  test('deletes documents past the retention window without being asked', async ({ page }) => {
+    await seed(page, [
+      { id: 'kept', title: 'Kept.docx' },
+      { id: 'expired', title: 'Expired.docx', ageMs: 8 * 24 * 60 * 60 * 1000 },
+    ]);
+    await page.reload();
+
+    await expect(titles(page)).toHaveText(['Kept.docx']);
+
+    // Gone from storage, not merely filtered out of the view.
+    const remaining = await page.evaluate(
+      () =>
+        new Promise<string[]>((resolve) => {
+          const request = indexedDB.open('document-history', 1);
+          request.onsuccess = () => {
+            const db = request.result;
+            const all = db.transaction('docs', 'readonly').objectStore('docs').getAllKeys();
+            all.onsuccess = () => {
+              db.close();
+              resolve(all.result as string[]);
+            };
+          };
+          request.onerror = () => resolve([]);
+        }),
+    );
+    expect(remaining).toEqual(['kept']);
+  });
+
+  test('the homepage says what autosave keeps, for how long, and where to look', async ({ page }) => {
+    // Served HTML, not drawn by script: a promise about someone's documents
+    // has to hold for a first-time visitor and with JavaScript off.
+    await page.goto('/');
+    const line = page.locator('#landing-hero .recent');
+    await expect(line).toContainText('7 days');
+    await expect(line.locator('a.recent-all')).toHaveAttribute('href', '/history');
+
+    await line.locator('a.recent-all').click();
+    await page.waitForURL(/\/history/);
+    await expect(page.locator('.history-title')).toBeVisible();
+  });
+
   test('clears everything at once', async ({ page }) => {
     await seed(page, [
       { id: 'a', title: 'A.docx' },
@@ -201,6 +255,8 @@ test.describe('local history page', () => {
 
     await page.locator('.history-row', { hasText: 'Reopen.docx' }).locator('.history-open').click();
 
-    await page.waitForURL(/\/editor\?open=history&id=reopen-me/);
+    // The id is the document's identity everywhere: in the URL the editor
+    // already uses, and in the link the history page hands back to it.
+    await page.waitForURL(/\/editor\?doc=reopen-me/);
   });
 });

--- a/test/e2e/history-page.spec.ts
+++ b/test/e2e/history-page.spec.ts
@@ -1,0 +1,206 @@
+import { expect, test } from './lib/l0';
+import type { Page } from '@playwright/test';
+
+/**
+ * /history -- the local document library: paging, title search, single-row
+ * delete and clear-everything.
+ *
+ * Rows are seeded straight into IndexedDB rather than produced by editing
+ * documents: this spec is about the page, and paying for 25 real exports to
+ * fill two pages would make it one of the slowest in the suite. The full
+ * editor -> snapshot -> recovery path is covered by autosave-recovery.spec.ts.
+ */
+type SeedRow = { id: string; title: string; savedToDisk?: boolean };
+
+async function seed(page: Page, rows: SeedRow[]): Promise<void> {
+  await page.evaluate(async (seedRows: SeedRow[]) => {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('document-history', 1);
+      request.onupgradeneeded = () => {
+        const database = request.result;
+        if (!database.objectStoreNames.contains('docs')) {
+          database.createObjectStore('docs', { keyPath: 'id' }).createIndex('by_updatedAt', 'updatedAt');
+        }
+        if (!database.objectStoreNames.contains('blobs')) {
+          database.createObjectStore('blobs', { keyPath: ['docId', 'rev'] }).createIndex('by_docId', 'docId');
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(['docs', 'blobs'], 'readwrite');
+      seedRows.forEach((row, index) => {
+        const now = Date.now() - (seedRows.length - index) * 1000;
+        tx.objectStore('docs').put({
+          id: row.id,
+          title: row.title,
+          titleLower: row.title.toLowerCase(),
+          ext: row.title.split('.').pop(),
+          origin: 'local',
+          size: 32,
+          totalBytes: 32,
+          createdAt: now,
+          updatedAt: now,
+          lastOpenedAt: now,
+          revCount: 1,
+          nextRev: 1,
+          savedToDiskAt: row.savedToDisk ? now + 1 : undefined,
+        });
+        tx.objectStore('blobs').put({
+          docId: row.id,
+          rev: 0,
+          savedAt: now,
+          bytes: new Uint8Array(32),
+          byteLength: 32,
+        });
+      });
+      tx.oncomplete = () => {
+        db.close();
+        resolve();
+      };
+      tx.onerror = () => reject(tx.error);
+    });
+  }, rows);
+}
+
+async function search(page: Page, value: string): Promise<void> {
+  // r-input keeps its real <input> in a closed shadow root, so the component's
+  // own contract (value + an `input` CustomEvent) is what a caller drives.
+  await page.locator('#history-search').evaluate((element, text) => {
+    (element as unknown as { value: string }).value = text;
+    element.dispatchEvent(new CustomEvent('input', { detail: { value: text } }));
+  }, value);
+}
+
+const titles = (page: Page) => page.locator('.history-row-title');
+
+test.describe('local history page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/history');
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          const request = indexedDB.deleteDatabase('document-history');
+          request.onsuccess = () => resolve();
+          request.onerror = () => resolve();
+          request.onblocked = () => resolve();
+        }),
+    );
+  });
+
+  test('says so when there is nothing stored', async ({ page }) => {
+    await page.reload();
+    await expect(page.locator('#history-empty')).toBeVisible();
+    await expect(page.locator('.history-row')).toHaveCount(0);
+  });
+
+  test('pages the library newest first', async ({ page }) => {
+    await seed(
+      page,
+      Array.from({ length: 25 }, (_, i) => ({ id: `doc-${i}`, title: `Doc-${i}.docx` })),
+    );
+    await page.reload();
+
+    await expect(page.locator('.history-row')).toHaveCount(20);
+    // Newest first: the last one seeded is the freshest.
+    await expect(titles(page).first()).toHaveText('Doc-24.docx');
+    await expect(page.locator('.history-page-info')).toContainText('1');
+
+    await page.locator('#history-next').click();
+
+    await expect(page.locator('.history-row')).toHaveCount(5);
+    await expect(titles(page).last()).toHaveText('Doc-0.docx');
+    // The view is in the URL, so this page survives a reload and can be shared.
+    expect(new URL(page.url()).searchParams.get('page')).toBe('2');
+  });
+
+  test('filters by title, including a substring of a Chinese name', async ({ page }) => {
+    await seed(page, [
+      { id: 'a', title: 'Quarterly Report.docx' },
+      { id: 'b', title: '年度总结报告.docx' },
+      { id: 'c', title: 'budget.xlsx' },
+    ]);
+    await page.reload();
+    await expect(page.locator('.history-row')).toHaveCount(3);
+
+    // Assert on the text, not just the count: one row matches either query, so
+    // a count alone cannot tell a re-render from the previous result standing.
+    await search(page, 'REPORT');
+    await expect(titles(page)).toHaveText(['Quarterly Report.docx']);
+
+    await search(page, '总结');
+    await expect(titles(page)).toHaveText(['年度总结报告.docx']);
+
+    await search(page, 'nothing here');
+    await expect(page.locator('#history-empty')).toBeVisible();
+  });
+
+  test('marks the rows whose only copy is in this browser', async ({ page }) => {
+    await seed(page, [
+      { id: 'only-here', title: 'OnlyHere.docx' },
+      { id: 'on-disk', title: 'OnDisk.docx', savedToDisk: true },
+    ]);
+    await page.reload();
+    await expect(page.locator('.history-row')).toHaveCount(2);
+
+    const unsavedRow = page.locator('.history-row', { hasText: 'OnlyHere.docx' });
+    const savedRow = page.locator('.history-row', { hasText: 'OnDisk.docx' });
+    await expect(unsavedRow.locator('.history-badge')).toBeVisible();
+    await expect(savedRow.locator('.history-badge')).toHaveCount(0);
+  });
+
+  test('deletes one document and leaves the rest alone', async ({ page }) => {
+    await seed(page, [
+      { id: 'keep', title: 'Keep.docx' },
+      { id: 'drop', title: 'Drop.docx' },
+    ]);
+    await page.reload();
+
+    page.on('dialog', (dialog) => void dialog.accept());
+    await page.locator('.history-row', { hasText: 'Drop.docx' }).locator('.history-delete').click();
+
+    await expect(titles(page)).toHaveText(['Keep.docx']);
+
+    // Gone from storage, not just from the list -- the bytes have to go too.
+    const remaining = await page.evaluate(
+      () =>
+        new Promise<number>((resolve) => {
+          const request = indexedDB.open('document-history', 1);
+          request.onsuccess = () => {
+            const db = request.result;
+            const all = db.transaction('blobs', 'readonly').objectStore('blobs').getAllKeys();
+            all.onsuccess = () => {
+              db.close();
+              resolve(all.result.length);
+            };
+          };
+          request.onerror = () => resolve(-1);
+        }),
+    );
+    expect(remaining).toBe(1);
+  });
+
+  test('clears everything at once', async ({ page }) => {
+    await seed(page, [
+      { id: 'a', title: 'A.docx' },
+      { id: 'b', title: 'B.docx' },
+    ]);
+    await page.reload();
+
+    page.on('dialog', (dialog) => void dialog.accept());
+    await page.locator('#history-clear-all').click();
+
+    await expect(page.locator('#history-empty')).toBeVisible();
+  });
+
+  test('opens a stored document back in the editor', async ({ page }) => {
+    await seed(page, [{ id: 'reopen-me', title: 'Reopen.docx' }]);
+    await page.reload();
+
+    await page.locator('.history-row', { hasText: 'Reopen.docx' }).locator('.history-open').click();
+
+    await page.waitForURL(/\/editor\?open=history&id=reopen-me/);
+  });
+});

--- a/test/unit/history-autosave.test.ts
+++ b/test/unit/history-autosave.test.ts
@@ -22,7 +22,7 @@ import {
   takeSnapshot,
 } from '../../lib/history/autosave';
 import { DB_NAME, resetHistoryDbForTests } from '../../lib/history/db';
-import { getLatestSnapshot, listDocs } from '../../lib/history/store';
+import { getLatestSnapshot, listDocs, resetHistoryClockForTests } from '../../lib/history/store';
 import { markDocumentDirty, resetUnsavedGuardForTests } from '../../lib/unsaved-guard';
 
 const ready: import('../../lib/history/autosave').SnapshotDecision = {
@@ -42,6 +42,7 @@ function fileOf(values: number[], name = 'Report.docx'): File {
 
 async function wipe(): Promise<void> {
   resetHistoryDbForTests();
+  resetHistoryClockForTests();
   await new Promise<void>((resolve) => {
     const request = indexedDB.deleteDatabase(DB_NAME);
     request.onsuccess = () => resolve();
@@ -87,7 +88,7 @@ describe('autosave session', () => {
 
   it('exports the document in its own format and stores the bytes', async () => {
     requestSaveDocument.mockResolvedValue(fileOf([1, 2, 3]));
-    await beginAutosaveSession({ title: 'Report.docx', origin: 'local' });
+    await beginAutosaveSession({ docId: 'report', title: 'Report.docx', origin: 'local' });
 
     const doc = await takeSnapshot();
 
@@ -99,7 +100,7 @@ describe('autosave session', () => {
 
   it('keeps appending to the same row across snapshots', async () => {
     requestSaveDocument.mockResolvedValue(fileOf([1]));
-    await beginAutosaveSession({ title: 'Report.docx', origin: 'local' });
+    await beginAutosaveSession({ docId: 'report', title: 'Report.docx', origin: 'local' });
 
     const first = await takeSnapshot();
     const second = await takeSnapshot();
@@ -112,7 +113,7 @@ describe('autosave session', () => {
   it('does not start in embed mode', async () => {
     window.history.replaceState(null, '', '/editor?embed=1');
 
-    await beginAutosaveSession({ title: 'Report.docx', origin: 'local' });
+    await beginAutosaveSession({ docId: 'report', title: 'Report.docx', origin: 'local' });
 
     expect(isAutosaveSessionActive()).toBe(false);
   });
@@ -120,7 +121,7 @@ describe('autosave session', () => {
   it('does not start when the user turned autosave off', async () => {
     setAutosaveEnabled(false);
 
-    await beginAutosaveSession({ title: 'Report.docx', origin: 'local' });
+    await beginAutosaveSession({ docId: 'report', title: 'Report.docx', origin: 'local' });
 
     expect(isAutosaveSessionActive()).toBe(false);
     setAutosaveEnabled(true);
@@ -135,7 +136,7 @@ describe('autosave session', () => {
     });
     requestSaveDocument.mockResolvedValue(fileOf([1]));
 
-    await beginAutosaveSession({ title: 'Shared.docx', origin: 'local' });
+    await beginAutosaveSession({ docId: 'shared', title: 'Shared.docx', origin: 'local' });
     markDocumentDirty();
     Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
     document.dispatchEvent(new Event('visibilitychange'));
@@ -147,7 +148,7 @@ describe('autosave session', () => {
 
   it('takes a snapshot when the page is hidden, without waiting for the interval', async () => {
     requestSaveDocument.mockResolvedValue(fileOf([9]));
-    await beginAutosaveSession({ title: 'Hidden.docx', origin: 'local' });
+    await beginAutosaveSession({ docId: 'hidden', title: 'Hidden.docx', origin: 'local' });
     markDocumentDirty();
 
     Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
@@ -159,7 +160,7 @@ describe('autosave session', () => {
   it('does not snapshot a read-only document', async () => {
     getReadonlyMode.mockReturnValue(true);
     requestSaveDocument.mockResolvedValue(fileOf([1]));
-    await beginAutosaveSession({ title: 'Locked.docx', origin: 'local' });
+    await beginAutosaveSession({ docId: 'locked', title: 'Locked.docx', origin: 'local' });
     markDocumentDirty();
 
     Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
@@ -170,7 +171,7 @@ describe('autosave session', () => {
 
   it('gives up after repeated export failures instead of retrying forever', async () => {
     requestSaveDocument.mockRejectedValue(new Error('export failed'));
-    await beginAutosaveSession({ title: 'Broken.docx', origin: 'local' });
+    await beginAutosaveSession({ docId: 'broken', title: 'Broken.docx', origin: 'local' });
 
     await takeSnapshot();
     await takeSnapshot();
@@ -182,7 +183,7 @@ describe('autosave session', () => {
 
   it('waits its turn while a user-initiated save owns the channel', async () => {
     requestSaveDocument.mockRejectedValue(new Error('A save request is already in progress'));
-    await beginAutosaveSession({ title: 'Busy.docx', origin: 'local' });
+    await beginAutosaveSession({ docId: 'busy', title: 'Busy.docx', origin: 'local' });
 
     await takeSnapshot();
     await takeSnapshot();
@@ -193,29 +194,30 @@ describe('autosave session', () => {
     expect(isAutosaveSessionActive()).toBe(true);
   });
 
-  it('reuses the history row of a file that was open before', async () => {
+  it('keeps writing to the row its id names, across sessions', async () => {
     requestSaveDocument.mockResolvedValue(fileOf([1]));
-    await beginAutosaveSession({ title: 'Daily.docx', origin: 'local' });
+    await beginAutosaveSession({ docId: 'daily', title: 'Daily.docx', origin: 'local' });
     const first = await takeSnapshot();
 
     stopAutosaveSession();
-    await beginAutosaveSession({ title: 'Daily.docx', origin: 'local' });
+    await beginAutosaveSession({ docId: 'daily', title: 'Daily.docx', origin: 'local' });
     const second = await takeSnapshot();
 
     expect(second?.id).toBe(first?.id);
     expect((await listDocs()).total).toBe(1);
   });
 
-  it('gives every blank document its own row', async () => {
+  it('keeps documents with the same name apart', async () => {
+    // Every blank document is called New_Document.docx, and plenty of people
+    // have two unrelated Report.docx files. Identity is the id, never the name.
     requestSaveDocument.mockResolvedValue(fileOf([1], 'New_Document.docx'));
-    await beginAutosaveSession({ title: 'New_Document.docx', origin: 'new' });
+    await beginAutosaveSession({ docId: 'first-blank', title: 'New_Document.docx', origin: 'new' });
     const first = await takeSnapshot();
 
     stopAutosaveSession();
-    await beginAutosaveSession({ title: 'New_Document.docx', origin: 'new' });
+    await beginAutosaveSession({ docId: 'second-blank', title: 'New_Document.docx', origin: 'new' });
     const second = await takeSnapshot();
 
-    // They are different documents that happen to share the default name.
     expect(second?.id).not.toBe(first?.id);
     expect((await listDocs()).total).toBe(2);
   });

--- a/test/unit/history-autosave.test.ts
+++ b/test/unit/history-autosave.test.ts
@@ -1,0 +1,222 @@
+import 'fake-indexeddb/auto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// vi.mock is hoisted above the imports, so the doubles have to be too.
+const { requestSaveDocument, getReadonlyMode } = vi.hoisted(() => ({
+  requestSaveDocument: vi.fn(),
+  getReadonlyMode: vi.fn(() => false),
+}));
+
+vi.mock('../../lib/onlyoffice/save-stream', () => ({ requestSaveDocument }));
+vi.mock('../../lib/onlyoffice/readonly', () => ({ getReadonlyMode }));
+
+import {
+  IDLE_GRACE_MS,
+  SNAPSHOT_INTERVAL_MS,
+  beginAutosaveSession,
+  getAutosaveDocId,
+  isAutosaveSessionActive,
+  setAutosaveEnabled,
+  shouldSnapshot,
+  stopAutosaveSession,
+  takeSnapshot,
+} from '../../lib/history/autosave';
+import { DB_NAME, resetHistoryDbForTests } from '../../lib/history/db';
+import { getLatestSnapshot, listDocs } from '../../lib/history/store';
+import { markDocumentDirty, resetUnsavedGuardForTests } from '../../lib/unsaved-guard';
+
+const ready: import('../../lib/history/autosave').SnapshotDecision = {
+  now: 1_000_000,
+  enabled: true,
+  dirty: true,
+  readonly: false,
+  holdsLock: true,
+  lastSnapshotAt: 1_000_000 - SNAPSHOT_INTERVAL_MS,
+  lastEditAt: 1_000_000 - IDLE_GRACE_MS,
+  exporting: false,
+};
+
+function fileOf(values: number[], name = 'Report.docx'): File {
+  return new File([new Uint8Array(values).buffer], name);
+}
+
+async function wipe(): Promise<void> {
+  resetHistoryDbForTests();
+  await new Promise<void>((resolve) => {
+    const request = indexedDB.deleteDatabase(DB_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+  });
+}
+
+describe('autosave scheduling rule', () => {
+  it('fires when there is work, a lull, and time since the last snapshot', () => {
+    expect(shouldSnapshot(ready)).toBe(true);
+  });
+
+  it('holds off for every reason on its own', () => {
+    expect(shouldSnapshot({ ...ready, enabled: false })).toBe(false);
+    expect(shouldSnapshot({ ...ready, dirty: false })).toBe(false);
+    expect(shouldSnapshot({ ...ready, readonly: true })).toBe(false);
+    expect(shouldSnapshot({ ...ready, holdsLock: false })).toBe(false);
+    expect(shouldSnapshot({ ...ready, exporting: true })).toBe(false);
+    // Too soon after the previous snapshot.
+    expect(shouldSnapshot({ ...ready, lastSnapshotAt: ready.now - 1 })).toBe(false);
+    // Still typing: an export on top of active editing is felt.
+    expect(shouldSnapshot({ ...ready, lastEditAt: ready.now })).toBe(false);
+  });
+});
+
+describe('autosave session', () => {
+  beforeEach(async () => {
+    await wipe();
+    resetUnsavedGuardForTests();
+    requestSaveDocument.mockReset();
+    getReadonlyMode.mockReturnValue(false);
+    setAutosaveEnabled(true);
+    window.history.replaceState(null, '', '/editor');
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+  });
+
+  afterEach(() => {
+    stopAutosaveSession();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('exports the document in its own format and stores the bytes', async () => {
+    requestSaveDocument.mockResolvedValue(fileOf([1, 2, 3]));
+    await beginAutosaveSession({ title: 'Report.docx', origin: 'local' });
+
+    const doc = await takeSnapshot();
+
+    expect(requestSaveDocument).toHaveBeenCalledWith('DOCX');
+    expect(doc?.title).toBe('Report.docx');
+    expect(Array.from((await getLatestSnapshot(doc!.id))!.bytes)).toEqual([1, 2, 3]);
+    expect(getAutosaveDocId()).toBe(doc!.id);
+  });
+
+  it('keeps appending to the same row across snapshots', async () => {
+    requestSaveDocument.mockResolvedValue(fileOf([1]));
+    await beginAutosaveSession({ title: 'Report.docx', origin: 'local' });
+
+    const first = await takeSnapshot();
+    const second = await takeSnapshot();
+
+    expect(second?.id).toBe(first?.id);
+    expect(second?.revCount).toBe(2);
+    expect((await listDocs()).total).toBe(1);
+  });
+
+  it('does not start in embed mode', async () => {
+    window.history.replaceState(null, '', '/editor?embed=1');
+
+    await beginAutosaveSession({ title: 'Report.docx', origin: 'local' });
+
+    expect(isAutosaveSessionActive()).toBe(false);
+  });
+
+  it('does not start when the user turned autosave off', async () => {
+    setAutosaveEnabled(false);
+
+    await beginAutosaveSession({ title: 'Report.docx', origin: 'local' });
+
+    expect(isAutosaveSessionActive()).toBe(false);
+    setAutosaveEnabled(true);
+  });
+
+  it('stays quiet when another tab holds the document lock', async () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      // The Web Locks contract for ifAvailable: the callback runs with null
+      // when someone else already holds the lock.
+      locks: { request: (_name: string, _opts: unknown, cb: (lock: null) => unknown) => Promise.resolve(cb(null)) },
+    });
+    requestSaveDocument.mockResolvedValue(fileOf([1]));
+
+    await beginAutosaveSession({ title: 'Shared.docx', origin: 'local' });
+    markDocumentDirty();
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    // The other tab is the one writing this document's history; two tabs
+    // taking turns would interleave two divergent documents into one row.
+    expect(requestSaveDocument).not.toHaveBeenCalled();
+  });
+
+  it('takes a snapshot when the page is hidden, without waiting for the interval', async () => {
+    requestSaveDocument.mockResolvedValue(fileOf([9]));
+    await beginAutosaveSession({ title: 'Hidden.docx', origin: 'local' });
+    markDocumentDirty();
+
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+    // The handler starts the export without awaiting; let it settle.
+    await vi.waitFor(async () => expect((await listDocs()).total).toBe(1));
+  });
+
+  it('does not snapshot a read-only document', async () => {
+    getReadonlyMode.mockReturnValue(true);
+    requestSaveDocument.mockResolvedValue(fileOf([1]));
+    await beginAutosaveSession({ title: 'Locked.docx', origin: 'local' });
+    markDocumentDirty();
+
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(requestSaveDocument).not.toHaveBeenCalled();
+  });
+
+  it('gives up after repeated export failures instead of retrying forever', async () => {
+    requestSaveDocument.mockRejectedValue(new Error('export failed'));
+    await beginAutosaveSession({ title: 'Broken.docx', origin: 'local' });
+
+    await takeSnapshot();
+    await takeSnapshot();
+    expect(isAutosaveSessionActive()).toBe(true);
+    await takeSnapshot();
+
+    expect(isAutosaveSessionActive()).toBe(false);
+  });
+
+  it('waits its turn while a user-initiated save owns the channel', async () => {
+    requestSaveDocument.mockRejectedValue(new Error('A save request is already in progress'));
+    await beginAutosaveSession({ title: 'Busy.docx', origin: 'local' });
+
+    await takeSnapshot();
+    await takeSnapshot();
+    await takeSnapshot();
+    await takeSnapshot();
+
+    // Losing the race to the user is not a failure, so the session survives.
+    expect(isAutosaveSessionActive()).toBe(true);
+  });
+
+  it('reuses the history row of a file that was open before', async () => {
+    requestSaveDocument.mockResolvedValue(fileOf([1]));
+    await beginAutosaveSession({ title: 'Daily.docx', origin: 'local' });
+    const first = await takeSnapshot();
+
+    stopAutosaveSession();
+    await beginAutosaveSession({ title: 'Daily.docx', origin: 'local' });
+    const second = await takeSnapshot();
+
+    expect(second?.id).toBe(first?.id);
+    expect((await listDocs()).total).toBe(1);
+  });
+
+  it('gives every blank document its own row', async () => {
+    requestSaveDocument.mockResolvedValue(fileOf([1], 'New_Document.docx'));
+    await beginAutosaveSession({ title: 'New_Document.docx', origin: 'new' });
+    const first = await takeSnapshot();
+
+    stopAutosaveSession();
+    await beginAutosaveSession({ title: 'New_Document.docx', origin: 'new' });
+    const second = await takeSnapshot();
+
+    // They are different documents that happen to share the default name.
+    expect(second?.id).not.toBe(first?.id);
+    expect((await listDocs()).total).toBe(2);
+  });
+});

--- a/test/unit/history-recovery.test.ts
+++ b/test/unit/history-recovery.test.ts
@@ -1,0 +1,97 @@
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { openLocalFile } = vi.hoisted(() => ({ openLocalFile: vi.fn() }));
+vi.mock('../../lib/document', () => ({ openLocalFile }));
+
+import { DB_NAME, resetHistoryDbForTests } from '../../lib/history/db';
+import { getDoc, markSavedToDisk, putSnapshot } from '../../lib/history/store';
+import { dismissRecoveryBar, formatRelativeTime, offerRecovery, restoreDocument } from '../../lib/history/recovery';
+
+async function wipe(): Promise<void> {
+  resetHistoryDbForTests();
+  await new Promise<void>((resolve) => {
+    const request = indexedDB.deleteDatabase(DB_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+  });
+}
+
+function bar(): HTMLElement | null {
+  return document.getElementById('recovery-bar');
+}
+
+describe('recovery offer', () => {
+  beforeEach(async () => {
+    await wipe();
+    dismissRecoveryBar();
+    openLocalFile.mockReset();
+  });
+
+  it('says nothing when there is nothing to recover', async () => {
+    expect(await offerRecovery()).toBeNull();
+    expect(bar()).toBeNull();
+  });
+
+  it('offers the document whose edits never reached the disk, naming it', async () => {
+    const doc = await putSnapshot({ title: 'Report.docx', origin: 'local', bytes: new Uint8Array([1]) });
+
+    const offered = await offerRecovery();
+
+    expect(offered?.id).toBe(doc!.id);
+    expect(bar()?.textContent).toContain('Report.docx');
+  });
+
+  it('says nothing about a document that was saved to disk', async () => {
+    const doc = await putSnapshot({ title: 'Saved.docx', origin: 'local', bytes: new Uint8Array([1]) });
+    await markSavedToDisk(doc!.id);
+
+    expect(await offerRecovery()).toBeNull();
+  });
+
+  it('does not offer the document that is already open', async () => {
+    const doc = await putSnapshot({ title: 'Open.docx', origin: 'local', bytes: new Uint8Array([1]) });
+
+    expect(await offerRecovery({ excludeId: doc!.id })).toBeNull();
+  });
+
+  it('reopens the newest snapshot through the ordinary open path', async () => {
+    const doc = await putSnapshot({ title: 'Restore.docx', origin: 'local', bytes: new Uint8Array([7, 7]) });
+
+    expect(await restoreDocument(doc!)).toBe(true);
+
+    const [file, options] = openLocalFile.mock.calls[0];
+    expect((file as File).name).toBe('Restore.docx');
+    expect(new Uint8Array(await (file as File).arrayBuffer())).toEqual(new Uint8Array([7, 7]));
+    // Continues the same history row instead of starting a duplicate.
+    expect(options).toEqual({ historyId: doc!.id });
+  });
+
+  it('restores from the bar and takes the bar away', async () => {
+    await putSnapshot({ title: 'Bar.docx', origin: 'local', bytes: new Uint8Array([1]) });
+    await offerRecovery();
+
+    bar()!.querySelectorAll('r-button')[0].dispatchEvent(new Event('click'));
+
+    expect(bar()).toBeNull();
+    await vi.waitFor(() => expect(openLocalFile).toHaveBeenCalled());
+  });
+
+  it('remembers a dismissal so the next boot stays quiet', async () => {
+    const doc = await putSnapshot({ title: 'Dismiss.docx', origin: 'local', bytes: new Uint8Array([1]) });
+    await offerRecovery();
+
+    bar()!.querySelectorAll('r-button')[1].dispatchEvent(new Event('click'));
+
+    expect(bar()).toBeNull();
+    await vi.waitFor(async () => expect((await getDoc(doc!.id))?.dismissedAt).toBeGreaterThan(0));
+    expect(await offerRecovery()).toBeNull();
+  });
+
+  it('describes when the edits happened, not just that they exist', () => {
+    const now = Date.UTC(2026, 0, 1, 12, 0, 0);
+    expect(formatRelativeTime(now - 5 * 60_000, now)).toMatch(/5/);
+    expect(formatRelativeTime(now - 3 * 60 * 60_000, now)).toMatch(/3/);
+  });
+});

--- a/test/unit/history-recovery.test.ts
+++ b/test/unit/history-recovery.test.ts
@@ -5,11 +5,12 @@ const { openLocalFile } = vi.hoisted(() => ({ openLocalFile: vi.fn() }));
 vi.mock('../../lib/document', () => ({ openLocalFile }));
 
 import { DB_NAME, resetHistoryDbForTests } from '../../lib/history/db';
-import { getDoc, markSavedToDisk, putSnapshot } from '../../lib/history/store';
+import { getDoc, markSavedToDisk, putSnapshot, resetHistoryClockForTests } from '../../lib/history/store';
 import { dismissRecoveryBar, formatRelativeTime, offerRecovery, restoreDocument } from '../../lib/history/recovery';
 
 async function wipe(): Promise<void> {
   resetHistoryDbForTests();
+  resetHistoryClockForTests();
   await new Promise<void>((resolve) => {
     const request = indexedDB.deleteDatabase(DB_NAME);
     request.onsuccess = () => resolve();

--- a/test/unit/history-store.test.ts
+++ b/test/unit/history-store.test.ts
@@ -7,18 +7,19 @@ import {
   clearAllHistory,
   deleteDoc,
   dismissRecovery,
-  findDocByTitle,
   getDoc,
   getLatestSnapshot,
   getRecoverableDoc,
   historyUsage,
+  pruneExpired,
   listDocs,
   markOpened,
   markSavedToDisk,
   putSnapshot,
+  resetHistoryClockForTests,
   storageBudget,
 } from '../../lib/history/store';
-import { hasUnsavedWork } from '../../lib/history/types';
+import { MAX_AGE_MS, daysUntilExpiry, hasUnsavedWork } from '../../lib/history/types';
 
 function bytes(size: number, fill = 65): Uint8Array {
   return new Uint8Array(size).fill(fill);
@@ -26,6 +27,7 @@ function bytes(size: number, fill = 65): Uint8Array {
 
 async function wipe(): Promise<void> {
   resetHistoryDbForTests();
+  resetHistoryClockForTests();
   await new Promise<void>((resolve) => {
     const request = indexedDB.deleteDatabase(DB_NAME);
     request.onsuccess = () => resolve();
@@ -184,11 +186,42 @@ describe('history store', () => {
     expect((await listDocs()).items.map((row) => row.title)).toEqual(['New.docx']);
   });
 
-  it('reuses the row for a file name that is opened again', async () => {
-    const first = await putSnapshot({ title: 'Daily.docx', origin: 'local', bytes: bytes(8) });
+  it('deletes documents that went seven days without being touched', async () => {
+    const stale = await putSnapshot({ title: 'Stale.docx', origin: 'local', bytes: bytes(16) });
+    const fresh = await putSnapshot({ title: 'Fresh.docx', origin: 'local', bytes: bytes(16) });
 
-    expect((await findDocByTitle('daily.docx'))?.id).toBe(first!.id);
-    expect(await findDocByTitle('other.docx')).toBeNull();
+    // Only Date is faked: faking timers as well would stall fake-indexeddb,
+    // which drives its transactions through the macrotask queue.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(Date.now() + MAX_AGE_MS + 1000);
+    // Coming back to the fresh one restarts its clock; nobody touched the other.
+    await markOpened(fresh!.id);
+
+    expect(await pruneExpired()).toEqual([stale!.id]);
+    expect(await getDoc(stale!.id)).toBeNull();
+    expect(await getLatestSnapshot(stale!.id)).toBeNull();
+    expect(await getDoc(fresh!.id)).not.toBeNull();
+    vi.useRealTimers();
+  });
+
+  it('sweeps expired documents on the next write, without waiting for a visit', async () => {
+    const stale = await putSnapshot({ title: 'Stale.docx', origin: 'local', bytes: bytes(16) });
+
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(Date.now() + MAX_AGE_MS + 1000);
+    await putSnapshot({ title: 'Later.docx', origin: 'local', bytes: bytes(16) });
+
+    expect(await getDoc(stale!.id)).toBeNull();
+    expect((await listDocs()).items.map((doc) => doc.title)).toEqual(['Later.docx']);
+    vi.useRealTimers();
+  });
+
+  it('counts the days a document has left', async () => {
+    const doc = await putSnapshot({ title: 'Counting.docx', origin: 'local', bytes: bytes(8) });
+
+    expect(daysUntilExpiry(doc!, doc!.updatedAt)).toBe(7);
+    expect(daysUntilExpiry(doc!, doc!.updatedAt + 6.5 * 24 * 60 * 60 * 1000)).toBe(1);
+    expect(daysUntilExpiry(doc!, doc!.updatedAt + MAX_AGE_MS + 1)).toBe(0);
   });
 
   it('offers only documents whose work never reached the disk', async () => {

--- a/test/unit/history-store.test.ts
+++ b/test/unit/history-store.test.ts
@@ -1,0 +1,219 @@
+import 'fake-indexeddb/auto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DB_NAME, resetHistoryDbForTests } from '../../lib/history/db';
+import {
+  DEFAULT_PAGE_SIZE,
+  MAX_REVS_PER_DOC,
+  clearAllHistory,
+  deleteDoc,
+  dismissRecovery,
+  findDocByTitle,
+  getDoc,
+  getLatestSnapshot,
+  getRecoverableDoc,
+  historyUsage,
+  listDocs,
+  markOpened,
+  markSavedToDisk,
+  putSnapshot,
+  storageBudget,
+} from '../../lib/history/store';
+import { hasUnsavedWork } from '../../lib/history/types';
+
+function bytes(size: number, fill = 65): Uint8Array {
+  return new Uint8Array(size).fill(fill);
+}
+
+async function wipe(): Promise<void> {
+  resetHistoryDbForTests();
+  await new Promise<void>((resolve) => {
+    const request = indexedDB.deleteDatabase(DB_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+  });
+}
+
+// jsdom ships no StorageManager; the budget path reads one when it exists.
+function mockQuota(quota: number): void {
+  Object.defineProperty(navigator, 'storage', {
+    value: { estimate: () => Promise.resolve({ quota, usage: 0 }) },
+    configurable: true,
+  });
+}
+
+describe('history store', () => {
+  beforeEach(wipe);
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('stores a snapshot and reads its metadata back', async () => {
+    const doc = await putSnapshot({ title: 'Report.docx', origin: 'local', bytes: bytes(128) });
+
+    expect(doc).not.toBeNull();
+    expect(doc?.title).toBe('Report.docx');
+    expect(doc?.ext).toBe('docx');
+    expect(doc?.size).toBe(128);
+    expect(doc?.totalBytes).toBe(128);
+    expect(doc?.revCount).toBe(1);
+
+    const { items, total } = await listDocs();
+    expect(total).toBe(1);
+    expect(items[0].id).toBe(doc?.id);
+  });
+
+  it('appends revisions to the same document and hands back the newest bytes', async () => {
+    const first = await putSnapshot({ title: 'Report.docx', origin: 'local', bytes: bytes(10, 1) });
+    const second = await putSnapshot({ id: first!.id, title: 'Report.docx', origin: 'local', bytes: bytes(20, 2) });
+
+    expect(second?.id).toBe(first!.id);
+    expect(second?.revCount).toBe(2);
+    expect(second?.totalBytes).toBe(30);
+
+    const latest = await getLatestSnapshot(first!.id);
+    expect(latest?.byteLength).toBe(20);
+    expect(latest!.bytes[0]).toBe(2);
+
+    // One document, not two.
+    expect((await listDocs()).total).toBe(1);
+  });
+
+  it('keeps only the newest revisions and accounts for the bytes it dropped', async () => {
+    let id: string | undefined;
+    for (let i = 0; i < MAX_REVS_PER_DOC + 2; i += 1) {
+      const doc = await putSnapshot({ id, title: 'Long.docx', origin: 'local', bytes: bytes(100) });
+      id = doc!.id;
+    }
+
+    const doc = await getDoc(id!);
+    expect(doc?.revCount).toBe(MAX_REVS_PER_DOC);
+    expect(doc?.totalBytes).toBe(MAX_REVS_PER_DOC * 100);
+    expect(await historyUsage()).toBe(MAX_REVS_PER_DOC * 100);
+
+    // The surviving revisions are the newest ones.
+    const latest = await getLatestSnapshot(id!);
+    expect(latest?.rev).toBe(MAX_REVS_PER_DOC + 1);
+  });
+
+  it('pages the list newest first and clamps a page past the end', async () => {
+    for (let i = 0; i < DEFAULT_PAGE_SIZE + 5; i += 1) {
+      await putSnapshot({ title: `Doc-${i}.docx`, origin: 'local', bytes: bytes(8) });
+    }
+
+    const first = await listDocs();
+    expect(first.items).toHaveLength(DEFAULT_PAGE_SIZE);
+    expect(first.total).toBe(DEFAULT_PAGE_SIZE + 5);
+    expect(first.items[0].title).toBe(`Doc-${DEFAULT_PAGE_SIZE + 4}.docx`);
+
+    const second = await listDocs({ page: 2 });
+    expect(second.items).toHaveLength(5);
+
+    const past = await listDocs({ page: 99 });
+    expect(past.page).toBe(2);
+    expect(past.items).toHaveLength(5);
+  });
+
+  it('searches titles case-insensitively and by substring, including Chinese', async () => {
+    await putSnapshot({ title: 'Quarterly Report.docx', origin: 'local', bytes: bytes(8) });
+    await putSnapshot({ title: '年度总结报告.docx', origin: 'local', bytes: bytes(8) });
+    await putSnapshot({ title: 'budget.xlsx', origin: 'local', bytes: bytes(8) });
+
+    expect((await listDocs({ query: 'report' })).total).toBe(1);
+    expect((await listDocs({ query: 'REPORT' })).total).toBe(1);
+    // Substring, not prefix -- the thing an IndexedDB key range cannot do.
+    expect((await listDocs({ query: '总结' })).total).toBe(1);
+    expect((await listDocs({ query: 'nothing' })).total).toBe(0);
+  });
+
+  it('deletes a document together with its bytes', async () => {
+    const doc = await putSnapshot({ title: 'Gone.docx', origin: 'local', bytes: bytes(64) });
+
+    expect(await deleteDoc(doc!.id)).toBe(true);
+    expect(await getDoc(doc!.id)).toBeNull();
+    expect(await getLatestSnapshot(doc!.id)).toBeNull();
+    expect(await historyUsage()).toBe(0);
+  });
+
+  it('clears the library, bytes included', async () => {
+    const a = await putSnapshot({ title: 'A.docx', origin: 'local', bytes: bytes(64) });
+    await putSnapshot({ title: 'B.docx', origin: 'local', bytes: bytes(64) });
+
+    expect(await clearAllHistory()).toBe(true);
+    expect((await listDocs()).total).toBe(0);
+    // The promise a "clear everything" button makes is about the content, not
+    // the index: the bytes have to be gone too.
+    expect(await getLatestSnapshot(a!.id)).toBeNull();
+  });
+
+  it('evicts the least-recently-opened document when the budget is exceeded', async () => {
+    mockQuota(600);
+    expect(await storageBudget()).toBe(300);
+
+    const cold = await putSnapshot({ title: 'Cold.docx', origin: 'local', bytes: bytes(100) });
+    const warm = await putSnapshot({ title: 'Warm.docx', origin: 'local', bytes: bytes(100) });
+    await markOpened(warm!.id);
+    // Pushes the library past the 300-byte budget.
+    const fresh = await putSnapshot({ title: 'Fresh.docx', origin: 'local', bytes: bytes(150) });
+
+    const titles = (await listDocs()).items.map((doc) => doc.title);
+    expect(titles).toContain('Fresh.docx');
+    expect(titles).not.toContain('Cold.docx');
+    expect(await getLatestSnapshot(cold!.id)).toBeNull();
+    expect(await getDoc(fresh!.id)).not.toBeNull();
+  });
+
+  it('makes room and retries once when the browser refuses a write', async () => {
+    await putSnapshot({ title: 'Old.docx', origin: 'local', bytes: bytes(16) });
+
+    const put = IDBObjectStore.prototype.put;
+    let thrown = false;
+    vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (this: IDBObjectStore, ...args) {
+      if (!thrown && this.name === 'blobs') {
+        thrown = true;
+        throw Object.assign(new Error('quota'), { name: 'QuotaExceededError' });
+      }
+      return put.apply(this, args as Parameters<typeof put>);
+    });
+
+    const doc = await putSnapshot({ title: 'New.docx', origin: 'local', bytes: bytes(16) });
+
+    expect(thrown).toBe(true);
+    expect(doc).not.toBeNull();
+    // The retry paid for itself by dropping the coldest document.
+    expect((await listDocs()).items.map((row) => row.title)).toEqual(['New.docx']);
+  });
+
+  it('reuses the row for a file name that is opened again', async () => {
+    const first = await putSnapshot({ title: 'Daily.docx', origin: 'local', bytes: bytes(8) });
+
+    expect((await findDocByTitle('daily.docx'))?.id).toBe(first!.id);
+    expect(await findDocByTitle('other.docx')).toBeNull();
+  });
+
+  it('offers only documents whose work never reached the disk', async () => {
+    const doc = await putSnapshot({ title: 'Unsaved.docx', origin: 'local', bytes: bytes(8) });
+    expect(hasUnsavedWork(doc!)).toBe(true);
+    expect((await getRecoverableDoc())?.id).toBe(doc!.id);
+
+    await markSavedToDisk(doc!.id);
+    expect(await getRecoverableDoc()).toBeNull();
+  });
+
+  it('stops offering a document the user dismissed, until it changes again', async () => {
+    const doc = await putSnapshot({ title: 'Dismissed.docx', origin: 'local', bytes: bytes(8) });
+
+    await dismissRecovery(doc!.id);
+    expect(await getRecoverableDoc()).toBeNull();
+
+    // A new snapshot is new work: worth offering again.
+    await putSnapshot({ id: doc!.id, title: 'Dismissed.docx', origin: 'local', bytes: bytes(9) });
+    expect((await getRecoverableDoc())?.id).toBe(doc!.id);
+  });
+
+  it('never offers the document already open in this editor', async () => {
+    const doc = await putSnapshot({ title: 'Current.docx', origin: 'local', bytes: bytes(8) });
+
+    expect(await getRecoverableDoc({ excludeId: doc!.id })).toBeNull();
+  });
+});

--- a/test/unit/sw-routing.test.ts
+++ b/test/unit/sw-routing.test.ts
@@ -19,7 +19,7 @@ const FONT_REGEX = /\.(ttf|woff2?|otf|eot)(\?.*)?$/;
 
 /** Keep in sync with DEPLOY_COUPLED in public/sw.js and the no-cache group in public/_headers. */
 const DEPLOY_COUPLED =
-  /^\/(?:home|landing)\.css$|^\/(?:lang-switch|sw-register|open-local|landing-prefetch)\.js$|^\/ranui-iife\//;
+  /^\/(?:home|landing)\.css$|^\/(?:lang-switch|sw-register|open-local|landing-prefetch|history-recent)\.js$|^\/ranui-iife\//;
 
 const isHtmlRequest = (mode: string, pathname: string): boolean =>
   mode === 'navigate' || pathname.endsWith('.html') || pathname === '/' || pathname.endsWith('/');
@@ -182,6 +182,8 @@ describe('deploy-coupled assets use network-first', () => {
       // the browser's disk cache indefinitely.
       '/open-local.js',
       '/landing-prefetch.js',
+      // Reads one history row so the homepage can offer the way back to it.
+      '/history-recent.js',
       '/ranui-iife/button.iife.js',
       '/ranui-iife/card.iife.js',
     ]) {

--- a/test/unit/unsaved-guard.test.ts
+++ b/test/unit/unsaved-guard.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  hasUnsavedChanges,
+  installUnsavedChangesGuard,
+  markDocumentDirty,
+  markDocumentSaved,
+  resetUnsavedChanges,
+  resetUnsavedGuardForTests,
+} from '../../lib/unsaved-guard';
+
+// One module instance throughout: resetModules() would leave the previous
+// instance's beforeunload listener attached to the same window, and that stale
+// listener answers for state the current test cannot reach.
+function fireBeforeUnload(): Event {
+  const event = new Event('beforeunload', { cancelable: true });
+  window.dispatchEvent(event);
+  return event;
+}
+
+describe('unsaved changes guard', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/editor');
+  });
+
+  afterEach(() => {
+    resetUnsavedGuardForTests();
+  });
+
+  it('does not block unload when the document has no edits', () => {
+    installUnsavedChangesGuard();
+
+    expect(hasUnsavedChanges()).toBe(false);
+    expect(fireBeforeUnload().defaultPrevented).toBe(false);
+  });
+
+  it('blocks unload once the editor reports an edit', () => {
+    installUnsavedChangesGuard();
+
+    markDocumentDirty();
+
+    expect(hasUnsavedChanges()).toBe(true);
+    expect(fireBeforeUnload().defaultPrevented).toBe(true);
+  });
+
+  it('stops blocking once the bytes reached the disk', () => {
+    installUnsavedChangesGuard();
+
+    markDocumentDirty();
+    markDocumentSaved();
+
+    expect(fireBeforeUnload().defaultPrevented).toBe(false);
+  });
+
+  it('clears the flag when another document takes over the editor', () => {
+    installUnsavedChangesGuard();
+
+    markDocumentDirty();
+    resetUnsavedChanges();
+
+    expect(fireBeforeUnload().defaultPrevented).toBe(false);
+  });
+
+  it('stays out of the way in embed mode', () => {
+    window.history.replaceState(null, '', '/editor?embed=1');
+    installUnsavedChangesGuard();
+
+    markDocumentDirty();
+
+    // The host page owns the unload experience for its own iframe.
+    expect(fireBeforeUnload().defaultPrevented).toBe(false);
+  });
+
+  it('installs a single listener however many times it is called', () => {
+    const addEventListener = vi.spyOn(window, 'addEventListener');
+
+    installUnsavedChangesGuard();
+    installUnsavedChangesGuard();
+    installUnsavedChangesGuard();
+
+    expect(addEventListener.mock.calls.filter(([type]) => type === 'beforeunload')).toHaveLength(1);
+    addEventListener.mockRestore();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -92,11 +92,14 @@ export default defineConfig(() => {
     publicDir: publicDirName,
     build: {
       outDir: 'dist',
-      // Two HTML entries: / (static landing, no editor bundle) and /editor (the app).
+      // Three HTML entries: / (static landing, no editor bundle), /editor (the
+      // app) and /history (the local library, which reads IndexedDB metadata
+      // and never loads the editor stack).
       rollupOptions: {
         input: {
           main: resolve(__dirname, 'index.html'),
           editor: resolve(__dirname, 'editor.html'),
+          history: resolve(__dirname, 'history.html'),
         },
       },
     },


### PR DESCRIPTION
Editing work could be lost by closing a tab. There was no autosave, and no
`beforeunload` guard either -- a mistaken Cmd+W threw the session away in
silence. This adds the layers that stop that, and the ways to find the work
again afterwards.

Design notes and the survey of how other web apps solve this are in
[docs/explorations/2026-08-22-autosave-history-evaluation.md](docs/explorations/2026-08-22-autosave-history-evaluation.md);
what actually got built, and where it diverged, is in
[the implementation record](docs/explorations/2026-08-22-autosave-history-implementation.md).

## What is in it

**Don't lose it.** A `beforeunload` prompt when the open document has edits
that never reached the disk. Guard 11 drops the vendor's own handler inside
the editor frame: with serverless save semantics the SDK never learns a
document was saved, so its prompt kept firing afterwards -- the reliable way
to teach someone to dismiss a prompt without reading it.

**Keep a recovery point.** Snapshots go to IndexedDB on the app's own
metronome -- something to save, a lull in the typing, time since the last one,
plus one on `visibilitychange -> hidden`. Slow on purpose: a snapshot here is a
full x2t export behind a 283 MB heap request, not a `JSON.stringify`. This is
AutoRecover, not AutoSave: it never touches the user's file and never clears
the unsaved-changes warning. A Web Lock keeps two tabs from interleaving one
document.

**Find it again.** A recovery bar on the next boot that names the document and
when the edits happened (WordPress's framing: which copy is ahead), a
"continue editing" line on both homepages, and `/history` -- paged, searchable
by any substring of a title in any language, with a delete on every row and a
clear-everything that empties the bytes as well as the index.

**Identity is an id, not a file name.** Every session mints one before the
editor mounts and stamps it into `?doc=<id>`. Reusing rows by name merged
unrelated documents (every blank document is `New_Document.docx`), and the
address now also means a reload reopens the same document instead of a second
blank one.

**It clears itself after seven days**, counted from the last edit or open,
swept on boot, on every write, and when the history page opens. The rule is
stated in the homepage HTML (not drawn by script -- it has to hold with JS
off), on the history page, and as a per-row countdown.

## Tests

37 new unit tests and 13 new e2e tests; full suites green (879 unit, 113 e2e
passed / 16 skipped), plus a real deployment build.

Reverse-verified per convention 3 -- each of these turns exactly one case red
on its own: the `preventDefault`/`returnValue` pair, the revision trim, the
budget eviction, the blob clear in `clearAllHistory`, the quota retry, the
dismissal check, the saved-to-disk check, the history id on restore, the
`visibilitychange` snapshot, and the expiry sweep.

Worth knowing: the recovery e2e originally passed either way -- its 120 s
window let the 90 s periodic tick take the snapshot instead of the branch it
names. The window is now 45 s, inside the interval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)