### PR TITLE
test(history): read the history database through one guarded reader

### DIFF
--- a/docs/explorations/2026-08-22-opfs-read-race-in-save-to-file-spec.md
+++ b/docs/explorations/2026-08-22-opfs-read-race-in-save-to-file-spec.md
@@ -109,6 +109,58 @@ expect(await writesCommitted(page)).toBe(2); // 两次 Ctrl+S = 恰好两次写
 3. `--repeat-each=3` 跑这个 spec，6 次全绿；改动前的完整 e2e 套件（115 用例）
    也全绿。
 
+## 同类排查：`expect.poll` 回调里还有谁会抛
+
+既然放大器是"回调抛异常 = 直接判红"，就把 e2e 里全部 26 处 poll 回调扫了一遍，
+按"除了'等的东西真没发生'以外还能不能抛"来判。结论是只有一处，而且**比这次红的
+那处更严重**——就在同一个文件里，等自动保存快照的那段：
+
+```js
+const request = indexedDB.open('document-history');   // 注意：没带版本号
+request.onsuccess = () => {
+  const db = request.result;
+  const all = db.transaction('docs', 'readonly').objectStore('docs').getAllKeys();
+  ...
+};
+```
+
+不带版本号的 `open` 打开一个**还不存在**的库时，会就地建一个空的 version 1、
+没有任何 object store（app 用的是 version 2，`docs` / `blobs` / `handles` 在那里
+建，见 `lib/history/db.ts`）。而用例问的正是"快照写进去了没有"——它跑在 app 还
+没来得及建库的那一刻是**正常情况**，不是异常情况。
+
+于是：
+
+1. `db.transaction('docs')` 抛 `NotFoundError`，抛在 `onsuccess` 事件处理器里，
+   没人接——promise **永远不 settle**，`db.close()` 也就永远不会执行；
+2. 那个泄漏的 version 1 连接**挡住 app 自己的 version 2 升级**，于是自动保存再也
+   写不进去；
+3. 用例在 60s 超时后变红，报的是 "a snapshot exists to reopen"——看起来像自动保存
+   坏了。
+
+实测（每种写法各一个干净 context）：
+
+```
+old shape page error: Failed to execute 'transaction' on 'IDBDatabase':
+                      One of the specified object stores was not found.
+old shape : NEVER SETTLED
+  app afterwards: BLOCKED by a leaked connection
+new shape : resolved 0 (no store yet)
+  app afterwards: opened, stores created
+```
+
+`autosave-recovery.spec.ts` 里那份读法是对的（判 `objectStoreNames.contains`、
+每条路径都 `close()`、接 `onupgradeneeded` 和 `all.onerror`），只是没人共用它，
+`save-to-file` 与 `history-page` 各自手抄了一份不带守卫的。所以抽成
+`test/e2e/lib/history-db.ts`，三个 spec 全部改用：读法只剩一份，下一个要读历史库
+的 spec 也不用重新踩一遍。
+
+其余 25 处判定安全，各有各的理由（读的是普通 JS 值、已有 `??` 兜底、
+`Frame.url()` 同步且 detach 后仍可读、WebMCP 工具层自己把异常转成 `isError`
+结果等）。
+
 ## 顺带确认
 
-`navigator.storage.getDirectory()` 全仓只有这个 spec 在用。
+`navigator.storage.getDirectory()` 全仓只有这个 spec 在用；`indexedDB.open` 还有
+一处在 `entry-paths.spec.ts`，开的是另一个库（`document-handoff`）且带了版本号，
+不在这个坑里。

--- a/test/e2e/autosave-recovery.spec.ts
+++ b/test/e2e/autosave-recovery.spec.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Page } from '@playwright/test';
+import { readHistoryDocs } from './lib/history-db';
 import { buildDocx, ooxmlText, zipEntryText } from './lib/ooxml';
 import { expect, test } from './lib/l0';
 
@@ -38,34 +39,6 @@ const waitForEditorReady = (page: Page) =>
     },
     undefined,
     { timeout: 90_000 },
