### PR TITLE
fix(editor): move a tab off an older build by itself, and stop flashing the home panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,15 @@ notes. Entries describe what users experience, not internal refactors.
 
 ### Fixed
 
+- **A new version now reaches you by itself.** An update used to wait until no
+  document was open anywhere, which for anyone who goes straight to the editor
+  meant never -- reloading served the same old build back, and when that build
+  referred to files a deploy had removed, the page was not merely stale but
+  broken. A tab still on an older build now moves onto the new one on its next
+  load, without asking and without interrupting anything: it happens while the
+  page is still loading, once, and never over unsaved edits.
+- The four home-screen buttons ("View/Edit Document", "New Word"...) no longer
+  flash behind the spinner while a document named in the URL is loading.
 - Chinese, Japanese and Korean text in an exported PDF came out blank. The
   export writes its own list of font files, and that list had been pointing at
   files that were not in the bundle.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -510,6 +510,25 @@ docs/explorations/2026-08-19-ci-e2e-sharding.md。
    落地页那侧的提升要覆盖三种到达方式：已经 `waiting`、`installing` 中途、
    以及 `updatefound` 时已经 `installed`（`statechange` 只报此后的迁移，
    漏掉这一支等于整页生命周期内再没人提升它）。
+   **第三条路（2026-08-22 起）：静默自愈**。前两条都到不了"直接进 /editor 且一直开着
+   文档"的用户——他们刷新只会再拿到旧构建，被 revert 的版本因此在用户屏幕上留了一天
+   （而它引用的字体已被删除，表现为乱码）。`healStaleController()`（`lib/sw-update.ts`）
+   在启动时把这类标签页悄悄换过去：等待中的 worker 是我们自己的、且是这台浏览器没跑过
+   的构建，就 skipWaiting 并 reload 一次。**每个标签页只做一次**（sessionStorage），
+   **有未保存改动时不做**，不弹任何提示（用户明确要求别打扰）。可行的前提是导航
+   network-first——卡住的标签页跑的其实已经是新 bundle。
+   **判据是"本地有没有那个构建的运行时缓存"，不是"问当前 worker 它是谁"**：问过一版，
+   并发下对方 1s 内回不上来，沉默被当成"它旧了"，页面自己刷新，E2E 稳定挂 2 条。
+   缓存名是 `document-editor-runtime-<vendorVersion>`，找不到同名的才算新构建；问不到
+   或本地还没有运行时缓存，一律不动。检测用 `onWaitingWorker()`，覆盖那三种到达方式。
+   **注意"有 worker 在等"不等于"有新版本"**：厂商的编辑器 iframe 会往同一个 scope
+   注册它自己的 worker（`/document_editor_service_worker.js`，本仓库是空 stub），
+   一个 scope 只有一个 registration，于是脚本在我们的 sw.js 与它之间来回换，`waiting`
+   几乎永远非空。两处都据此加了判断：**提升前比对脚本 URL**（不是自己的就不碰——
+   否则会把整个源站交给那个空 worker，vendor 树不再 cache-first，编辑器可能直接加载
+   失败），**提示前比对构建**（`isNewerBuild()` 用 `VERSION` 消息问两端的
+   `vendorVersion`，不同才算新版本；vendor 没变的部署压根不会等待）。见
+   docs/explorations/2026-08-22-stale-build-and-panel-flash.md。
    见 docs/explorations/2026-08-20-service-worker-update-never-promoted.md。
 4. **站点页面统一 ran 设计体系**：所有用户可见页面（落地页、demo 页如
    `public/embed-demo.html`、404 等）必须使用 ranui 组件/设计 token

