### PR TITLE
feat(save): write back into the document's own file instead of downloading a copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,11 +83,12 @@ lib/                  # 应用层（纯 TypeScript，只在本站点用）
   pending-open.ts       # 静态落地页经 IndexedDB 交接文件（?open=local）
   unsaved-guard.ts      # 未保存提示（beforeunload）+ 全局脏位，编辑器 onDocumentStateChange 驱动
   embed-mode.ts         # isEmbedMode() 单一实现（save-stream / unsaved-guard / history 共用）
+  save-target.ts        # 文档在磁盘上的那个文件：记住 File System Access 句柄，之后的保存直接写回
   history/              # 本地历史（自动保存恢复点），2026-08-22
     db.ts                 # IndexedDB schema：docs（元数据）+ blobs（字节）两个 store
     store.ts              # CRUD、内存分页与标题子串搜索、每篇 3 rev、七天过期、配额降级
     autosave.ts           # 节拍器：脏位 + 空闲 + 间隔三重条件，visibilitychange 补一刀，Web Locks 互斥
-    session.ts            # 会话身份：mint docId 并写进 ?doc=<id>
+    session.ts            # 会话身份：mint docId 并写进 ?saved=<id>
     recovery.ts           # 启动恢复条（Office Document Recovery 模型）
     types.ts / index.ts   # 记录形状与保留期工具 / 对外装配（含 savedToDisk 回调注入）
   history-page.ts       # /history 页面（第三个 vite entry，见 history.html）
@@ -109,7 +110,7 @@ content/              # 生成页面的 markdown 源（content/<locale>/*.md，f
 docs/                 # embed-api / fonts 文档、explorations/（每次改动的记录）、superpowers/plans/
 index.ts              # 编辑器入口（初始化事件、UI、PWA），挂在 editor.html
 index.html            # `/`：静态落地页（无编辑器 bundle；CTA 跳 /editor，旧深链内联脚本重定向）