-  );
-
-/** Metadata rows currently in the history database. */
-const readHistory = (page: Page) =>
-  page.evaluate(
-    () =>
-      new Promise<Array<{ id: string; title: string; size: number; savedToDiskAt?: number }>>((resolve) => {
-        const request = indexedDB.open('document-history');
-        request.onsuccess = () => {
-          const db = request.result;
-          if (!db.objectStoreNames.contains('docs')) {
-            db.close();
-            resolve([]);
-            return;
-          }
-          const all = db.transaction('docs', 'readonly').objectStore('docs').getAll();
-          all.onsuccess = () => {
-            db.close();
-            resolve(all.result);
-          };
-          all.onerror = () => {
-            db.close();
-            resolve([]);
-          };
-        };
-        request.onerror = () => resolve([]);
-        request.onupgradeneeded = () => resolve([]);
-      }),
   );
 
 async function hidePage(page: Page): Promise<void> {
@@ -111,9 +84,9 @@ test.describe('autosave and recovery (real editor)', () => {
     // pass whether or not hiding the page did anything -- which is exactly
     // what it looked like before this bound was tightened.
     await expect
-      .poll(async () => (await readHistory(page)).length, { timeout: 25_000, message: 'a snapshot was stored' })
+      .poll(async () => (await readHistoryDocs(page)).length, { timeout: 25_000, message: 'a snapshot was stored' })
       .toBe(1);
-    const [stored] = await readHistory(page);
+    const [stored] = await readHistoryDocs(page);
     expect(stored.title).toBe('Recovery.docx');
     expect(stored.size).toBeGreaterThan(0);
     // Never exported, so the browser holds the only copy of that sentence.
@@ -144,7 +117,9 @@ test.describe('autosave and recovery (real editor)', () => {
     expect(text).toContain('original paragraph never saved to disk');
 
     // Saved at last: the offer has nothing left to make.
-    await expect.poll(async () => (await readHistory(page))[0]?.savedToDiskAt, { timeout: 30_000 }).toBeGreaterThan(0);
+    await expect
+      .poll(async () => (await readHistoryDocs(page))[0]?.savedToDiskAt, { timeout: 30_000 })
+      .toBeGreaterThan(0);
   });
 
   test('a reload comes back to the same document, not a fresh one', async ({ page }) => {
@@ -164,7 +139,7 @@ test.describe('autosave and recovery (real editor)', () => {
 
     await hidePage(page);
     await expect
-      .poll(async () => (await readHistory(page)).length, { timeout: 25_000, message: 'a snapshot was stored' })
+      .poll(async () => (await readHistoryDocs(page)).length, { timeout: 25_000, message: 'a snapshot was stored' })
       .toBe(1);
 
     await page.reload();
@@ -173,7 +148,7 @@ test.describe('autosave and recovery (real editor)', () => {
     await reloadedSdk.waitFor({ state: 'visible', timeout: 30_000 });
     // Same document, same row: no second id, no duplicate history entry.
     expect(new URL(page.url()).searchParams.get('saved')).toBe(docId);
-    expect(await readHistory(page)).toHaveLength(1);
+    expect(await readHistoryDocs(page)).toHaveLength(1);
 
     await reloadedSdk.click({ position: { x: 300, y: 200 } });
     const downloadPromise = page.waitForEvent('download', { timeout: 120_000 });
@@ -217,6 +192,6 @@ test.describe('autosave and recovery (real editor)', () => {
     }
     await page.waitForTimeout(3_000);
 
-    expect(await readHistory(page)).toHaveLength(0);
+    expect(await readHistoryDocs(page)).toHaveLength(0);
   });
 });

--- a/test/e2e/history-page.spec.ts
+++ b/test/e2e/history-page.spec.ts
@@ -1,3 +1,4 @@
+import { readHistoryKeys } from './lib/history-db';
 import { expect, test } from './lib/l0';
 import type { Page } from '@playwright/test';
 
@@ -167,22 +168,7 @@ test.describe('local history page', () => {
     await expect(titles(page)).toHaveText(['Keep.docx']);
 
     // Gone from storage, not just from the list -- the bytes have to go too.
-    const remaining = await page.evaluate(
-      () =>
-        new Promise<number>((resolve) => {
-          const request = indexedDB.open('document-history');
-          request.onsuccess = () => {
-            const db = request.result;
-            const all = db.transaction('blobs', 'readonly').objectStore('blobs').getAllKeys();
-            all.onsuccess = () => {
-              db.close();
-              resolve(all.result.length);
-            };
-          };
-          request.onerror = () => resolve(-1);
-        }),
-    );
-    expect(remaining).toBe(1);
+    expect(await readHistoryKeys(page, 'blobs')).toHaveLength(1);
   });
 
   test('says how long each document has left', async ({ page }) => {
@@ -208,22 +194,7 @@ test.describe('local history page', () => {
     await expect(titles(page)).toHaveText(['Kept.docx']);
 
     // Gone from storage, not merely filtered out of the view.
-    const remaining = await page.evaluate(
-      () =>
-        new Promise<string[]>((resolve) => {
-          const request = indexedDB.open('document-history');
-          request.onsuccess = () => {
-            const db = request.result;
-            const all = db.transaction('docs', 'readonly').objectStore('docs').getAllKeys();
-            all.onsuccess = () => {
-              db.close();
-              resolve(all.result as string[]);
-            };
-          };
-          request.onerror = () => resolve([]);
-        }),
-    );
-    expect(remaining).toEqual(['kept']);
+    expect(await readHistoryKeys(page, 'docs')).toEqual(['kept']);
   });
 
   test('the homepage says what autosave keeps, for how long, and where to look', async ({ page }) => {

--- a/test/e2e/lib/history-db.ts
+++ b/test/e2e/lib/history-db.ts
@@ -1,0 +1,65 @@
+/**
+ * Reading the history database from a test.
+ *
+ * Every spec that checks what autosave stored needs the same handful of
+ * guards, and getting them wrong does not merely fail -- it hangs, and takes
+ * the app down with it. A versionless `indexedDB.open` on a database that does
+ * not exist yet *creates* an empty version 1 with no object stores (the app
+ * opens version 2 and creates its stores there, see lib/history/db.ts). Asking
+ * that empty database for `docs` throws inside the `onsuccess` handler, where
+ * nothing is listening: the promise never settles, so the connection is never
+ * closed, and a stray open connection then blocks the app's own upgrade -- so
+ * the snapshot the test is waiting for can never be written. A spec that races
+ * autosave, which is every spec that reads this database, loses that race
+ * sooner or later.
+ *
+ * So: one guarded reader, used by all of them.
+ */
+import type { Page } from '@playwright/test';
+
+export interface HistoryRow {
+  id: string;
+  title: string;
+  size: number;
+  savedToDiskAt?: number;
+}
+
+const DB_NAME = 'document-history';
+
+/**
+ * Run `read` against an existing store, or resolve `fallback` if the database
+ * or the store is not there yet. Closes the connection on every path.
+ */
+const withStore = <T>(page: Page, store: string, wantKeys: boolean, fallback: T) =>
+  page.evaluate(
+    ([dbName, storeName, keysOnly, empty]) =>
+      new Promise<T>((resolve) => {
+        const request = indexedDB.open(dbName as string);
+        const done = (db: IDBDatabase | null, value: unknown): void => {
+          db?.close();
+          resolve(value as T);
+        };
+        request.onerror = () => resolve(empty as T);
+        request.onsuccess = () => {
+          const db = request.result;
+          if (!db.objectStoreNames.contains(storeName as string)) return done(db, empty);
+          try {
+            const objectStore = db.transaction(storeName as string, 'readonly').objectStore(storeName as string);
+            const query = keysOnly ? objectStore.getAllKeys() : objectStore.getAll();
+            query.onsuccess = () => done(db, query.result);
+            query.onerror = () => done(db, empty);
+          } catch {
+            // The store was dropped between the check and the transaction.
+            done(db, empty);
+          }
+        };
+      }),
+    [DB_NAME, store, wantKeys, fallback] as const,
+  );
+
+/** The metadata rows autosave has stored, or none if it has stored nothing. */
+export const readHistoryDocs = (page: Page): Promise<HistoryRow[]> => withStore<HistoryRow[]>(page, 'docs', false, []);
+
+/** The keys in one history store -- what survived a delete, or an expiry sweep. */
+export const readHistoryKeys = (page: Page, store: 'docs' | 'blobs'): Promise<string[]> =>
+  withStore<string[]>(page, store, true, []);

--- a/test/e2e/save-to-file.spec.ts
+++ b/test/e2e/save-to-file.spec.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Page } from '@playwright/test';
+import { readHistoryKeys } from './lib/history-db';
 import { buildDocx, ooxmlText, zipEntryText } from './lib/ooxml';
 import { expect, test } from './lib/l0';
 
@@ -216,25 +217,10 @@ test.describe('saving into the document own file (real editor)', () => {
       document.dispatchEvent(new Event('visibilitychange'));
     });
     await expect
-      .poll(
-        () =>
-          page.evaluate(
-            () =>
-              new Promise<number>((resolve) => {
-                const request = indexedDB.open('document-history');
-                request.onsuccess = () => {
-                  const db = request.result;
-                  const all = db.transaction('docs', 'readonly').objectStore('docs').getAllKeys();
-                  all.onsuccess = () => {
-                    db.close();
-                    resolve(all.result.length);
-                  };
-                };
-                request.onerror = () => resolve(0);
-              }),
-          ),
-        { timeout: 60_000, message: 'a snapshot exists to reopen' },
-      )
+      .poll(async () => (await readHistoryKeys(page, 'docs')).length, {
+        timeout: 60_000,
+        message: 'a snapshot exists to reopen',
+      })
       .toBeGreaterThan(0);
 
     // A second page rather than a reload: it starts with an empty JS heap, so


### PR DESCRIPTION
Follow-up to #182. Fixing that flake raised the obvious question — what else in the suite is one lost race away — so I swept all 26 `expect.poll` callbacks in `test/e2e/` asking, of each: can this throw for a reason *other* than "the thing being waited for hasn't happened yet". `expect.poll` does not retry a throwing callback, so any such callback is a red build waiting for a slow CI box.

One hit. It is in the same file as #182, and it is worse than the one that was failing.

## What it does

```js
const request = indexedDB.open('document-history');   // no version
request.onsuccess = () => {
  const db = request.result;
  const all = db.transaction('docs', 'readonly').objectStore('docs').getAllKeys();
  ...
};
```

A versionless `indexedDB.open` on a database that does not exist yet **creates** an empty version 1 with no object stores. The app creates `docs` / `blobs` / `handles` at version 2 (`lib/history/db.ts`). And "database not there yet" is exactly the state this poll is in while it waits for autosave's first snapshot — that is what it is polling *for*.

So on a lost race:

1. `db.transaction('docs')` throws `NotFoundError` **inside the `onsuccess` handler**, where nothing is listening — the promise never settles, and `db.close()` is never reached;
2. the leaked version 1 connection **blocks the app's own version 2 upgrade**, so autosave can never store the snapshot;
3. sixty seconds later the poll fails saying `a snapshot exists to reopen` — by then true, and looking exactly like an autosave bug.

Measured, one clean context per shape:

```
old shape page error: Failed to execute 'transaction' on 'IDBDatabase':
                      One of the specified object stores was not found.
old shape : NEVER SETTLED
  app afterwards: BLOCKED by a leaked connection
new shape : resolved 0 (no store yet)
  app afterwards: opened, stores created
```

## The fix

`autosave-recovery.spec.ts` already had the right shape — guard `objectStoreNames.contains`, close on every path, handle `onupgradeneeded` and the query's `onerror`. It was just private to that file, so `save-to-file.spec.ts` and `history-page.spec.ts` had each hand-rolled a copy without the guards.

Moved to `test/e2e/lib/history-db.ts` (`readHistoryDocs`, `readHistoryKeys`) and all three now use it. Four hand-rolled readers become one, and the next spec that needs to read history does not get to rediscover any of this.

## The other 25

Safe, each for a stated reason: plain JS value reads, values already guarded with `??`, `Frame.url()` (synchronous, still readable after detach), the WebMCP tool layer converting its own throws into `isError` results, the `CLIENT_COUNT` round trip resolving `null` on timeout rather than throwing. Written up in the exploration doc.

Local: the three affected specs, 16/16 green. `lint:ts`, `format:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)