--- a/docs/explorations/2026-08-22-stale-build-and-panel-flash.md
+++ b/docs/explorations/2026-08-22-stale-build-and-panel-flash.md
@@ -121,6 +121,15 @@ Qjgbc rgjc / Qjgbc qs`rgjc / Ajgai rm_bb l mrcq
 | `test/unit/update-prompt.test.ts` 五条（出现一次、点刷新会 SKIP_WAITING、接管后 reload 一次、超时兜底、忽略不动 worker） | —                                                                                              |
 | `test/e2e/entry-paths.spec.ts` 的"the home-state panel never shows while a named document loads"（从首帧起连采 12 次）   | 去掉 `opening-document` 那一行 → 用例报 `the panel was painted while the document was loading` |
 
+### 这条用例必须 `@serial`
+
+第一版没打标签，CI 里连带弄红了同分片的另外两条。原因是它"模拟部署"的手段是改写
+**整个源站共用的** `dist/sw.js`：并行跑时别的用例的 worker 也会被换掉，缓存在它们
+脚下被清空——一个正在加载的编辑器于是取不到 `spell.wasm`，`sw-vendor-cache-first`
+也看不到自己缓存的资源。打上 `@serial` 之后它只在单 worker 那一趟跑；Docker 与
+Pages 两趟本来就 `--grep-invert @serial`，而且那里的文件根本不在本机磁盘上
+（Docker 那次报的就是 `ENOENT: dist/sw.js`），所以再加一条"文件不在就 skip"。
+
 ## 给下一个人
 
 - 面板默认可见这件事本身是个坑：任何新的"启动时决定开什么"的入口（新的 query 参数、

--- a/docs/explorations/2026-08-22-stale-build-and-panel-flash.md
+++ b/docs/explorations/2026-08-22-stale-build-and-panel-flash.md
@@ -1,0 +1,136 @@
+# 用户刷新拿不到新版本，以及加载时露出来的那排按钮
+
+日期：2026-08-22
+相关：`lib/sw-update.ts`、`lib/update-prompt.ts`、`index.ts`、`styles/base.css`
+前情：[SW 更新从不提升](2026-08-20-service-worker-update-never-promoted.md)、
+[字体替换](2026-08-22-font-substitution-solved.md)
+
+## 起因
+
+字体替换（PR #184）上线并实测通过之后，用户仍然看到满屏乱码：
+
+```
+Qjgbc rgjc / Qjgbc qs`rgjc / Ajgai rm_bb l mrcq
+```
+
+把 PR #170（当天早上被 revert 的那版）的 `public/` 检出到本地跑同一个页面，得到
+**逐字相同**的乱码 —— 所以那不是当前线上，是**缓存在浏览器里的旧构建**。用户用无痕
+窗口打开是正常的，普通窗口**刷新也没用**。
+
+## 一、为什么刷新没用
+
+`sw.js` 在 vendor 变化时刻意不 `skipWaiting()`：激活会删掉上一版 vendor 缓存，而
+仍在跑旧版的页面之后惰性加载 sdk-all.js / 字体就会混版。所以提升等待中的 worker
+需要有人主动请求，而现有的两条路都到不了这个用户：
+
+| 谁负责提升                        | 条件                                  | 为什么没生效                                                                 |
+| --------------------------------- | ------------------------------------- | ---------------------------------------------------------------------------- |
+| 编辑器页（`lib/sw-update.ts`）    | **没有文档打开**                      | 编辑器页几乎总是带着文档打开（`?new=` / `?file=` / `?saved=`），条件永远为假 |
+| 落地页（`public/sw-register.js`） | **没有编辑器窗口**（`editors === 0`） | 用户直接进 `/editor`，根本没经过落地页                                       |
+
+于是"直接进编辑器、开着文档"的用户没有任何出路：刷新只会让旧 worker 再服务一次旧
+构建。这不是理论问题——被 revert 掉的构建就这样在用户屏幕上留了一整天，而它引用的
+字体已经从源站删掉了，于是显示为乱码。
+
+## 二、修法：让页面自己悄悄换过去
+
+用户的要求是"尽量不要打扰，别弹提示"。这条路走得通，因为**卡住的标签页跑的其实是新
+代码**：导航请求走 network-first，HTML 和 app bundle 都是新的；旧的只有 worker 从
+自己缓存里 cache-first 喂出来的那棵 vendor 树。所以新代码有机会自己把这件事办了。
+
+`healStaleController()`（`lib/sw-update.ts`）在启动时做三件事：
+
+1. 等待中的 worker 得是**我们自己的**（比对脚本 URL，理由见下一节）；
+2. 它得是**这台浏览器没跑过的构建**；
+3. 满足前两条就 `postMessage(SKIP_WAITING)`，接管后 reload 一次。
+
+**每个标签页只做一次**（sessionStorage 记住，杜绝 reload 循环），**有未保存改动时
+不做**（`shouldReloadOnControllerChange` 里判），而这一切发生在启动那一刻——那时用户
+还没输入任何东西，代价就是加载多一秒。
+
+### "有 worker 在等"根本不等于"有新版本"
+
+第一版通知在 E2E 里每次都弹，还带崩了两条用例。查下去发现一件之前没人注意的事：
+
+**厂商的编辑器 iframe 会往同一个 scope 里注册它自己的 worker**
+（`/document_editor_service_worker.js`，本仓库把它换成了一个空 stub）。一个 scope
+只有一个 registration，于是这个 scope 的脚本在"我们的 sw.js"和"厂商的 stub"之间
+来回换：
+
+```
+打开 /            active=/sw.js   waiting=null
+打开 /editor      active=/sw.js   waiting=/document_editor_service_worker.js
+再刷新一次        active=/sw.js   waiting=/sw.js      ← 我们自己又被装了一遍
+```
+
+两个后果，都真实存在：
+
+1. **谁去提升等待中的 worker，就可能把整个源站交给那个空 stub**——
+   `promoteWaitingWorker()`（编辑器页）与 `maybePromote()`（落地页）原本都只看
+   "有没有 waiting"。空 worker 接管之后 vendor 树不再 cache-first，编辑器甚至可能
+   直接加载失败。这是本轮之前就存在的隐患，现在两处都比对脚本 URL，不是自己的就不碰。
+2. **"有 waiting"永远为真**，所以判据不能是它。
+
+### 判据不是"问一句"，是"看证据"
+
+第二版去问：给等待中的 worker 和**当前控制页面的 worker** 各发一条 `VERSION` 消息
+（`sw.js` 新增的 handler，回 `cacheVersion` / `vendorVersion`），版本不同才算新构建；
+控制方要是不回话，就当它老到还没有这个 handler。
+
+**这一版是错的，而且错得很典型**：并发跑五个 WASM 编辑器时，控制方经常在 1 秒超时内
+回不过来。沉默被读成"它是旧的"，页面于是自己 skipWaiting + reload，测试跑到一半整页
+刷新——表现为"编辑器没起来"。全量 E2E 稳定挂 2 条，而基线（同一台机器、同样并发）
+121 条全绿；把这段接线关掉，122 条全绿且快了两分半。
+
+第三版不问对方，看**本地证据**：`sw.js` 的运行时缓存是按 vendor 内容哈希命名的
+（`document-editor-runtime-<vendorVersion>`），所以"这台浏览器有没有那个构建的缓存"
+本身就是答案。只问等待中的 worker（它是新代码，一定答得上），拿到 vendorVersion 后
+在本地 `caches.keys()` 里找：
+
+- 找得到 → 这个构建这台机器跑过 → 什么都不做（就是上面那种"同构建被重装"）；
+- 找不到 → 没跑过 → 换过去；
+- 它不回话，或者本地压根还没有运行时缓存 → **什么都不做**。宁可这一次加载还用旧的，
+  下一次再说：默认值取"沉默 = 不动"，正是第二版翻车的教训。
+
+## 三、加载时露出来的那排按钮
+
+同一张截图里还有第二个问题：`?new=docx&saved=<id>` 加载期间，屏幕中间是
+"View/Edit Document / New Word / New Excel / New PowerPoint"。
+
+根因不是 CSS，是顺序：`createControlPanel()` 在 boot 时就把面板**可见地**建出来，
+只有等文档接管后才 `hideControlPanel()`。实测：
+
+```
+?new=docx                 t+0ms  opacity=0     （几乎看不见）
+?new=docx&saved=<id>      t+0ms  opacity=1     t+200ms 才开始淡出
+```
+
+`?saved=` 那条路要先动态 import `history/store` 与 `history/recovery` 再决定开什么，
+于是可见窗口被拉长；线上冷加载更长，就成了截图里那样。
+
+修法：**URL 已经指明要打开什么时，面板从一开始就不渲染**。index.ts 在建面板之前
+读一次 query（`?file` / `?src` / `?new` / `?saved` / `?open=local`），给 body 加
+`opening-document`，CSS 据此 `display: none`；真的回到主页状态时
+`showControlPanel()` 再把这个类摘掉。
+
+## 用例与反向验证
+
+| 用例                                                                                                                     | 反向验证                                                                                       |
+| ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| `test/unit/sw-update.test.ts` 的 `onWaitingWorker` 四条（三种到达方式 + 没有新 worker）                                  | 删掉 `updatefound` 那一支 → "reports one that turns up after the page has loaded" 变红         |
+| `test/unit/update-prompt.test.ts` 五条（出现一次、点刷新会 SKIP_WAITING、接管后 reload 一次、超时兜底、忽略不动 worker） | —                                                                                              |
+| `test/e2e/entry-paths.spec.ts` 的"the home-state panel never shows while a named document loads"（从首帧起连采 12 次）   | 去掉 `opening-document` 那一行 → 用例报 `the panel was painted while the document was loading` |
+
+## 给下一个人
+
+- 面板默认可见这件事本身是个坑：任何新的"启动时决定开什么"的入口（新的 query 参数、
+  新的恢复路径）都要记得进 `opensSomething` 的判断，否则又会闪一下。
+- **不要用"对方回不回话"当判据。** 超时只说明它忙，不说明它旧。这条一次就够贵了。
+- 静默 reload 只在启动那一刻做，且有未保存改动时不做。要是以后想扩到"用户用到一半
+  也自动换"，先想清楚丢的是谁的东西。
+- **已经卡在旧构建上的用户，这段代码也救得了他们**——导航是 network-first，他们下一次
+  刷新拿到的 HTML 和 bundle 就是新的，这段逻辑随之运行。真正救不了的是"从不刷新"的
+  标签页。
+- **删除 vendor 资源的部署仍然要额外小心**：老客户端的注册表指着已经不存在的文件，
+  在它自愈之前那一屏就是坏的（本轮就是字体乱码）。删文件的那次部署，最好同时接受
+  "所有老标签页会自动刷新一次"。

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,9 @@
-import { shouldReloadOnControllerChange, wireServiceWorkerUpdates } from './lib/sw-update';
+import {
+  healStaleController,
+  onWaitingWorker,
+  shouldReloadOnControllerChange,
+  wireServiceWorkerUpdates,
+} from './lib/sw-update';
 import { getAllQueryString } from 'ranuts/utils';
 import { View } from 'ranui/builder';
 import { initEmbedApi } from './lib/embed-api';
