### PR TITLE
test(save): wait for the save to finish instead of racing it

### DIFF
--- a/docs/explorations/2026-08-22-opfs-read-race-in-save-to-file-spec.md
+++ b/docs/explorations/2026-08-22-opfs-read-race-in-save-to-file-spec.md
@@ -1,0 +1,114 @@
+# save-to-file 用例读到一半的文件（CI 偶发红）
+
+日期：2026-08-22
+分支：`fix/save-to-file-read-race`
+现场：PR #177（只改 readme 翻译）的 `E2E (Docker image) shard 3`
+[run 32560753184](https://github.com/ranuts/document/actions/runs/32560753184/job/97001811809)
+
+## 症状
+
+```
+1) [chromium] › test/e2e/save-to-file.spec.ts:103:3 › saving into the document own file (real editor)
+   › still writes to the same file after a reload
+
+  Error: page.evaluate: NotReadableError: The requested file could not be read,
+  typically due to permission problems that have occurred after a reference to
+  a file was acquired.
+
+    > 29 |   page.evaluate(async () => {
+      30 |     const root = await navigator.storage.getDirectory();
+      31 |     const handle = await root.getFileHandle('saved-document.docx');
+      32 |     return Array.from(new Uint8Array(await (await handle.getFile()).arrayBuffer()));
+```
+
+同一个 PR 的另外两套 E2E（vite preview / wrangler pages）全绿，改动本身是八个
+readme 文件，与保存链路无关——**是用例自己的竞态**，不是被测代码的缺陷。
+
+## 根因
+
+`FileSystemWritableFileStream` 不在原文件上原地改写：写进别处，`close()` 时整体
+换进来。`getFile()` 拿到的是**换进来之前**那个文件的快照（大小 + 修改时间），
+真正读字节是在 `arrayBuffer()`。中间只要发生一次 swap，快照就作废，Chromium 抛
+`NotReadableError`。
+
+用例的读恰好排在这个窗口里：`Ctrl+S` 之后立刻开始 poll 文件内容，而一次保存要先
+过 x2t 转换，`close()` 落在 poll 的某一轮中间。CI 的 docker 分片两个 worker 抢核，
+时序更容易踩上，所以只有它偶发。
+
+放大它的是第二件事：**`expect.poll` 的回调抛异常不会重试**，直接判失败。于是
+"读早了一拍"被报成"文件读不出来"。
+
+### 复现（脱离本项目，20 行）
+
+```js
+const handle = await (await navigator.storage.getDirectory()).getFileHandle('t.bin', { create: true });
+let w = await handle.createWritable();
+await w.write(new Uint8Array(1 << 20));
+await w.close();
+
+const snapshot = await handle.getFile(); // 读从这里开始
+w = await handle.createWritable();
+await w.write(new Uint8Array(2 << 20));
+await w.close(); // 保存在这里提交
+await snapshot.arrayBuffer(); // NotReadableError
+```
+
+实测输出：
+
+```
+naive   : threw NotReadableError
+retrying: read ok on attempt 2 (3145728 bytes)
+```
+
+## 修法：不再和写抢，而是等写完
+
+第一版是给读加重试（每次重新取快照，最多 5 次）。它能过，但只是把窗口变小——用例
+仍然在"文件内容会不会变成我要的样子"上轮询，只是撞上的概率低了。既然窗口存在，
+CI 的负载迟早会再撞一次。
+
+**彻底的做法是让用例知道写在什么时候结束**，而不是猜。`stubPicker` 里包住
+`FileSystemFileHandle.prototype.createWritable`，记两个数：
+
+| 计数                | 含义                    |
+| ------------------- | ----------------------- |
+| `__writesInFlight`  | 此刻开着几个写入流      |
+| `__writesCommitted` | 已经 `close()` 成功几次 |
+
+包**原型**而不是包 picker 返回的那个 handle：第二个页面用的 handle 是 IndexedDB
+重建出来的，挂在原对象上的东西那时早就没了——而"句柄能被结构化克隆存取回来"正是
+这个用例要测的东西。
+
+于是所有读都走同一道闸：
+
+```ts
+await waitForWrites(page, 1); // 这次保存的写已提交，且没有流开着
+expect(await savedText(page)).toContain('first paragraph one');
+```
+
+竞态窗口不是被躲开，是不存在了：读开始的时候没有任何流开着，也不会有新的
+——那个文件只有用户保存时才会被打开写。
+
+顺带多出一条断言，是原来测不到的：
+
+```ts
+expect(await writesCommitted(page)).toBe(2); // 两次 Ctrl+S = 恰好两次写
+```
+
+保存之外没人动用户的文件（自动保存快照只进 IndexedDB，见
+[2026-08-22-autosave-history-implementation.md](./2026-08-22-autosave-history-implementation.md)）。
+这一条以后要是被破坏，红的是它，而不是某个下游用例偶发。
+
+产品代码一行没动：`lib/save-target.ts` 一次保存只 `createWritable` 一次。
+
+## 验证
+
+1. **机制的反向验证**：上面那段复现脚本，`naive` 那半（老写法）必抛
+   `NotReadableError`，`retrying` 那半读到完整字节。竞态是真的，不是猜的。
+2. **断言活性**：把期望文本改成 `first paragraph one two THREE` 跑一遍，用例变红
+   ——说明它确实在读真实存回的字节，绿不是因为断言没执行。
+3. `--repeat-each=3` 跑这个 spec，6 次全绿；改动前的完整 e2e 套件（115 用例）
+   也全绿。
+
+## 顺带确认
+
+`navigator.storage.getDirectory()` 全仓只有这个 spec 在用。

--- a/test/e2e/save-to-file.spec.ts
+++ b/test/e2e/save-to-file.spec.ts
@@ -13,24 +13,110 @@ import { expect, test } from './lib/l0';
  * structured clone into IndexedDB and comes back out the way a handle to a file
  * on disk does. That is the part worth testing -- a fake object cannot survive
  * the round trip, and the round trip is the feature.
+ *
+ * The writes are counted too, because a save does not edit the file in place:
+ * it writes elsewhere and swaps the result in when the stream closes. Any
+ * snapshot taken before that swap is dead after it, so a read that straddles
+ * one fails with NotReadableError no matter what the file ends up holding.
+ * Counting opens and closes lets this spec wait for the save it asked for and
+ * then read a file nobody is replacing, rather than poll the file's contents
+ * and hope not to land inside a swap.
+ *
+ * The counting wraps createWritable on the prototype rather than on the handle
+ * the picker returns, because the second page's handle was rebuilt out of
+ * IndexedDB: anything hung on the original object is gone by then.
  */
 const stubPicker = `
   window.__pickerCalls = 0;
+  window.__writesInFlight = 0;
+  window.__writesCommitted = 0;
+
   window.showSaveFilePicker = async () => {
     window.__pickerCalls += 1;
     const root = await navigator.storage.getDirectory();
     return root.getFileHandle('saved-document.docx', { create: true });
   };
+
+  // Every frame on the page runs this, and only the top window ever saves --
+  // so a frame without the API is not a problem to report, just nothing to wrap.
+  if (typeof FileSystemFileHandle !== 'undefined') {
+    const nativeCreateWritable = FileSystemFileHandle.prototype.createWritable;
+    FileSystemFileHandle.prototype.createWritable = async function (...args) {
+      window.__writesInFlight += 1;
+      let stream;
+      try {
+        stream = await nativeCreateWritable.apply(this, args);
+      } catch (error) {
+        window.__writesInFlight -= 1;
+        throw error;
+      }
+
+      let settled = false;
+      const settle = (committed) => {
+        if (settled) return;
+        settled = true;
+        window.__writesInFlight -= 1;
+        if (committed) window.__writesCommitted += 1;
+      };
+
+      const nativeClose = stream.close.bind(stream);
+      const nativeAbort = stream.abort.bind(stream);
+      stream.close = async () => {
+        try {
+          await nativeClose();
+        } catch (error) {
+          settle(false);
+          throw error;
+        }
+        settle(true);
+      };
+      stream.abort = async (reason) => {
+        try {
+          await nativeAbort(reason);
+        } finally {
+          settle(false);
+        }
+      };
+      return stream;
+    };
+  }
 `;
 
 const pickerCalls = (page: Page) => page.evaluate(() => (window as unknown as { __pickerCalls: number }).__pickerCalls);
 
+const writesCommitted = (page: Page) =>
+  page.evaluate(() => (window as unknown as { __writesCommitted: number }).__writesCommitted);
+
+/**
+ * Wait until the file has taken `count` writes and no stream is open on it.
+ *
+ * This is the whole answer to reading a file that something else is writing:
+ * ask when the writing is done instead of guessing. Everything below reads the
+ * file only through this gate.
+ */
+const waitForWrites = (page: Page, count: number) =>
+  page.waitForFunction(
+    (expected) => {
+      const state = window as unknown as { __writesCommitted: number; __writesInFlight: number };
+      return state.__writesCommitted >= expected && state.__writesInFlight === 0;
+    },
+    count,
+    { timeout: 120_000 },
+  );
+
+/** The bytes now in the file the picker handed out. Call it behind waitForWrites. */
 const savedBytes = (page: Page) =>
   page.evaluate(async () => {
     const root = await navigator.storage.getDirectory();
     const handle = await root.getFileHandle('saved-document.docx');
     return Array.from(new Uint8Array(await (await handle.getFile()).arrayBuffer()));
   });
+
+/** The document text in that file, which is what every assertion here is about. */
+const savedText = async (page: Page): Promise<string> => {
+  const bytes = new Uint8Array(await savedBytes(page));
+  return ooxmlText((await zipEntryText(bytes, 'word/document.xml')) || '');
+};
 
 const waitForEditorReady = (page: Page) =>
   page.waitForFunction(
@@ -80,9 +166,8 @@ test.describe('saving into the document own file (real editor)', () => {
     await page.keyboard.press('Control+s');
 
     await expect.poll(() => pickerCalls(page), { timeout: 120_000 }).toBe(1);
-    await expect.poll(async () => (await savedBytes(page)).length, { timeout: 30_000 }).toBeGreaterThan(0);
-    const first = new Uint8Array(await savedBytes(page));
-    expect(ooxmlText((await zipEntryText(first, 'word/document.xml')) || '')).toContain('first paragraph one');
+    await waitForWrites(page, 1);
+    expect(await savedText(page)).toContain('first paragraph one');
 
     // Second save: same file, no second dialog. This is the whole difference
     // from a download -- the user chose a file, not a moment.
@@ -91,13 +176,12 @@ test.describe('saving into the document own file (real editor)', () => {
     await page.keyboard.type(' two', { delay: 60 });
     await page.keyboard.press('Control+s');
 
-    await expect
-      .poll(
-        async () => ooxmlText((await zipEntryText(new Uint8Array(await savedBytes(page)), 'word/document.xml')) || ''),
-        { timeout: 120_000 },
-      )
-      .toContain('first paragraph one two');
+    await waitForWrites(page, 2);
+    expect(await savedText(page)).toContain('first paragraph one two');
     expect(await pickerCalls(page)).toBe(1);
+    // Two saves, two writes: the file is opened for writing when the user
+    // saves and at no other time.
+    expect(await writesCommitted(page)).toBe(2);
   });
 
   test('still writes to the same file after a reload', async ({ page }) => {
@@ -117,6 +201,7 @@ test.describe('saving into the document own file (real editor)', () => {
     await sdk.click({ position: { x: 300, y: 200 } });
     await page.keyboard.press('Control+s');
     await expect.poll(() => pickerCalls(page), { timeout: 120_000 }).toBe(1);
+    await waitForWrites(page, 1);
 
     // Edit again, then let autosave take a snapshot. Saving to disk clears the
     // unsaved-changes flag -- correctly, there is nothing unsaved once the file
@@ -169,12 +254,10 @@ test.describe('saving into the document own file (real editor)', () => {
     await later.keyboard.type(' after', { delay: 60 });
     await later.keyboard.press('Control+s');
 
-    await expect
-      .poll(
-        async () => ooxmlText((await zipEntryText(new Uint8Array(await savedBytes(later)), 'word/document.xml')) || ''),
-        { timeout: 120_000 },
-      )
-      .toContain('after');
+    // The second page's own counter: one write, made through a handle it never
+    // picked.
+    await waitForWrites(later, 1);
+    expect(await savedText(later)).toContain('after');
     // The new page never opened a dialog: the link survived the tab closing.
     expect(await pickerCalls(later)).toBe(0);
   });


### PR DESCRIPTION
`E2E (Docker image) shard 3` went red on #177 — a PR that changes eight readme files:

```
save-to-file.spec.ts:103 › still writes to the same file after a reload
Error: page.evaluate: NotReadableError: The requested file could not be read...
```

The other two E2E suites on the same commit were green. The failure is the spec's own race, not the change under test.

## What happens

A save does not edit the file in place: `FileSystemWritableFileStream` writes elsewhere and swaps the result in on `close()`. `getFile()` takes a snapshot — size and modification time — and `arrayBuffer()` reads it later; a swap in between kills the snapshot and Chromium throws `NotReadableError`.

The spec polled the file's *contents* from the moment it pressed Ctrl+S, so a poll iteration could straddle the swap. And `expect.poll` does not retry a callback that throws — it fails the test — so "read one beat too early" was reported as "file could not be read". Two workers on four cores make the Docker shard the likeliest place to land on it.

Reproduced away from the app, 20 lines:

```js
const snapshot = await handle.getFile();     // the read starts here
const w = await handle.createWritable(); await w.write(bytes); await w.close();   // the save commits here
await snapshot.arrayBuffer();                // NotReadableError
```

```
naive   : threw NotReadableError
retrying: read ok on attempt 2 (3145728 bytes)
```

## The fix

Retrying the read was the first version and it passed, but it only narrows the window — the spec would still be racing the writer, and CI load decides who wins.

So the spec now knows when the writing is over instead of guessing. `stubPicker` wraps `createWritable` **on the prototype** — not on the handle it hands out, because the second page's handle was rebuilt out of IndexedDB, and surviving that round trip is the feature this spec exists to prove — and counts open streams and successful closes. Every read goes behind one gate:

```ts
await waitForWrites(page, 1);   // this save committed, and nothing is open on the file
expect(await savedText(page)).toContain('first paragraph one');
```

There is no window left to land in, rather than a smaller one.

It also buys an assertion the content polling could not make:

```ts
expect(await writesCommitted(page)).toBe(2);   // two saves, exactly two writes
```

Nothing but a save may open that file — autosave snapshots go to IndexedDB and never to the user's disk. If that ever changes, this is what goes red, instead of some downstream spec going flaky.

**No product change.** `lib/save-target.ts` opens one writable per save; the race was between the spec's reader and that one writer.

## Verification

- **The mechanism, reverse-verified**: the standalone script above throws `NotReadableError` on the old read shape every time, and reads clean bytes on the new one.
- **The assertions are live**: changing the expected text to `first paragraph one two THREE` turns the test red, so the green is a real read of the saved bytes.
- `--repeat-each=3` on this spec: 6/6 green. Full local E2E suite (115 tests): green.

Record: `docs/explorations/2026-08-22-opfs-read-race-in-save-to-file-spec.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)