-editor.html           # `/editor`：编辑器页面（?new= ?file= ?src= ?embed=1 ?open=local ?doc=<id>）
+editor.html           # `/editor`：编辑器页面（?new= ?file= ?src= ?embed=1 ?open=local ?saved=<id>）
 history.html          # `/history`：本地历史页（noindex，只读 IndexedDB 元数据，不加载编辑器）
 ```
 
@@ -240,7 +241,7 @@ test/setup/vitest.ts          # 全局 mock：matchMedia、URL.createObjectURL�
 | 失败与守卫        | `open-failure`（-82 可见 + 保存快速拒绝，兼作 L0 自检）、`comment-bulk-actions`（守卫 8）、`wasm-memory`（守卫 10：40 MB x2t 二进制用完即还）                                                                                                                                                                                                            |
 | 视觉 / 性能       | `visual-roundtrip`（无基线：原始 vs 存回再打开逐像素）、`slow-network` _opt-in_ `SLOW_NET=1`                                                                                                                                                                                                                                                             |
 | 交互面（策略 §9） | `api-surface` _opt-in_ `API_SWEEP=1`、`shortcut-surface` _opt-in_ `SHORTCUT_SWEEP=1`、`ui-crawl` _opt-in_ `UI_CRAWL=1`（逐页签点遍工具栏按钮，归因到按钮）、`monkey` _opt-in_ `MONKEY=1`（定种子随机序列，可精确回放）                                                                                                                                   |
-| 本地历史          | `history-page`（分页/中文子串搜索/删除/清空/七天过期/首页披露）、`autosave-recovery`（真实编辑器：编辑→隐藏页面→快照→恢复条→存回；`?doc=` 刷新回同一篇；embed 不写历史）                                                                                                                                                                                 |
+| 本地历史          | `history-page`（分页/中文子串搜索/删除/清空/七天过期/首页披露）、`autosave-recovery`（真实编辑器：编辑→隐藏页面→快照→恢复条→存回；`?saved=` 刷新回同一篇；embed 不写历史）                                                                                                                                                                               |
 | 真实语料          | `corpus` _opt-in_ `CORPUS_DIR=…`（见上）                                                                                                                                                                                                                                                                                                                 |
 
 另有三套独立配置：`playwright.pages.config.ts`（`bin/build.sh` + `wrangler pages dev`，
@@ -536,7 +537,7 @@ docs/explorations/2026-08-19-ci-e2e-sharding.md。
    快照只进本机 IndexedDB，永远不动用户磁盘上的文件，也**不清除未保存提示**（只有真正导出到
    磁盘才清）。四条硬约束，改这块前先读
    docs/explorations/2026-08-22-autosave-history-implementation.md：
-   1. **身份是 `?doc=<id>`，不是文件名**。会话在挂载前 mint id 并写进地址栏；按标题复用行
+   1. **身份是 `?saved=<id>`，不是文件名**。会话在挂载前 mint id 并写进地址栏；按标题复用行
       会把无关文档的历史合并（每个新建空文档都叫 `New_Document.docx`）。一行 = 一次编辑会话；
       只打开不编辑不留行（行由第一次快照创建）。
    2. **七天自动清除**，从 `max(updatedAt, lastOpenedAt)` 起算，在启动、每次写快照、
@@ -547,6 +548,12 @@ docs/explorations/2026-08-19-ci-e2e-sharding.md。
       被用户的保存占用时跳过这一拍。
    4. **embed 模式与只读一律不写**；两个标签页开同一 id 由 Web Locks 互斥，拿不到锁的那个
       不写快照（否则两边轮流覆盖，比没有历史更糟）。
+   5. **保存优先写回文档自己的文件**（`lib/save-target.ts`，仅 Chromium）：第一次保存选文件，
+      句柄按 docId 存进 `handles` store，之后静默写回。任何异常（文件被移走、权限被拒、
+      浏览器没这个 API）都回落到下载，并**忘掉句柄**——那既是容错也是"另存为"的出口。
+      注意保存到磁盘会清掉未保存脏位，所以之后不再产生快照，直到用户又编辑。
+      `?saved=` 用查询参数而不是路径段：这个 id 指的是**某台设备上某个浏览器里的一行记录**，
+      放进路径会让它看起来可分享，而收到链接的人只会打开一个空编辑器。
       节拍是 90s 间隔 + 2s 空闲 + 脏位三重条件，另加 `visibilitychange → hidden` 补一刀
       （`beforeunload` 里发起导出来不及）。**E2E 等快照的窗口必须小于 90s**，否则周期 tick
       会替你把用例变绿，测不到它声称测的分支（踩过）。

--- a/index.ts
+++ b/index.ts
@@ -123,19 +123,26 @@ const createNewOnLoad = ['docx', 'xlsx', 'pptx'].includes(newExt) && !documentUr
 // IndexedDB via public/open-local.js — take it out and open it on boot.
 const openParam = getAllQueryString()['open'];
 const openLocalOnLoad = openParam === 'local' && !documentUrl && !createNewOnLoad;
-// `?doc=<id>`: which document this is. Every editing session stamps its own id
-// here (see lib/history/session.ts), so a reload comes back to the same
-// document instead of a second blank one, and the history page's Open link is
-// the same URL the editor was already using. File names cannot play this role:
-// they repeat, and two documents sharing one would share a history.
-const docParam = getAllQueryString()['doc'] ?? '';
+// `?saved=<id>`: which of this browser's saved documents to open. Every
+// editing session stamps its own id here (see lib/history/session.ts), so a
+// reload comes back to the same document instead of a second blank one, and
+// the Open link on /history is the URL the editor was already using.
+//
+// A query parameter rather than a path segment, deliberately. Google Docs and
+// Figma put ids in the path because those ids name something on a server that
+// anyone with the link can open; this one names a row in one browser's
+// IndexedDB. In a path it would look shareable, and the person it was sent to
+// would open an empty editor. It is also why it is not called `id`: what makes
+// it meaningful is not that it is an identifier, it is that the document is
+// saved on this device.
+const savedParam = getAllQueryString()['saved'] ?? '';
 
 // Landing hero orchestration. Only the bare homepage (no ?file/?src/?new, not
 // embedded) shows the crawlable hero. If a document is about to load or be
 // created, or we're embedded, hide it immediately to avoid a flash before the
 // editor takes over.
 const isEmbedded = document.body.classList.contains('embed-mode');
-if (documentUrl || isEmbedded || createNewOnLoad || openLocalOnLoad || docParam) {
+if (documentUrl || isEmbedded || createNewOnLoad || openLocalOnLoad || savedParam) {
   hideLanding();
 } else {
   // Bare /editor with nothing to open: the landing lives at / now.
@@ -146,12 +153,12 @@ void (async () => {
   // A stored snapshot wins over every other way of opening: it is strictly
   // newer than the file on disk or the blank document the other parameters
   // would produce, and it is the copy nobody else has.
-  if (docParam && !isEmbedded) {
+  if (savedParam && !isEmbedded) {
     const [{ getDoc }, { restoreDocument }] = await Promise.all([
       import('./lib/history/store'),
       import('./lib/history/recovery'),
     ]);
-    const doc = await getDoc(docParam);
+    const doc = await getDoc(savedParam);
     if (doc && (await restoreDocument(doc))) return;
     // No snapshot yet (nothing was edited before the reload) or it expired:
     // fall through and open the same document again under the same id.
@@ -160,17 +167,17 @@ void (async () => {
   if (documentUrl) {
     try {
       const decodedUrl = decodeURIComponent(documentUrl);
-      await openDocumentFromUrl(decodedUrl, undefined, { readonly: isReadonly, docId: docParam || undefined });
+      await openDocumentFromUrl(decodedUrl, undefined, { readonly: isReadonly, docId: savedParam || undefined });
     } catch (error) {
       // If decoding fails, try using original URL
       console.warn('Failed to decode URL, using original:', error);
-      await openDocumentFromUrl(documentUrl, undefined, { readonly: isReadonly, docId: docParam || undefined });
+      await openDocumentFromUrl(documentUrl, undefined, { readonly: isReadonly, docId: savedParam || undefined });
     }
     return;
   }
 
   if (createNewOnLoad && !isEmbedded) {
-    await onCreateNew(`.${newExt}`, { docId: docParam || undefined });
+    await onCreateNew(`.${newExt}`, { docId: savedParam || undefined });
     return;
   }
 
@@ -183,7 +190,7 @@ void (async () => {
     cleaned.searchParams.delete('open');
     window.history.replaceState(null, '', cleaned);
     if (file) {
-      await openLocalFile(file, { historyId: docParam || undefined });
+      await openLocalFile(file, { historyId: savedParam || undefined });
       return;
     }
     // Stale deep link (reload, bookmarked URL): nothing pending -- back to the landing.
@@ -191,9 +198,9 @@ void (async () => {
     return;
   }
 
-  // `?doc=` on its own and nothing stored under it: the document it names was
+  // `?saved=` on its own and nothing stored under it: the document it names was
   // deleted or has expired, so there is nothing here to show.
-  if (docParam && !isEmbedded) window.location.replace('/');
+  if (savedParam && !isEmbedded) window.location.replace('/');
 })();
 
 // Boot-time recovery offer. Deliberately late and lazy: it must not compete
@@ -204,7 +211,7 @@ if (!isEmbedded) {
   window.addEventListener('load', () => {
     window.setTimeout(() => {
       void import('./lib/history/recovery').then(({ offerRecovery }) =>
-        offerRecovery({ excludeId: docParam || undefined }),
+        offerRecovery({ excludeId: savedParam || undefined }),
       );
     }, 1500);
   });

--- a/lib/document.ts
+++ b/lib/document.ts
@@ -129,7 +129,7 @@ export const openDocumentFromUrl = async (
   options?: {
     readonly?: boolean;
     fetchOptions?: RequestInit;
-    /** Continue an existing history row (a reload of `?doc=<id>&file=<url>`). */
+    /** Continue an existing history row (a reload of `?saved=<id>&file=<url>`). */
     docId?: string;
   },
 ): Promise<void> => {

--- a/lib/history-page.ts
+++ b/lib/history-page.ts
@@ -88,7 +88,7 @@ function buildRow(doc: HistoryDoc, refresh: () => void): HTMLElement {
     .children(
       View('a')
         .class('history-row-title history-open')
-        .attr('href', `/editor?doc=${encodeURIComponent(doc.id)}`)
+        .attr('href', `/editor?saved=${encodeURIComponent(doc.id)}`)
         .text(doc.title)
         .build(),
       ...(hasUnsavedWork(doc)

--- a/lib/history/db.ts
+++ b/lib/history/db.ts
@@ -14,10 +14,17 @@
  * takes for the landing-page handoff.
  */
 export const DB_NAME = 'document-history';
-export const DB_VERSION = 1;
+export const DB_VERSION = 2;
 
 export const DOCS_STORE = 'docs';
 export const BLOBS_STORE = 'blobs';
+/**
+ * File System Access handles, keyed by document id: where on the user's disk
+ * this document lives. Handles are structured-cloneable, so IndexedDB is the
+ * only place they can survive a reload -- which is the whole point of keeping
+ * one (see lib/save-target.ts).
+ */
+export const HANDLES_STORE = 'handles';
 
 /** `docs` ordered by snapshot time -- the list view's default order. */
 export const DOCS_BY_UPDATED = 'by_updatedAt';
@@ -53,6 +60,11 @@ export function openHistoryDb(): Promise<IDBDatabase | null> {
       if (!db.objectStoreNames.contains(BLOBS_STORE)) {
         const blobs = db.createObjectStore(BLOBS_STORE, { keyPath: ['docId', 'rev'] });
         blobs.createIndex(BLOBS_BY_DOC, 'docId');
+      }
+      // Added in v2. The guard is what makes the upgrade incremental: a
+      // database created at v1 gains this store and keeps its documents.
+      if (!db.objectStoreNames.contains(HANDLES_STORE)) {
+        db.createObjectStore(HANDLES_STORE, { keyPath: 'docId' });
       }
     };
     request.onsuccess = () => {

--- a/lib/history/index.ts
+++ b/lib/history/index.ts
@@ -3,7 +3,8 @@
  * has a single call, and so the pieces that must not import each other -- the
  * save channel and the autosave scheduler -- stay uncoupled.
  */
-import { setSavedToDiskListener } from '../onlyoffice/save-stream';
+import { setDiskWriter, setSavedToDiskListener } from '../onlyoffice/save-stream';
+import { saveToDiskFile } from '../save-target';
 import { getAutosaveDocId } from './autosave';
 import { markSavedToDisk, pruneExpired } from './store';
 
@@ -12,6 +13,19 @@ export function initDocumentHistory(): void {
   // history page: "this browser forgets after seven days" is only a promise if
   // nothing has to be done to collect on it.
   void pruneExpired();
+
+  // Saving writes back to the file the document came from, once the user has
+  // pointed at one. The document id is what links the two, which is why this
+  // is wired here rather than inside the save channel.
+  setDiskWriter(async (file) => {
+    const docId = getAutosaveDocId();
+    if (!docId) return false;
+    const outcome = await saveToDiskFile(docId, file, 'Document');
+    // 'cancelled' means the user closed the picker: they decided not to save,
+    // so downloading a copy anyway would be answering a question they declined.
+    if (outcome === 'cancelled') return true;
+    return outcome === 'written';
+  });
 
   setSavedToDiskListener(() => {
     // The document now exists on disk, so its history row has nothing left to
@@ -23,5 +37,5 @@ export function initDocumentHistory(): void {
 }
 
 export { beginAutosaveSession, isAutosaveEnabled, setAutosaveEnabled, stopAutosaveSession } from './autosave';
-export { clearAllHistory, deleteDoc, getLatestSnapshot, getRecoverableDoc, listDocs } from './store';
+export { clearAllHistory, deleteDoc, getLatestSnapshot, listDocs } from './store';
 export type { HistoryDoc } from './types';

--- a/lib/history/session.ts
+++ b/lib/history/session.ts
@@ -6,7 +6,7 @@
  * because it has to exist before there is anything to store. Two consequences
  * worth stating:
  *
- * - The URL becomes `?doc=<id>`, so a reload lands back on the same document
+ * - The URL becomes `?saved=<id>`, so a reload lands back on the same document
  *   instead of on a second blank one, and the history page's Open link is the
  *   same URL the editor was already using.
  * - Identity never depends on the file name. Names repeat -- two people each
@@ -25,12 +25,12 @@ export function newDocumentId(): string {
   return `doc-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-/** Put `?doc=<id>` in the address bar, dropping the one-shot open parameters. */