@@ -13,7 +18,7 @@ import 'ranui/button';
 import 'ranui/card';
 import 'ranui/select';
 import { initWebMcp } from './lib/web-mcp';
-import { installUnsavedChangesGuard } from './lib/unsaved-guard';
+import { hasUnsavedChanges, installUnsavedChangesGuard } from './lib/unsaved-guard';
 import { initDocumentHistory } from './lib/history';
 import '@khmyznikov/pwa-install';
 import './styles/base.css';
@@ -75,6 +80,18 @@ window.onOpenDocument = onOpenDocument;
 window.hideControlPanel = hideControlPanel;
 window.showControlPanel = showControlPanel;
 
+// If the URL already says what to open, the home-state panel must never be
+// painted: it is built visible and only hidden once the document takes over,
+// and on a cold load that gap is long enough to read (a `?saved=` restore adds
+// two dynamic imports before it). Deciding here, before the panel exists,
+// keeps "View/Edit Document / New Word / New Excel / New PowerPoint" off the
+// loading screen instead of racing to remove it afterwards.
+const params = getAllQueryString();
+const opensSomething = Boolean(
+  params['file'] || params['src'] || params['new'] || params['saved'] || params['open'] === 'local',
+);
+if (opensSomething) document.body.classList.add('opening-document');
+
 // Initialize UI components
 createControlPanel();
 
@@ -88,7 +105,7 @@ createControlPanel();
 //   ?file=https://example.com/doc.docx
 //   ?src=https://example.com/doc.docx
 //   ?file=doc1.docx&src=doc2.xlsx (will use file: doc1.docx)
-const { file, src, readonly, agent } = getAllQueryString();
+const { file, src, readonly, agent } = params;
 const documentUrl = file || src;
 // Pure preview mode: ?readonly=true (also accepts ?readonly=1 or bare ?readonly).
 // Opens the document with editing/download disabled (#25, #85, #87).
@@ -116,12 +133,12 @@ window.addEventListener('message', (event: MessageEvent) => {
 // into a new file (skipping the landing hero). The localized homepages use it —
 // e.g. /zh-CN/ links to `/?locale=zh-CN&new=docx`, so i18n (which reads ?locale)
 // boots the editor UI in Chinese and drops the user directly into editing.
-const newExtRaw = getAllQueryString()['new'];
+const newExtRaw = params['new'];
 const newExt = typeof newExtRaw === 'string' ? newExtRaw.replace(/^\./, '').toLowerCase() : '';
 const createNewOnLoad = ['docx', 'xlsx', 'pptx'].includes(newExt) && !documentUrl;
 // `?open=local`: a static landing page (e.g. /zh-CN/) stashed a picked file in
 // IndexedDB via public/open-local.js — take it out and open it on boot.
-const openParam = getAllQueryString()['open'];
+const openParam = params['open'];
 const openLocalOnLoad = openParam === 'local' && !documentUrl && !createNewOnLoad;
 // `?saved=<id>`: which of this browser's saved documents to open. Every
 // editing session stamps its own id here (see lib/history/session.ts), so a
@@ -135,7 +152,7 @@ const openLocalOnLoad = openParam === 'local' && !documentUrl && !createNewOnLoa
 // would open an empty editor. It is also why it is not called `id`: what makes
 // it meaningful is not that it is an identifier, it is that the document is
 // saved on this device.
-const savedParam = getAllQueryString()['saved'] ?? '';
+const savedParam = params['saved'] ?? '';
 
 // Landing hero orchestration. Only the bare homepage (no ?file/?src/?new, not
 // embedded) shows the crawlable hero. If a document is about to load or be
@@ -216,6 +233,10 @@ if ('serviceWorker' in navigator) {
   // no document is open, then takes over and the page reloads once.
   const hadController = !!navigator.serviceWorker.controller;
   let reloadingForUpdate = false;
+  // Set when this tab asked an older worker to step aside (see below): the
+  // reload that follows is the point, so it is not blocked by having a
+  // document open the way an ordinary update is.
+  let healingStaleBuild = false;
   const hasOpenDocument = () => Boolean(getDocmentObj().fileName);
 
   navigator.serviceWorker.addEventListener('controllerchange', () => {
@@ -224,6 +245,8 @@ if ('serviceWorker' in navigator) {
         hadController,
         alreadyReloading: reloadingForUpdate,
         hasOpenDocument: hasOpenDocument(),
+        healingStaleBuild,
+        hasUnsavedChanges: hasUnsavedChanges(),
       })
     ) {
       return;
@@ -232,12 +255,45 @@ if ('serviceWorker' in navigator) {
     window.location.reload();
   });
 
+  // The script we register, absolute: the vendored editor registers one of its
+  // own into this same scope from inside the iframe, and only this URL says
+  // which waiting worker is a new build of ours.
+  const ownScriptURL = new URL('./sw.js', window.location.href).href;
+
   window.addEventListener('load', () => {
     navigator.serviceWorker
       .register('./sw.js')
       .then((registration) => {
         console.log('SW registered: ', registration);
-        wireServiceWorkerUpdates(registration, hasOpenDocument);
+        wireServiceWorkerUpdates(registration, hasOpenDocument, ownScriptURL);
+        // Promotion above is refused while a document is open, and this page
+        // is usually opened with one (?new=, ?file=, ?saved=). Without an
+        // offer, such a visitor never leaves the build their worker cached --
+        // reloading serves it again. Ask instead of deciding for them: the
+        // reload happens on click, so the mixed-version hazard the waiting
+        // exists to prevent cannot happen either.
+        // A tab whose worker is an older build heals itself, quietly. The
+        // navigation is network-first, so this page and its bundle are already
+        // the new ones; it is the vendored tree underneath that is still being
+        // served from the outgoing build's cache, and a registry that no longer
+        // matches the origin is how a reverted build kept rendering garbled
+        // text long after the revert had shipped. Promote and reload once --
+        // at boot there is nothing typed to lose, and no one has to be told.
+        onWaitingWorker(
+          registration,
+          (waiting) => {
+            void healStaleController({
+              registration,
+              waiting,
+              controller: navigator.serviceWorker.controller,
+              hadController,
+              storage: window.sessionStorage,
+            }).then((started) => {
+              if (started) healingStaleBuild = true;
+            });
+          },
+          ownScriptURL,
+        );
         // Check for updates on every page load. Firefox rejects the update
         // when the registration changed since it was scheduled (a benign race
         // right after register()); swallow it so it never surfaces as an

--- a/lib/sw-update.ts
+++ b/lib/sw-update.ts
@@ -16,20 +16,49 @@
 
 export type SwLike = {
   state: string;
+  scriptURL?: string;
   postMessage: (msg: unknown) => unknown;
   addEventListener: (t: 'statechange', cb: () => void) => void;
 };
 export type RegistrationLike = {
+  active?: SwLike | null;
   waiting: SwLike | null;
   installing: SwLike | null;
   addEventListener: (t: 'updatefound', cb: () => void) => void;
 };
 
+/**
+ * Is this waiting worker a new build of OURS?
+ *
+ * It is not a rhetorical question. The vendored editor registers its own
+ * worker -- `/document_editor_service_worker.js`, a stub we ship empty -- into
+ * the same scope from inside the editor iframe, so on the editor route
+ * `registration.waiting` is usually THAT, not a new deploy. Telling it to
+ * skipWaiting hands the whole origin to an empty worker: the vendor tree stops
+ * being served cache-first and the editor can fail to load outright. And
+ * announcing it as "a new version is ready" is simply false.
+ *
+ * The script URL we registered is the reference. `registration.active` is the
+ * fallback, but only that: right after a reload it can still be null, and
+ * "nothing to compare with" must not mean "assume it is ours" -- that is how
+ * the notice came back on every reload of the editor.
+ */
+export function isOwnWorker(reg: RegistrationLike, worker: SwLike, ownScriptURL?: string): boolean {
+  const mine = ownScriptURL ?? reg.active?.scriptURL;
+  if (!mine || !worker.scriptURL) return true; // nothing to compare: old behaviour
+  return worker.scriptURL === mine;
+}
+
 export const SKIP_WAITING_MESSAGE = { type: 'SKIP_WAITING' } as const;
 
 /** Tell a waiting worker to take over -- only if nothing is open. Returns whether it did. */
-export function promoteWaitingWorker(reg: RegistrationLike, hasOpenDocument: () => boolean): boolean {
+export function promoteWaitingWorker(
+  reg: RegistrationLike,
+  hasOpenDocument: () => boolean,
+  ownScriptURL?: string,
+): boolean {
   if (!reg.waiting || hasOpenDocument()) return false;
+  if (!isOwnWorker(reg, reg.waiting, ownScriptURL)) return false;
   reg.waiting.postMessage(SKIP_WAITING_MESSAGE);
   return true;
 }
@@ -40,15 +69,49 @@ export function promoteWaitingWorker(reg: RegistrationLike, hasOpenDocument: () 
  * open"). A worker that stays waiting because a document is open activates on
  * the next visit, when the landing page calls this again.
  */
-export function wireServiceWorkerUpdates(reg: RegistrationLike, hasOpenDocument: () => boolean): void {
-  promoteWaitingWorker(reg, hasOpenDocument);
+export function wireServiceWorkerUpdates(
+  reg: RegistrationLike,
+  hasOpenDocument: () => boolean,
+  ownScriptURL?: string,
+): void {
+  promoteWaitingWorker(reg, hasOpenDocument, ownScriptURL);
   reg.addEventListener('updatefound', () => {
     const installing = reg.installing;
     if (!installing) return;
     installing.addEventListener('statechange', () => {
-      if (installing.state === 'installed') promoteWaitingWorker(reg, hasOpenDocument);
+      if (installing.state === 'installed') promoteWaitingWorker(reg, hasOpenDocument, ownScriptURL);
     });
   });
+}
+
+/**
+ * Call back with a worker that is installed and waiting -- now, or as soon as
+ * one arrives. Three ways it can show up and all three matter: it is already
+ * waiting when the page loads, it is mid-install (`installing`), or an
+ * `updatefound` fires later. Missing the third is how a whole page lifetime
+ * can pass with nobody offering the new build.
+ */
+export function onWaitingWorker(
+  reg: RegistrationLike,
+  onWaiting: (worker: SwLike) => void,
+  ownScriptURL?: string,
+): void {
+  const report = (worker: SwLike): void => {
+    if (isOwnWorker(reg, worker, ownScriptURL)) onWaiting(worker);
+  };
+  const watch = (worker: SwLike | null): void => {
+    if (!worker) return;
+    if (worker.state === 'installed') {
+      report(worker);
+      return;
+    }
+    worker.addEventListener('statechange', () => {
+      if (worker.state === 'installed') report(worker);
+    });
+  };
+  if (reg.waiting) report(reg.waiting);
+  else watch(reg.installing);
+  reg.addEventListener('updatefound', () => watch(reg.installing));
 }
 
 /**
@@ -60,6 +123,121 @@ export function shouldReloadOnControllerChange(state: {
   hadController: boolean;
   alreadyReloading: boolean;
   hasOpenDocument: boolean;
+  /** This tab asked an older worker to step aside; the reload is the point. */
+  healingStaleBuild?: boolean;
+  hasUnsavedChanges?: boolean;
 }): boolean {
-  return state.hadController && !state.alreadyReloading && !state.hasOpenDocument;
+  if (!state.hadController || state.alreadyReloading) return false;
+  if (state.healingStaleBuild) return !state.hasUnsavedChanges;
+  return !state.hasOpenDocument;
+}
+
+/** How sw.js names the cache it keeps the vendored editor in. */
+export const RUNTIME_CACHE_PREFIX = 'document-editor-runtime-';
+
+/** Remembered per tab, so a heal can never turn into a reload loop. */
+export const HEAL_STORAGE_KEY = 'sw-heal-reloaded';
+
+export type HealInput = {
+  registration: RegistrationLike;
+  waiting: SwLike;
+  controller: SwLike | null;
+  hadController: boolean;
+  storage?: Pick<Storage, 'getItem' | 'setItem'>;
+  cacheStorage?: Pick<CacheStorage, 'keys'>;
+  ownScriptURL?: string;
+};
+
+/**
+ * Move a tab that an older build's worker is still serving onto the new one,
+ * without saying anything.
+ *
+ * The situation this exists for: a deploy whose vendor tree changed leaves its
+ * worker WAITING (activating it would delete the caches the outgoing build is
+ * still reading). Nothing promotes it while a document is open, and the editor
+ * route practically always has one -- so the tab keeps being served the old
+ * vendor tree even though the page and its bundle, fetched network-first, are
+ * already new. If that old tree references files the deploy deleted, the
+ * result is not a stale page but a broken one: a reverted font build kept
+ * rendering garbled text for a day after the revert shipped.
+ *
+ * Silent is deliberate. This runs at boot, where nothing has been typed, so
+ * the reload costs a second of loading and no work -- there is nothing worth
+ * interrupting the reader for. It happens at most once per tab, only when the
+ * waiting worker is ours and is genuinely a different build, and never when
+ * there are unsaved edits (see shouldReloadOnControllerChange).
+ */
+export async function healStaleController(input: HealInput): Promise<boolean> {
+  const { registration, waiting, controller, hadController, storage, ownScriptURL } = input;
+  if (!hadController || !controller) return false;
+  if (!isOwnWorker(registration, waiting, ownScriptURL)) return false;
+  if (storage?.getItem(HEAL_STORAGE_KEY)) return false;
+  if (!(await isUnseenBuild(waiting, input.cacheStorage))) return false;
+  storage?.setItem(HEAL_STORAGE_KEY, '1');
+  waiting.postMessage(SKIP_WAITING_MESSAGE);
+  return true;
+}
+
+/** What a worker answers `VERSION` with (public/sw.js). */
+export type WorkerVersion = { cacheVersion?: string; vendorVersion?: string };
+
+/** Ask one worker which build it is. Resolves null when it does not answer. */
+export function askVersion(worker: SwLike | null, timeoutMs = 1000): Promise<WorkerVersion | null> {
+  return new Promise((resolve) => {
+    if (!worker || typeof MessageChannel === 'undefined') {
+      resolve(null);
+      return;
+    }
+    const channel = new MessageChannel();
+    let settled = false;
+    const done = (value: WorkerVersion | null): void => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    channel.port1.onmessage = (event: MessageEvent) => done((event.data ?? null) as WorkerVersion | null);
+    setTimeout(() => done(null), timeoutMs);
+    try {
+      // Two-argument postMessage, which the narrow SwLike shape does not model.
+      (worker as unknown as { postMessage(msg: unknown, transfer: MessagePort[]): void }).postMessage(
+        { type: 'VERSION' },
+        [channel.port2],
+      );
+    } catch {
+      done(null);
+    }
+  });
+}
+
+/**
+ * Is the waiting worker a build this browser has never run?
+ *
+ * "There is a worker waiting" is not that question, and on the editor route it
+ * is usually the wrong one: the vendored editor registers a script of its own
+ * into this scope from inside its iframe, so the scope's script alternates and
+ * OUR worker is re-installed on the next load -- waiting, same build, nothing
+ * to do.
+ *
+ * The evidence is the runtime cache, not a conversation. sw.js names it after
+ * the vendor tree's content hash (`document-editor-runtime-<vendorVersion>`),
+ * so a build whose cache is already on this machine is a build this browser
+ * has been running. Asking the CONTROLLER instead was the first attempt and it
+ * was wrong in a way worth remembering: a worker under load does not answer
+ * within a timeout, silence got read as "it is old", and tabs reloaded
+ * themselves in the middle of a test run.
+ */
+export async function isUnseenBuild(
+  waiting: SwLike | null,
+  cacheStorage: Pick<CacheStorage, 'keys'> | undefined = typeof caches === 'undefined' ? undefined : caches,
+): Promise<boolean> {
+  const version = await askVersion(waiting);
+  const vendorVersion = version?.vendorVersion;
+  if (!vendorVersion || !cacheStorage) return false; // cannot tell -- do nothing
+  const runtime = (await cacheStorage.keys()).filter((name) => name.startsWith(RUNTIME_CACHE_PREFIX));
+  // No runtime cache yet means nothing to compare against, which is not the
+  // same as "this build is new". Staying quiet is the safe reading: the worst
+  // case is one page load served by the outgoing build, and the next load has
+  // the evidence.
+  if (!runtime.length) return false;
+  return !runtime.some((name) => name.endsWith(`-${vendorVersion}`));
 }

--- a/lib/ui.ts
+++ b/lib/ui.ts
@@ -60,6 +60,10 @@ export const showControlPanel = (): void => {
   // Back to the home state (no document, or an error) — bring the hero back so
   // it, not the legacy overlay, is what the user (and crawlers) see.
   showLanding();
+  // Whatever the URL said it would open did not happen (or was closed), so the
+  // panel is the home state again; drop the flag that keeps it off the loading
+  // screen (index.ts sets it before the panel is built).
+  document.body.classList.remove('opening-document');
 
   const panel = getControlPanel();
   panel.style.display = 'flex';

--- a/public/sw-register.js
+++ b/public/sw-register.js
@@ -88,6 +88,17 @@
     function maybePromote(registration) {
       var waiting = registration.waiting;
       if (!waiting) return Promise.resolve(false);
+      // Not every waiting worker is one of ours. The vendored editor registers
+      // its own (`/document_editor_service_worker.js`, an empty stub) into the
+      // same scope from inside the editor iframe, so a visitor who has opened
+      // the editor leaves one waiting here. Promoting THAT hands the origin to
+      // an empty worker and the vendor tree stops being served cache-first.
+      // SW_URL is the reference, not registration.active: right after a
+      // reload `active` can still be null, and "nothing to compare with" must
+      // not be read as "it is ours".
+      if (waiting.scriptURL && waiting.scriptURL.indexOf(SW_URL, waiting.scriptURL.length - SW_URL.length) === -1) {
+        return Promise.resolve(false);
+      }
       return countClients().then(function (answer) {
         if (!answer) return false;
         var blocked = typeof answer.editors === 'number' ? answer.editors > 0 : answer.count > 1;

--- a/public/sw.js
+++ b/public/sw.js
@@ -211,6 +211,16 @@ self.addEventListener('message', (event) => {
   // document is not, so any editor window counts against promotion. Another
   // LANDING tab does not -- it has nothing to lose, and blocking on it was
   // enough to leave a two-tab reader on an old build indefinitely.
+  // Which build this worker is. A page cannot tell a NEW build waiting behind
+  // it from its own build re-installed: the vendored editor registers a second
+  // script into this scope from inside its iframe, which makes the scope's
+  // script alternate and re-installs this one on the next load. Same versions
+  // means same build, however many times it has been installed -- so the page
+  // has something better to go on than "there is a worker waiting".
+  if (event.data && event.data.type === 'VERSION') {
+    const port = event.ports && event.ports[0];
+    if (port) port.postMessage({ type: 'VERSION', cacheVersion: CACHE_VERSION, vendorVersion: VENDOR_VERSION });
+  }
   if (event.data && event.data.type === 'CLIENT_COUNT') {
     const port = event.ports && event.ports[0];
     if (!port) return;

--- a/styles/base.css
+++ b/styles/base.css
@@ -92,6 +92,15 @@ body.embed-mode #landing-hero {
 body.landing-active #control-panel-container {
   display: none !important;
 }
+
+/* A URL that already names a document (?file / ?src / ?new / ?saved /
+   ?open=local) goes straight into the editor, so the home-state panel is never
+   the answer -- and it must not be visible while the document loads. index.ts
+   sets this before the panel is built; showControlPanel() removes it if we end
+   up back at the home state after all. */
+body.opening-document #control-panel-container {
+  display: none !important;
+}
 body.landing-active,
 body.landing-active #app {
   height: auto;

--- a/test/e2e/entry-paths.spec.ts
+++ b/test/e2e/entry-paths.spec.ts
@@ -77,6 +77,34 @@ test.describe('entry paths (real editor)', () => {
     expect(result.magic).toEqual([0x50, 0x4b]);
   });
 
+  /**
+   * Whatever the URL names, the home-state panel must not be on screen while
+   * it loads. The panel is built visible and only hidden once the document
+   * takes over, so on a cold load -- and `?saved=` adds two dynamic imports
+   * before the document even starts -- "View/Edit Document / New Word / New
+   * Excel / New PowerPoint" sat under the spinner, which is what a user
+   * reported seeing. Sampled from first paint, not after settling: the whole
+   * defect lives in the first second.
+   */
+  test('the home-state panel never shows while a named document loads', async ({ page }) => {
+    await page.goto('/editor?new=docx&saved=b0a1c2d3-0000-4000-8000-000000000000', {
+      waitUntil: 'commit',
+    });
+    const visible = async () =>
+      page.evaluate(() => {
+        const panel = document.getElementById('control-panel-container');
+        if (!panel) return false;
+        const style = getComputedStyle(panel);
+        return style.display !== 'none' && style.visibility !== 'hidden' && Number(style.opacity) > 0.01;
+      });
+    const seen: boolean[] = [];
+    for (let i = 0; i < 12; i++) {
+      seen.push(await visible());
+      await page.waitForTimeout(150);
+    }
+    expect(seen.filter(Boolean), 'the panel was painted while the document was loading').toEqual([]);
+  });
+
   test('?open=local consumes the file a static landing page stashed in IndexedDB', async ({ page }) => {
     // Same DB/store/key names as public/open-local.js and lib/pending-open.ts.
     await page.goto('/zh-CN/');

--- a/test/e2e/sw-silent-update.spec.ts
+++ b/test/e2e/sw-silent-update.spec.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { expect, test } from './lib/l0';
 import { settleEditor } from './lib/visual';
@@ -20,6 +20,13 @@ import { settleEditor } from './lib/visual';
  * The test deploys a second build the only way a static preview can: it
  * rewrites the vendor stamp inside the served sw.js, which is exactly what
  * bin/build.sh does when the vendored tree changes.
+ *
+ * That rewrite is visible to the whole origin, so this case is `@serial`: run
+ * beside others it replaces THEIR service worker mid-test too, which wipes the
+ * cache under them (an editor mid-load then fails to fetch spell.wasm, and the
+ * cache-first case stops seeing its cached asset). It is skipped where the
+ * served files are not on this disk -- the Docker image and any run against a
+ * deployed site.
  */
 const PORT = process.env.E2E_PORT ?? '4173';
 const OUT_DIR = process.env.E2E_PORT ? `dist-e2e-${PORT}` : 'dist';
@@ -38,8 +45,11 @@ const controllerVendorVersion = (page: import('@playwright/test').Page) =>
     });
   });
 
-test.describe('a stale build heals itself', () => {
+test.describe('a stale build heals itself @serial', () => {
   test.describe.configure({ timeout: 240_000 });
+  // The container and a deployed site serve their own copy; there is nothing
+  // here to rewrite, and no way to deploy a second build mid-run.
+  test.skip(!existsSync(SW_PATH), 'needs the locally built site this run is serving');
 
   let original = '';
   test.beforeAll(() => {

--- a/test/e2e/sw-silent-update.spec.ts
+++ b/test/e2e/sw-silent-update.spec.ts
@@ -1,0 +1,86 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { expect, test } from './lib/l0';
+import { settleEditor } from './lib/visual';
+
+/**
+ * A tab whose service worker is an older build moves itself onto the new one,
+ * without asking and without being told to.
+ *
+ * Why it has to: a deploy that changed the vendored tree leaves its worker
+ * WAITING, because activating it deletes the caches the outgoing build is
+ * still reading from. Nothing promotes it while a document is open, and the
+ * editor route practically always has one -- so the tab keeps being served the
+ * old vendor tree even though the page and its bundle came from the network
+ * and are new. When that old tree names files the deploy deleted, the result
+ * is not a stale page but a broken one: the font sweep's reverted build kept
+ * rendering garbled text for a day after the revert had shipped, and reloading
+ * did not help.
+ *
+ * The test deploys a second build the only way a static preview can: it
+ * rewrites the vendor stamp inside the served sw.js, which is exactly what
+ * bin/build.sh does when the vendored tree changes.
+ */
+const PORT = process.env.E2E_PORT ?? '4173';
+const OUT_DIR = process.env.E2E_PORT ? `dist-e2e-${PORT}` : 'dist';
+const SW_PATH = resolve(process.cwd(), OUT_DIR, 'sw.js');
+
+/** Ask whichever worker controls this page which build it is. */
+const controllerVendorVersion = (page: import('@playwright/test').Page) =>
+  page.evaluate(async () => {
+    const controller = navigator.serviceWorker.controller;
+    if (!controller) return null;
+    return await new Promise<string | null>((done) => {
+      const channel = new MessageChannel();
+      channel.port1.onmessage = (event) => done((event.data?.vendorVersion as string) ?? null);
+      setTimeout(() => done(null), 3000);
+      controller.postMessage({ type: 'VERSION' }, [channel.port2]);
+    });
+  });
+
+test.describe('a stale build heals itself', () => {
+  test.describe.configure({ timeout: 240_000 });
+
+  let original = '';
+  test.beforeAll(() => {
+    original = readFileSync(SW_PATH, 'utf8');
+  });
+  test.afterAll(() => {
+    if (original) writeFileSync(SW_PATH, original);
+  });
+
+  test('a new vendor build takes over on the next load, silently', async ({ page }) => {
+    await page.goto('/editor?new=docx');
+    await settleEditor(page);
+    // The worker only controls the page from the load after it installed.
+    await page.reload();
+    await settleEditor(page);
+    await page.waitForFunction(() => !!navigator.serviceWorker.controller, undefined, { timeout: 30_000 });
+    const before = await controllerVendorVersion(page);
+    expect(before, 'the page is controlled by a worker that reports its build').toBeTruthy();
+
+    // Deploy: same site, new vendor stamp.
+    writeFileSync(SW_PATH, original.replace(/const VENDOR_VERSION = [^;]+;/, "const VENDOR_VERSION = 'e2e-next';"));
+
+    await page.reload();
+    // No click, no prompt: the page notices the build it is being served is not
+    // the one that is installed, and reloads itself into the new one.
+    await page.waitForFunction(
+      async () => {
+        const controller = navigator.serviceWorker.controller;
+        if (!controller) return false;
+        return await new Promise<boolean>((done) => {
+          const channel = new MessageChannel();
+          channel.port1.onmessage = (event) => done(event.data?.vendorVersion === 'e2e-next');
+          setTimeout(() => done(false), 1000);
+          controller.postMessage({ type: 'VERSION' }, [channel.port2]);
+        });
+      },
+      undefined,
+      { timeout: 90_000 },
+    );
+    await settleEditor(page);
+    expect(await controllerVendorVersion(page)).toBe('e2e-next');
+    expect(await page.locator('#update-notice').count(), 'nothing was shown to the reader').toBe(0);
+  });
+});

--- a/test/unit/sw-register.test.ts
+++ b/test/unit/sw-register.test.ts
@@ -34,9 +34,9 @@ beforeAll(() => {
 });
 
 /** A worker the page can post to, recording what it was told. */
-const fakeWorker = () => {
+const fakeWorker = (scriptURL = 'https://edit.example/sw.js') => {
   const posted: unknown[] = [];
-  return { posted, postMessage: (msg: unknown) => posted.push(msg) };
+  return { posted, scriptURL, postMessage: (msg: unknown) => posted.push(msg) };
 };
 
 /**
@@ -59,9 +59,13 @@ const legacyController = (count: number) => ({
   },
 });
 
-const fakeRegistration = (waiting: ReturnType<typeof fakeWorker> | null) => {
+const fakeRegistration = (
+  waiting: ReturnType<typeof fakeWorker> | null,
+  active: ReturnType<typeof fakeWorker> | null = fakeWorker(),
+) => {
   const listeners: Record<string, Array<() => void>> = {};
   return {
+    active,
     waiting,
     installing: null as null | { state: string; addEventListener: (t: string, cb: () => void) => void },
     addEventListener: (type: string, cb: () => void) => {
@@ -272,5 +276,20 @@ describe('the landing pages carry the policy', () => {
     // promotion, a second landing tab does not.
     expect(sw).toContain('isEditorWindow(client.url)');
     expect(sw).toMatch(/const EDITOR_ROUTE = /);
+  });
+});
+
+/**
+ * The editor iframe registers the vendor's own worker
+ * (`/document_editor_service_worker.js`, an empty stub here) into this same
+ * scope, so anyone who has opened the editor leaves one waiting. Promoting it
+ * from the landing page would hand the origin to an empty worker.
+ */
+describe('a worker from the vendored editor, waiting in the same scope', () => {
+  it('is left alone', async () => {
+    const updater = createSwUpdater(navWith(fakeController(1)));
+    const vendor = fakeWorker('https://edit.example/document_editor_service_worker.js');
+    await expect(updater.maybePromote(fakeRegistration(vendor))).resolves.toBe(false);
+    expect(vendor.posted).toEqual([]);
   });
 });

--- a/test/unit/sw-update.test.ts
+++ b/test/unit/sw-update.test.ts
@@ -4,6 +4,10 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   type SwLike,
   SKIP_WAITING_MESSAGE,
+  HEAL_STORAGE_KEY,
+  healStaleController,
+  isUnseenBuild,
+  onWaitingWorker,
   promoteWaitingWorker,
   shouldReloadOnControllerChange,
   wireServiceWorkerUpdates,
@@ -19,9 +23,10 @@ type FakeWorker = SwLike & {
   postMessage: ReturnType<typeof vi.fn<(msg: unknown) => unknown>>;
   listeners: Array<() => void>;
 };
-const worker = (state = 'installed'): FakeWorker => {
+const worker = (state = 'installed', scriptURL = 'https://edit.example/sw.js'): FakeWorker => {
   const w: FakeWorker = {
     state,
+    scriptURL,
     postMessage: vi.fn<(msg: unknown) => unknown>(),
     listeners: [],
     addEventListener: (_t, cb) => {
@@ -30,8 +35,12 @@ const worker = (state = 'installed'): FakeWorker => {
   };
   return w;
 };
-const registration = (waiting: ReturnType<typeof worker> | null = null) => {
+const registration = (
+  waiting: ReturnType<typeof worker> | null = null,
+  active: SwLike | null = worker('activated'),
+) => {
   const r = {
+    active,
     waiting: waiting as SwLike | null,
     installing: null as SwLike | null,
     updateListeners: [] as Array<() => void>,
@@ -487,5 +496,244 @@ describe('bin/build.sh stamps both versions into sw.js', () => {
     for (const dir of ['sdkjs', 'web-apps', 'fonts']) {
       expect(script, dir).toMatch(new RegExp(`for dir in [^\n]*\\b${dir}\\b`));
     }
+  });
+});
+
+/**
+ * The other half of the update path: someone whose document is open is never
+ * promoted automatically, so they have to be offered the new build instead.
+ * That offer is only as good as the detection -- a worker can be waiting
+ * already, be mid-install, or arrive later -- and missing the last case is how
+ * a whole page lifetime passes with nobody asking.
+ */
+describe('onWaitingWorker', () => {
+  it('reports a worker that is already waiting', () => {
+    const w = worker();
+    const seen: unknown[] = [];
+    onWaitingWorker(registration(w), (found) => seen.push(found));
+    expect(seen).toEqual([w]);
+  });
+
+  it('reports one that is still installing when the page loads', () => {
+    const r = registration();
+    const w = worker('installing');
+    r.installing = w;
+    const seen: unknown[] = [];
+    onWaitingWorker(r, (found) => seen.push(found));
+    expect(seen).toEqual([]);
+    w.state = 'installed';
+    w.listeners.forEach((cb) => cb());
+    expect(seen).toEqual([w]);
+  });
+
+  it('reports one that turns up after the page has loaded', () => {
+    const r = registration();
+    const seen: unknown[] = [];
+    onWaitingWorker(r, (found) => seen.push(found));
+    const w = worker('installing');
+    r.installing = w;
+    r.updateListeners.forEach((cb) => cb());
+    w.state = 'installed';
+    w.listeners.forEach((cb) => cb());
+    expect(seen).toEqual([w]);
+  });
+
+  it('says nothing when there is no new worker at all', () => {
+    const seen: unknown[] = [];
+    onWaitingWorker(registration(null), (found) => seen.push(found));
+    expect(seen).toEqual([]);
+  });
+});
+
+/**
+ * The vendored editor registers a worker of its own from inside the iframe --
+ * `/document_editor_service_worker.js`, a stub this repo ships empty -- into
+ * the same scope. So on the editor route `registration.waiting` is usually
+ * that, not a new deploy of ours. Promoting it hands the origin to an empty
+ * worker (no cache-first vendor tree, an editor that can fail to load), and
+ * announcing it as a new version is a lie. Both paths check the script URL.
+ */
+describe('a foreign worker in the same scope', () => {
+  const vendor = () => worker('installed', 'https://edit.example/document_editor_service_worker.js');
+
+  it('is never told to skip waiting', () => {
+    const v = vendor();
+    expect(promoteWaitingWorker(registration(v), () => false)).toBe(false);
+    expect(v.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('is never announced as a new version', () => {
+    const seen: unknown[] = [];
+    onWaitingWorker(registration(vendor()), (found) => seen.push(found));
+    expect(seen).toEqual([]);
+  });
+
+  it('does not stop a real update of ours from being promoted', () => {
+    const ours = worker();
+    expect(promoteWaitingWorker(registration(ours), () => false)).toBe(true);
+    expect(ours.postMessage).toHaveBeenCalledWith(SKIP_WAITING_MESSAGE);
+  });
+});
+
+/**
+ * "A worker is waiting" does not mean "a new build is waiting". The vendored
+ * editor registers a script of its own into this scope from inside its iframe,
+ * so the scope's script alternates and OUR worker gets re-installed on the
+ * next editor load -- waiting, same build, nothing to do.
+ *
+ * The evidence is the runtime cache sw.js names after the vendor tree's
+ * content hash: a build whose cache is already here is one this browser has
+ * been running. (Asking the controller instead was tried first and reloaded
+ * tabs mid-test whenever a busy worker missed the timeout.)
+ */
+describe('isUnseenBuild', () => {
+  const answering = (version: Record<string, string> | null) =>
+    ({
+      state: 'installed',
+      addEventListener: () => {},
+      postMessage: (_msg: unknown, transfer?: MessagePort[]) => {
+        const port = transfer?.[0];
+        if (port && version) setTimeout(() => port.postMessage({ type: 'VERSION', ...version }), 0);
+      },
+    }) as unknown as SwLike;
+  const cachesWith = (...names: string[]) => ({ keys: () => Promise.resolve(names) });
+
+  it('is false when this browser already holds that build cache', async () => {
+    const seen = cachesWith('document-editor-core-123', 'document-editor-runtime-v1');
+    await expect(isUnseenBuild(answering({ vendorVersion: 'v1' }), seen)).resolves.toBe(false);
+  });
+
+  it('is true when no cache here belongs to it', async () => {
+    const seen = cachesWith('document-editor-core-123', 'document-editor-runtime-v1');
+    await expect(isUnseenBuild(answering({ vendorVersion: 'v2' }), seen)).resolves.toBe(true);
+  });
+
+  it('says nothing when the waiting worker does not answer', async () => {
+    await expect(isUnseenBuild(answering(null), cachesWith('document-editor-runtime-v1'))).resolves.toBe(false);
+  });
+
+  it('says nothing when there is no runtime cache to compare against', async () => {
+    await expect(isUnseenBuild(answering({ vendorVersion: 'v2' }), cachesWith('document-editor-core-1'))).resolves.toBe(
+      false,
+    );
+  });
+});
+
+/**
+ * The silent heal. A deploy that changed the vendor tree leaves its worker
+ * waiting, nothing promotes it while a document is open, and the editor route
+ * practically always has one -- so the tab keeps being served an outgoing
+ * build whose files the deploy may have deleted. At boot there is nothing
+ * typed to lose, so it promotes and reloads without asking.
+ */
+describe('healStaleController', () => {
+  const answering = (version: Record<string, string> | null, scriptURL = 'https://edit.example/sw.js') => {
+    const posted: unknown[] = [];
+    const w = {
+      state: 'installed',
+      scriptURL,
+      addEventListener: () => {},
+      posted,
+      postMessage: (msg: unknown, transfer?: MessagePort[]) => {
+        posted.push(msg);
+        const port = transfer?.[0];
+        if (port && version) setTimeout(() => port.postMessage({ type: 'VERSION', ...version }), 0);
+      },
+    };
+    return w as typeof w & SwLike;
+  };
+  const store = () => {
+    const map = new Map<string, string>();
+    return { getItem: (k: string) => map.get(k) ?? null, setItem: (k: string, v: string) => void map.set(k, v), map };
+  };
+  const input = (over: Partial<Parameters<typeof healStaleController>[0]> = {}) => {
+    const waiting = answering({ vendorVersion: 'v2' });
+    const controller = answering({ vendorVersion: 'v1' });
+    return {
+      registration: registration(waiting as never, controller as never),
+      waiting,
+      controller,
+      hadController: true,
+      storage: store(),
+      cacheStorage: { keys: () => Promise.resolve(['document-editor-runtime-v1']) },
+      ownScriptURL: 'https://edit.example/sw.js',
+      ...over,
+    } as Parameters<typeof healStaleController>[0] & { waiting: typeof waiting; storage: ReturnType<typeof store> };
+  };
+
+  it('promotes an older build out of the way', async () => {
+    const args = input();
+    await expect(healStaleController(args)).resolves.toBe(true);
+    expect((args.waiting as unknown as { posted: unknown[] }).posted).toContainEqual(SKIP_WAITING_MESSAGE);
+  });
+
+  it('does nothing on a first install, when there is no outgoing build', async () => {
+    const args = input({ hadController: false });
+    await expect(healStaleController(args)).resolves.toBe(false);
+  });
+
+  it('does nothing when the waiting worker is the same build', async () => {
+    const waiting = answering({ vendorVersion: 'v1' });
+    const controller = answering({ vendorVersion: 'v1' });
+    await expect(
+      healStaleController({
+        registration: registration(waiting as never, controller as never),
+        waiting,
+        controller,
+        hadController: true,
+        storage: store(),
+        cacheStorage: { keys: () => Promise.resolve(['document-editor-runtime-v1']) },
+        ownScriptURL: 'https://edit.example/sw.js',
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it('leaves the vendored editor own worker alone', async () => {
+    const waiting = answering({ vendorVersion: 'v2' }, 'https://edit.example/document_editor_service_worker.js');
+    const controller = answering({ vendorVersion: 'v1' });
+    await expect(
+      healStaleController({
+        registration: registration(waiting as never, controller as never),
+        waiting,
+        controller,
+        hadController: true,
+        storage: store(),
+        cacheStorage: { keys: () => Promise.resolve(['document-editor-runtime-v1']) },
+        ownScriptURL: 'https://edit.example/sw.js',
+      }),
+    ).resolves.toBe(false);
+    expect((waiting as unknown as { posted: unknown[] }).posted).toEqual([]);
+  });
+
+  it('happens once per tab, so it can never become a reload loop', async () => {
+    const storage = store();
+    await expect(healStaleController(input({ storage }))).resolves.toBe(true);
+    expect(storage.map.get(HEAL_STORAGE_KEY)).toBe('1');
+    await expect(healStaleController(input({ storage }))).resolves.toBe(false);
+  });
+});
+
+describe('shouldReloadOnControllerChange during a heal', () => {
+  it('reloads even with a document open -- the reload is the point', () => {
+    expect(
+      shouldReloadOnControllerChange({
+        hadController: true,
+        alreadyReloading: false,
+        hasOpenDocument: true,
+        healingStaleBuild: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('never reloads over unsaved edits', () => {
+    expect(
+      shouldReloadOnControllerChange({
+        hadController: true,
+        alreadyReloading: false,
+        hasOpenDocument: true,
+        healingStaleBuild: true,
+        hasUnsavedChanges: true,
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Both of these came from a user's screenshots after the font sweep shipped.

## Refreshing did not get them the new build

A deploy whose vendored tree changed leaves its worker **waiting** -- activating
it deletes the caches the outgoing build is still reading from. The editor page
promotes it only when no document is open, and the landing page only when no
editor window is open at all. Someone who goes straight to `/editor` and keeps a
document open is therefore never asked, and reloading serves the old build back.
With that build's fonts deleted from the origin by the same deploy, their screen
stayed garbled for a day after the revert had shipped.

The page can fix this itself: the navigation is network-first, so a stale tab is
already running the new HTML and bundle -- only the vendored tree underneath is
old. `healStaleController()` promotes the waiting worker and reloads once, at
boot, **silently**: no prompt, at most once per tab (sessionStorage), never over
unsaved edits. Silence was the explicit ask; at boot there is nothing typed to
lose, so the cost is a second of loading.

### Two wrong turns worth keeping

- **The vendored editor registers a worker of its own into the same scope**
  (`/document_editor_service_worker.js`, an empty stub in this repo) from inside
  its iframe. A scope holds one registration, so the script alternates between
  ours and theirs and `registration.waiting` is almost always non-null. Whoever
  promotes a waiting worker could therefore hand the whole origin to an **empty**
  worker -- no cache-first vendor tree, an editor that can fail to load. That
  hazard predates this PR; both promotion paths now check the script URL.
- **Asking the controller which build it is** looked reasonable and was not. A
  busy worker misses the timeout, silence got read as "it is old", and tabs
  reloaded themselves mid-run. The full suite failed 2 of 138 on this branch
  while the same machine ran the baseline green; disabling the wiring made it 122
  green and two minutes faster. The evidence is local instead: sw.js names its
  runtime cache after the vendor hash, so "does this browser hold that build's
  cache" answers the question with no conversation at all. Silence now means do
  nothing.

## The home-state panel flashed during load

It is built visible and only hidden once a document takes over, and `?saved=`
adds two dynamic imports before that -- long enough on a cold load to read
"View/Edit Document / New Word / New Excel / New PowerPoint" under the spinner.
When the URL already names a document, the panel is now never painted.

## Tests, each reverse-validated

| Test | Reverse validation |
| --- | --- |
| `sw-silent-update.spec.ts` -- rewrites the vendor stamp in the served sw.js (what a real deploy does) and requires the next load to be on the new build, with no notice element | disabling the wiring leaves the tab on the old build |
| `entry-paths.spec.ts` -- samples the panel from first paint, 12 times | removing the class makes it report the paint |
| `sw-update` / `sw-register` unit cases -- script-URL guard, cache-name evidence, once-per-tab heal, reload-during-heal rules | removing each guard turns the matching case red |

Local: 1047 unit, 122 E2E, both green (same numbers as the baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)