+/** Put `?saved=<id>` in the address bar, dropping the one-shot open parameters. */
 export function stampDocumentIdInUrl(docId: string): void {
   if (typeof window === 'undefined') return;
   const url = new URL(window.location.href);
-  if (url.searchParams.get('doc') === docId) return;
-  url.searchParams.set('doc', docId);
+  if (url.searchParams.get('saved') === docId) return;
+  url.searchParams.set('saved', docId);
   // `open=local` hands a file over exactly once; leaving it in the URL would
   // make a reload look for a file that was already consumed.
   url.searchParams.delete('open');

--- a/lib/onlyoffice/save-stream.ts
+++ b/lib/onlyoffice/save-stream.ts
@@ -22,6 +22,21 @@ export function setSavedToDiskListener(listener: (() => void) | null): void {
 }
 
 /**
+ * Optional writer that puts the bytes straight into the file the document came
+ * from, instead of downloading a new copy (see lib/save-target.ts).
+ *
+ * Injected for the same reason as the listener above -- it needs the document's
+ * identity, which lives in the history layer, and that layer exports through
+ * this module. Returns true when the user's document is saved and there is
+ * nothing left to do; false means "carry on with the download".
+ */
+let diskWriter: ((file: File) => Promise<boolean>) | null = null;
+
+export function setDiskWriter(writer: ((file: File) => Promise<boolean>) | null): void {
+  diskWriter = writer;
+}
+
+/**
  * The v9 save channel end to end: the request the caller holds, the export
  * trigger on the editor frame, and the 'onlyoffice-file-stream' message the
  * finished bytes come back on.
@@ -112,14 +127,28 @@ function routeSavedFile(file: File): void {
     return;
   }
 
-  // Reaching the user's disk is the only thing that clears the unsaved-changes
-  // warning: an autosave snapshot lives in this browser, a saved file does not.
-  saveFileToDisk(file, file.name)
-    .then(() => {
-      markDocumentSaved();
-      savedToDiskListener?.();
-    })
-    .catch(notifyOperationFailed);
+  const reachedDisk = (): void => {
+    // Reaching the user's disk is the only thing that clears the unsaved-changes
+    // warning: an autosave snapshot lives in this browser, a saved file does not.
+    markDocumentSaved();
+    savedToDiskListener?.();
+  };
+
+  // Write back to the document's own file where that is possible, and download
+  // a copy where it is not. Both end in the same place from the app's point of
+  // view: the bytes are on the user's disk.
+  void (async () => {
+    try {
+      if (await diskWriter?.(file)) {
+        reachedDisk();
+        return;
+      }
+      await saveFileToDisk(file, file.name);
+      reachedDisk();
+    } catch (error) {
+      notifyOperationFailed(error);
+    }
+  })();
 }
 
 function handleFileStreamMessage(event: MessageEvent): void {

--- a/lib/save-target.ts
+++ b/lib/save-target.ts
@@ -1,0 +1,191 @@
+/**
+ * The document's file on the user's own disk.
+ *
+ * Every save so far has gone through a "save as" dialog and thrown the handle
+ * away, so saving twice meant choosing the same file twice, and the second
+ * choice raised the browser's "a file with that name already exists" prompt.
+ * Keeping the handle turns that into what a desktop editor does: the first
+ * save picks the file, every save after it writes to that file.
+ *
+ * It is also the strongest privacy answer this app has. A document that goes
+ * back to the user's own file system needs no copy in the browser at all --
+ * the local history exists precisely because, until now, there was nowhere
+ * else for the work to be.
+ *
+ * Chromium only. Safari has no local-disk picker at all and Firefox has said
+ * it will not add one, so this is strictly an upgrade: where the API is
+ * missing, everything falls back to the download the app already did.
+ */
+import { t } from '@ranuts/shared/i18n';
+import { HANDLES_STORE, requestToPromise, withStores } from './history/db';
+
+/** Only the parts of the File System Access API this module uses. */
+interface WritableFileStream {
+  write: (data: BufferSource | Blob) => Promise<void>;
+  close: () => Promise<void>;
+}
+interface FileHandle {
+  name: string;
+  createWritable: () => Promise<WritableFileStream>;
+  queryPermission?: (descriptor: { mode: 'readwrite' }) => Promise<PermissionState>;
+  requestPermission?: (descriptor: { mode: 'readwrite' }) => Promise<PermissionState>;
+}
+type SavePicker = (options: {
+  suggestedName?: string;
+  types?: Array<{ description: string; accept: Record<string, string[]> }>;
+}) => Promise<FileHandle>;
+
+interface StoredTarget {
+  docId: string;
+  handle: FileHandle;
+  name: string;
+  linkedAt: number;
+}
+
+/** What happened, so the caller knows whether it still owes the user a save. */
+export type SaveOutcome =
+  | 'written' // the bytes are in the user's file
+  | 'cancelled' // the user dismissed the picker; nothing more to do
+  | 'unavailable'; // no API, no permission, or the write failed -- fall back
+
+export function canWriteToDisk(): boolean {
+  return typeof (globalThis as { showSaveFilePicker?: SavePicker }).showSaveFilePicker === 'function';
+}
+
+/**
+ * Handles held for this page's lifetime.
+ *
+ * The store is what survives a reload; this is what makes a save cost nothing
+ * in between. It also keeps the feature working when IndexedDB is not -- a
+ * private window, a full disk -- for as long as the tab is open, which is
+ * exactly the session the user is in the middle of.
+ */
+const sessionTargets = new Map<string, StoredTarget>();
+
+async function readTarget(docId: string): Promise<StoredTarget | null> {
+  const held = sessionTargets.get(docId);
+  if (held) return held;
+  try {
+    return (
+      (await withStores([HANDLES_STORE], 'readonly', async (tx) => {
+        return ((await requestToPromise(tx.objectStore(HANDLES_STORE).get(docId))) as StoredTarget | undefined) ?? null;
+      })) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+async function writeTarget(target: StoredTarget): Promise<void> {
+  sessionTargets.set(target.docId, target);
+  try {
+    await withStores([HANDLES_STORE], 'readwrite', async (tx) => {
+      tx.objectStore(HANDLES_STORE).put(target);
+      return true;
+    });
+  } catch {
+    // Not being able to remember the file costs a picker next time, nothing more.
+  }
+}
+
+export async function forgetSaveTarget(docId: string): Promise<void> {
+  sessionTargets.delete(docId);
+  try {
+    await withStores([HANDLES_STORE], 'readwrite', async (tx) => {
+      tx.objectStore(HANDLES_STORE).delete(docId);
+      return true;
+    });
+  } catch {
+    /* nothing to forget */
+  }
+}
+
+/**
+ * Permission does not survive a reload on its own: a handle read back from
+ * IndexedDB starts at "prompt", and asking requires a user gesture. Saving is
+ * one, which is why this is only ever called from a save the user asked for.
+ */
+async function ensureWritable(handle: FileHandle): Promise<boolean> {
+  // A handle with no permission model is already writable -- origin-private
+  // handles have no gate to pass. Treating a missing method as a refusal would
+  // throw away a working handle on every save.
+  if (!handle.queryPermission && !handle.requestPermission) return true;
+  try {
+    if ((await handle.queryPermission?.({ mode: 'readwrite' })) === 'granted') return true;
+    return (await handle.requestPermission?.({ mode: 'readwrite' })) === 'granted';
+  } catch {
+    return false;
+  }
+}
+
+function notifySaved(name: string): void {
+  (window as unknown as { message?: { success?: (msg: string) => void } }).message?.success?.(
+    `${t('fileSavedSuccess')}${name}`,
+  );
+}
+
+/**
+ * Write the document to the file it is linked to, asking for one if it has
+ * none yet.
+ *
+ * Returns 'unavailable' rather than throwing whenever anything is off -- the
+ * file was moved or deleted, permission was refused, the API is absent -- so
+ * the caller can fall back to the ordinary download and the user still ends up
+ * with their document. A failed write also drops the link, so the next save
+ * offers the picker instead of failing the same way again; that doubles as the
+ * way to save somewhere else.
+ */
+export async function saveToDiskFile(docId: string, file: File, description: string): Promise<SaveOutcome> {
+  const picker = (globalThis as { showSaveFilePicker?: SavePicker }).showSaveFilePicker;
+  if (typeof picker !== 'function') return 'unavailable';
+
+  const existing = await readTarget(docId);
+  let handle = existing?.handle ?? null;
+
+  if (handle && !(await ensureWritable(handle))) {
+    await forgetSaveTarget(docId);
+    handle = null;
+  }
+
+  if (!handle) {
+    const extension = file.name.includes('.') ? `.${file.name.split('.').pop()}` : '';
+    try {
+      handle = await picker({
+        suggestedName: file.name,
+        types: [
+          {
+            description,
+            accept: { [file.type || 'application/octet-stream']: extension ? [extension] : [] },
+          },
+        ],
+      });
+    } catch (error) {
+      // AbortError is the user closing the dialog: a decision, not a failure.
+      if ((error as { name?: string })?.name === 'AbortError') return 'cancelled';
+      return 'unavailable';
+    }
+  }
+
+  try {
+    const writable = await handle.createWritable();
+    await writable.write(file);
+    await writable.close();
+  } catch {
+    await forgetSaveTarget(docId);
+    return 'unavailable';
+  }
+
+  await writeTarget({ docId, handle, name: handle.name || file.name, linkedAt: Date.now() });
+  notifySaved(handle.name || file.name);
+  return 'written';
+}
+
+/** Test seam: forget every handle this page is holding. */
+export function resetSaveTargetsForTests(): void {
+  sessionTargets.clear();
+}
+
+/** The file name this document writes to, if it is linked to one. */
+export async function getSaveTargetName(docId: string): Promise<string | null> {
+  return (await readTarget(docId))?.name ?? null;
+}

--- a/public/history-recent.js
+++ b/public/history-recent.js
@@ -78,7 +78,7 @@
       // not depend on a script having run.
       var resume = document.createElement('a');
       resume.className = 'recent-resume';
-      resume.href = '/editor?doc=' + encodeURIComponent(doc.id) + suffix;
+      resume.href = '/editor?saved=' + encodeURIComponent(doc.id) + suffix;
       resume.textContent = (slot.getAttribute('data-recent-label') || 'Continue') + ' ' + doc.title;
 
       slot.appendChild(resume);

--- a/readme.md
+++ b/readme.md
@@ -86,15 +86,15 @@ Any of them can be exported to PDF. CSV keeps its encoding on the way back out
 
 Parameters on `/editor`:
 
-| Parameter      | Description                                                                                                               |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `src=<url>`    | Open a document from a URL (the URL must allow CORS)                                                                      |
-| `file=<url>`   | Same, legacy spelling; wins if both are present                                                                           |
-| `new=docx`     | Start a blank document (`docx`, `xlsx`, `pptx`)                                                                           |
-| `doc=<id>`     | Reopen a document from this browser's history — the editor puts its own id here, so a reload returns to the same document |
-| `readonly=1`   | Open for viewing: editing and export are disabled                                                                         |
-| `embed=1`      | Embed mode; the host page drives the editor over postMessage                                                              |
-| `locale=zh-CN` | Interface language                                                                                                        |
+| Parameter      | Description                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `src=<url>`    | Open a document from a URL (the URL must allow CORS)                                                                     |
+| `file=<url>`   | Same, legacy spelling; wins if both are present                                                                          |
+| `new=docx`     | Start a blank document (`docx`, `xlsx`, `pptx`)                                                                          |
+| `saved=<id>`   | Reopen one of this browser's saved documents — the editor puts its own id here, so a reload returns to the same document |
+| `readonly=1`   | Open for viewing: editing and export are disabled                                                                        |
+| `embed=1`      | Embed mode; the host page drives the editor over postMessage                                                             |
+| `locale=zh-CN` | Interface language                                                                                                       |
 
 ---
 

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -89,7 +89,7 @@ pnpm run dev
 | `src=<url>`    | 从 URL 打开文档（该 URL 需允许 CORS）                                    |
 | `file=<url>`   | 同上，旧写法；两者同时存在时以它为准                                     |
 | `new=docx`     | 新建空白文档（`docx`、`xlsx`、`pptx`）                                   |
-| `doc=<id>`     | 从本机历史打开某一篇——编辑器会把自己的 id 写在这里，因此刷新会回到同一篇 |
+| `saved=<id>`   | 打开本机保存的某一篇——编辑器会把自己的 id 写在这里，因此刷新会回到同一篇 |
 | `readonly=1`   | 只读打开：禁用编辑与导出                                                 |
 | `embed=1`      | 嵌入模式，由宿主页面通过 postMessage 驱动                                |
 | `locale=zh-CN` | 界面语言                                                                 |

--- a/test/e2e/autosave-recovery.spec.ts
+++ b/test/e2e/autosave-recovery.spec.ts
@@ -44,7 +44,7 @@ const readHistory = (page: Page) =>
   page.evaluate(
     () =>
       new Promise<Array<{ id: string; title: string; size: number; savedToDiskAt?: number }>>((resolve) => {
-        const request = indexedDB.open('document-history', 1);
+        const request = indexedDB.open('document-history');
         request.onsuccess = () => {
           const db = request.result;
           if (!db.objectStoreNames.contains('docs')) {
@@ -157,7 +157,7 @@ test.describe('autosave and recovery (real editor)', () => {
     await page.keyboard.type('typed before the reload', { delay: 60 });
 
     // The editor stamped its identity into the address bar on open.
-    const docId = new URL(page.url()).searchParams.get('doc');
+    const docId = new URL(page.url()).searchParams.get('saved');
     expect(docId).toBeTruthy();
 
     await hidePage(page);
@@ -170,7 +170,7 @@ test.describe('autosave and recovery (real editor)', () => {
     const reloadedSdk = page.frameLocator('iframe[name="frameEditor"]').locator('#editor_sdk');
     await reloadedSdk.waitFor({ state: 'visible', timeout: 30_000 });
     // Same document, same row: no second id, no duplicate history entry.
-    expect(new URL(page.url()).searchParams.get('doc')).toBe(docId);
+    expect(new URL(page.url()).searchParams.get('saved')).toBe(docId);
     expect(await readHistory(page)).toHaveLength(1);
 
     await reloadedSdk.click({ position: { x: 300, y: 200 } });

--- a/test/e2e/history-page.spec.ts
+++ b/test/e2e/history-page.spec.ts
@@ -15,7 +15,7 @@ type SeedRow = { id: string; title: string; savedToDisk?: boolean; ageMs?: numbe
 async function seed(page: Page, rows: SeedRow[]): Promise<void> {
   await page.evaluate(async (seedRows: SeedRow[]) => {
     const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const request = indexedDB.open('document-history', 1);
+      const request = indexedDB.open('document-history');
       request.onupgradeneeded = () => {
         const database = request.result;
         if (!database.objectStoreNames.contains('docs')) {
@@ -170,7 +170,7 @@ test.describe('local history page', () => {
     const remaining = await page.evaluate(
       () =>
         new Promise<number>((resolve) => {
-          const request = indexedDB.open('document-history', 1);
+          const request = indexedDB.open('document-history');
           request.onsuccess = () => {
             const db = request.result;
             const all = db.transaction('blobs', 'readonly').objectStore('blobs').getAllKeys();
@@ -211,7 +211,7 @@ test.describe('local history page', () => {
     const remaining = await page.evaluate(
       () =>
         new Promise<string[]>((resolve) => {
-          const request = indexedDB.open('document-history', 1);
+          const request = indexedDB.open('document-history');
           request.onsuccess = () => {
             const db = request.result;
             const all = db.transaction('docs', 'readonly').objectStore('docs').getAllKeys();
@@ -272,6 +272,6 @@ test.describe('local history page', () => {
 
     // The id is the document's identity everywhere: in the URL the editor
     // already uses, and in the link the history page hands back to it.
-    await page.waitForURL(/\/editor\?doc=reopen-me/);
+    await page.waitForURL(/\/editor\?saved=reopen-me/);
   });
 });

--- a/test/e2e/save-to-file.spec.ts
+++ b/test/e2e/save-to-file.spec.ts
@@ -1,0 +1,181 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Page } from '@playwright/test';
+import { buildDocx, ooxmlText, zipEntryText } from './lib/ooxml';
+import { expect, test } from './lib/l0';
+
+/**
+ * Saving writes back into the document's own file instead of downloading a new
+ * copy each time.
+ *
+ * The picker is stubbed with a real origin-private file handle rather than a
+ * hand-made object: it is a genuine FileSystemFileHandle, so it goes through
+ * structured clone into IndexedDB and comes back out the way a handle to a file
+ * on disk does. That is the part worth testing -- a fake object cannot survive
+ * the round trip, and the round trip is the feature.
+ */
+const stubPicker = `
+  window.__pickerCalls = 0;
+  window.showSaveFilePicker = async () => {
+    window.__pickerCalls += 1;
+    const root = await navigator.storage.getDirectory();
+    return root.getFileHandle('saved-document.docx', { create: true });
+  };
+`;
+
+const pickerCalls = (page: Page) => page.evaluate(() => (window as unknown as { __pickerCalls: number }).__pickerCalls);
+
+const savedBytes = (page: Page) =>
+  page.evaluate(async () => {
+    const root = await navigator.storage.getDirectory();
+    const handle = await root.getFileHandle('saved-document.docx');
+    return Array.from(new Uint8Array(await (await handle.getFile()).arrayBuffer()));
+  });
+
+const waitForEditorReady = (page: Page) =>
+  page.waitForFunction(
+    () => {
+      const visit = (win: Window): boolean => {
+        try {
+          const api = (
+            win as unknown as { Asc?: { editor?: { isDocumentLoadComplete?: boolean; isLoadFullApi?: boolean } } }
+          ).Asc?.editor;
+          if (api && api.isDocumentLoadComplete && api.isLoadFullApi) return true;
+        } catch {
+          /* cross-origin */
+        }
+        for (let i = 0; i < win.frames.length; i++) if (visit(win.frames[i])) return true;
+        return false;
+      };
+      return visit(window);
+    },
+    undefined,
+    { timeout: 90_000 },
+  );
+
+test.describe('saving into the document own file (real editor)', () => {
+  test.describe.configure({ timeout: 240_000 });
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(stubPicker);
+  });
+
+  test('picks a file once, then writes to it on every later save', async ({ page }) => {
+    const dir = join('test-results', 'save-to-file');
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, 'WriteBack.docx');
+    writeFileSync(path, buildDocx('first paragraph'));
+
+    await page.goto('/');
+    const chooserPromise = page.waitForEvent('filechooser');
+    await page.locator('#hero-open').click();
+    (await chooserPromise).setFiles(path);
+
+    await waitForEditorReady(page);
+    const sdk = page.frameLocator('iframe[name="frameEditor"]').locator('#editor_sdk');
+    await sdk.waitFor({ state: 'visible', timeout: 30_000 });
+    await sdk.click({ position: { x: 300, y: 200 } });
+    await page.keyboard.press('End');
+    await page.keyboard.type(' one', { delay: 60 });
+    await page.keyboard.press('Control+s');
+
+    await expect.poll(() => pickerCalls(page), { timeout: 120_000 }).toBe(1);
+    await expect.poll(async () => (await savedBytes(page)).length, { timeout: 30_000 }).toBeGreaterThan(0);
+    const first = new Uint8Array(await savedBytes(page));
+    expect(ooxmlText((await zipEntryText(first, 'word/document.xml')) || '')).toContain('first paragraph one');
+
+    // Second save: same file, no second dialog. This is the whole difference
+    // from a download -- the user chose a file, not a moment.
+    await sdk.click({ position: { x: 300, y: 200 } });
+    await page.keyboard.press('End');
+    await page.keyboard.type(' two', { delay: 60 });
+    await page.keyboard.press('Control+s');
+
+    await expect
+      .poll(
+        async () => ooxmlText((await zipEntryText(new Uint8Array(await savedBytes(page)), 'word/document.xml')) || ''),
+        { timeout: 120_000 },
+      )
+      .toContain('first paragraph one two');
+    expect(await pickerCalls(page)).toBe(1);
+  });
+
+  test('still writes to the same file after a reload', async ({ page }) => {
+    const dir = join('test-results', 'save-to-file');
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, 'Reopened.docx');
+    writeFileSync(path, buildDocx('before reload'));
+
+    await page.goto('/');
+    const chooserPromise = page.waitForEvent('filechooser');
+    await page.locator('#hero-open').click();
+    (await chooserPromise).setFiles(path);
+    await waitForEditorReady(page);
+
+    const sdk = page.frameLocator('iframe[name="frameEditor"]').locator('#editor_sdk');
+    await sdk.waitFor({ state: 'visible', timeout: 30_000 });
+    await sdk.click({ position: { x: 300, y: 200 } });
+    await page.keyboard.press('Control+s');
+    await expect.poll(() => pickerCalls(page), { timeout: 120_000 }).toBe(1);
+
+    // Edit again, then let autosave take a snapshot. Saving to disk clears the
+    // unsaved-changes flag -- correctly, there is nothing unsaved once the file
+    // is written -- so a snapshot only exists if there is work on top of it.
+    // That is also the ordinary state of a document being worked on: linked to
+    // a file, and holding a recovery point for the edits since the last save.
+    await sdk.click({ position: { x: 300, y: 200 } });
+    await page.keyboard.press('End');
+    await page.keyboard.type(' unsaved', { delay: 60 });
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () =>
+              new Promise<number>((resolve) => {
+                const request = indexedDB.open('document-history');
+                request.onsuccess = () => {
+                  const db = request.result;
+                  const all = db.transaction('docs', 'readonly').objectStore('docs').getAllKeys();
+                  all.onsuccess = () => {
+                    db.close();
+                    resolve(all.result.length);
+                  };
+                };
+                request.onerror = () => resolve(0);
+              }),
+          ),
+        { timeout: 60_000, message: 'a snapshot exists to reopen' },
+      )
+      .toBeGreaterThan(0);
+
+    // A second page rather than a reload: it starts with an empty JS heap, so
+    // the handle cannot come from the session cache -- it has to be read back
+    // out of IndexedDB, which is the thing being tested. It is also the real
+    // scenario: the tab was closed and the document opened again later.
+    const docId = new URL(page.url()).searchParams.get('saved');
+    expect(docId).toBeTruthy();
+    const later = await page.context().newPage();
+    await later.addInitScript(stubPicker);
+    await later.goto(`/editor?saved=${docId}`);
+    await waitForEditorReady(later);
+    const reopened = later.frameLocator('iframe[name="frameEditor"]').locator('#editor_sdk');
+    await reopened.waitFor({ state: 'visible', timeout: 30_000 });
+    await reopened.click({ position: { x: 300, y: 200 } });
+    await later.keyboard.press('End');
+    await later.keyboard.type(' after', { delay: 60 });
+    await later.keyboard.press('Control+s');
+
+    await expect
+      .poll(
+        async () => ooxmlText((await zipEntryText(new Uint8Array(await savedBytes(later)), 'word/document.xml')) || ''),
+        { timeout: 120_000 },
+      )
+      .toContain('after');
+    // The new page never opened a dialog: the link survived the tab closing.
+    expect(await pickerCalls(later)).toBe(0);
+  });
+});

--- a/test/unit/save-target.test.ts
+++ b/test/unit/save-target.test.ts
@@ -1,0 +1,152 @@
+import 'fake-indexeddb/auto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DB_NAME, resetHistoryDbForTests } from '../../lib/history/db';
+import {
+  canWriteToDisk,
+  forgetSaveTarget,
+  getSaveTargetName,
+  resetSaveTargetsForTests,
+  saveToDiskFile,
+} from '../../lib/save-target';
+
+/** A stand-in for a file on disk: records what was written to it. */
+function fakeHandle(name = 'Report.docx', permission: PermissionState = 'granted') {
+  const written: Blob[] = [];
+  return {
+    written,
+    handle: {
+      name,
+      createWritable: vi.fn(async () => ({
+        write: async (data: Blob) => void written.push(data),
+        close: async () => undefined,
+      })),
+      queryPermission: vi.fn(async () => permission),
+      requestPermission: vi.fn(async () => permission),
+    },
+  };
+}
+
+function usePicker(handle: unknown): ReturnType<typeof vi.fn> {
+  const picker = vi.fn(async () => handle);
+  vi.stubGlobal('showSaveFilePicker', picker);
+  return picker;
+}
+
+const file = (): File => new File([new Uint8Array([1, 2, 3]).buffer], 'Report.docx');
+
+async function wipe(): Promise<void> {
+  resetHistoryDbForTests();
+  resetSaveTargetsForTests();
+  await new Promise<void>((resolve) => {
+    const request = indexedDB.deleteDatabase(DB_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => resolve();
+    request.onblocked = () => resolve();
+  });
+}
+
+describe("saving into the document's own file", () => {
+  beforeEach(wipe);
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('reports the capability honestly', () => {
+    expect(canWriteToDisk()).toBe(false);
+    usePicker(fakeHandle().handle);
+    expect(canWriteToDisk()).toBe(true);
+  });
+
+  it('falls back where the browser has no picker (Safari, Firefox)', async () => {
+    expect(await saveToDiskFile('doc-1', file(), 'Document')).toBe('unavailable');
+  });
+
+  it('asks for a file the first time and writes the bytes into it', async () => {
+    const target = fakeHandle();
+    const picker = usePicker(target.handle);
+
+    expect(await saveToDiskFile('doc-1', file(), 'Document')).toBe('written');
+
+    expect(picker).toHaveBeenCalledTimes(1);
+    expect(target.written).toHaveLength(1);
+    expect(await getSaveTargetName('doc-1')).toBe('Report.docx');
+  });
+
+  it('writes straight to that file every time after, without asking again', async () => {
+    const target = fakeHandle();
+    const picker = usePicker(target.handle);
+
+    await saveToDiskFile('doc-1', file(), 'Document');
+    expect(await saveToDiskFile('doc-1', file(), 'Document')).toBe('written');
+    expect(await saveToDiskFile('doc-1', file(), 'Document')).toBe('written');
+
+    // The whole point: one dialog, three saves.
+    expect(picker).toHaveBeenCalledTimes(1);
+    expect(target.written).toHaveLength(3);
+  });
+
+  it('keeps one file per document, not one per browser', async () => {
+    const first = fakeHandle('First.docx');
+    const picker = usePicker(first.handle);
+    await saveToDiskFile('doc-1', file(), 'Document');
+
+    const second = fakeHandle('Second.docx');
+    picker.mockResolvedValue(second.handle);
+    await saveToDiskFile('doc-2', file(), 'Document');
+
+    expect(await getSaveTargetName('doc-1')).toBe('First.docx');
+    expect(await getSaveTargetName('doc-2')).toBe('Second.docx');
+  });
+
+  it('treats a dismissed dialog as a decision, not a failure', async () => {
+    const picker = vi.fn(async () => {
+      throw Object.assign(new Error('user closed it'), { name: 'AbortError' });
+    });
+    vi.stubGlobal('showSaveFilePicker', picker);
+
+    // 'cancelled', not 'unavailable': the caller must not answer a declined
+    // save by downloading a copy anyway.
+    expect(await saveToDiskFile('doc-1', file(), 'Document')).toBe('cancelled');
+  });
+
+  it('drops the link when permission is refused, and asks again next time', async () => {
+    const granted = fakeHandle();
+    const picker = usePicker(granted.handle);
+    await saveToDiskFile('doc-1', file(), 'Document');
+
+    // A handle read back after a reload starts at "prompt"; refuse it.
+    granted.handle.queryPermission.mockResolvedValue('prompt');
+    granted.handle.requestPermission.mockResolvedValue('denied');
+    const denied = fakeHandle('Chosen.docx');
+    picker.mockResolvedValue(denied.handle);
+
+    expect(await saveToDiskFile('doc-1', file(), 'Document')).toBe('written');
+    expect(picker).toHaveBeenCalledTimes(2);
+    expect(await getSaveTargetName('doc-1')).toBe('Chosen.docx');
+  });
+
+  it('forgets a file it can no longer write to, so the next save offers a new one', async () => {
+    const target = fakeHandle();
+    usePicker(target.handle);
+    await saveToDiskFile('doc-1', file(), 'Document');
+
+    // The file was moved or deleted between saves.
+    target.handle.createWritable.mockRejectedValue(new Error('NotFoundError'));
+
+    expect(await saveToDiskFile('doc-1', file(), 'Document')).toBe('unavailable');
+    // Nothing is linked any more: the fallback download covers this save, and
+    // the next one starts from the picker again -- which is also how a user
+    // saves somewhere else.
+    expect(await getSaveTargetName('doc-1')).toBeNull();
+  });
+
+  it('can be unlinked deliberately', async () => {
+    usePicker(fakeHandle().handle);
+    await saveToDiskFile('doc-1', file(), 'Document');
+
+    await forgetSaveTarget('doc-1');
+
+    expect(await getSaveTargetName('doc-1')).toBeNull();
+  });
+});


### PR DESCRIPTION
Every save went through a "save as" dialog and threw the handle away, so saving
twice meant choosing the same file twice — and the second choice raised the
browser's "a file with that name already exists" prompt. Keeping the handle
turns that into what a desktop editor does: **the first save picks the file,
every save after it writes to that file.**

It is also the strongest privacy answer this app has. A document that goes back
to the user's own file system needs no copy in the browser at all — the local
history (#172) exists precisely because, until now, there was nowhere else for
the work to be.

## How it behaves

- Handles are stored per document id, in a new store in the history database,
  so the link survives closing the tab. They are also held in memory for the
  session: saving costs nothing between reloads, and the feature keeps working
  while IndexedDB is not (a private window, a full disk) for as long as the tab
  lives.
- Everything that can go wrong falls back to the download the app already did,
  and forgets the handle on the way: file moved or deleted, permission refused,
  API absent. **Forgetting doubles as the way to save somewhere else** — the
  next save offers the picker again.
- A dismissed picker is a decision, not a failure, so it does not download a
  copy the user just declined.
- Saving to disk clears the unsaved-changes flag, so no further snapshots are
  taken until the document is edited again. Correct, and worth knowing when
  reading the tests.

Chromium only. Safari has no local-disk picker and Firefox has stated it will
not add one, so this is strictly an upgrade over existing behaviour.

## `?doc=` → `?saved=`

The old name read as "docx". The parameter is not about a format, it is about
which of this browser's saved documents to open.

It stays a **query parameter rather than a path segment** on purpose. Google
Docs (`/document/d/<id>`) and Figma (`/file/<key>`) put ids in the path because
those ids name something on a server that anyone with the link can open. This
one names a row in one browser's IndexedDB. In a path it would look shareable,
and whoever received it would open an empty editor.

## Tests

9 new unit cases, 2 new e2e cases, 962 unit tests green.

The e2e stubs the picker with a **real origin-private file handle** rather than
a hand-made object, so the handle genuinely round-trips through structured
clone into IndexedDB the way a handle to a file on disk does — a fake object
cannot survive that trip, and the trip is the feature. Reverse-verified: not
remembering the handle turns both cases red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)