### PR TITLE
style(landing): dress the language menu in the site's own palette

### DIFF
--- a/public/home.css
+++ b/public/home.css
@@ -129,13 +129,41 @@
 }
 #landing-hero r-select.lang-select {
   display: inline-block;
-  min-width: 84px;
+  min-width: 76px;
   font-size: 14px;
-  height: 44px;
+  /* Matches the nav links beside it (14px on space-2/space-3 padding); the
+     44px default stood a head taller than everything else in the bar. */
+  height: 34px;
 }
 /* hide the raw option list pre-upgrade; the reserved width avoids layout shift */
 #landing-hero r-select.lang-select:not(:defined) {
   visibility: hidden;
+}
+
+/* ---------- language menu (ranui r-select) ----------
+   The site's own palette applied to the component's variables. The panel is
+   portalled to <body>, so these have to be declared at the root: scoped to the
+   trigger they would style the trigger and never reach the menu.
+
+   Kept byte-identical in home.css and landing.css (the homepage does not load
+   landing.css); test/unit/design-contract.test.ts compares the two blocks. */
+:root {
+  --ran-dropdown-padding: 4px;
+  /* 10px, not the component's 12: the panel is 76px wide and two rows tall,
+     and at radius-md its corners eat into the rows inside it. */
+  --ran-dropdown-border-radius: 10px;
+  --ran-dropdown-box-shadow:
+    0 0 0 1px var(--ran-color-border), 0 8px 24px -6px color-mix(in srgb, var(--ran-color-text) 18%, transparent);
+  --ran-dropdown-option-item-padding: 6px 10px;
+  --ran-dropdown-option-item-border-radius: var(--ran-radius-sm);
+  --ran-dropdown-option-item-font-size: 14px;
+  --ran-dropdown-option-item-content-font-size: 14px;
+  --ran-dropdown-option-item-hover-background-color: var(--ran-color-bg-hover);
+  /* Selection is weight plus a neutral ground, not a blue fill: on this site
+     blue means a link, and every row of this menu is one. */
+  --ran-dropdown-option-active-background-color: var(--ran-color-bg-active);
+  --ran-dropdown-option-active-hover-background-color: var(--ran-color-bg-active);
+  --ran-dropdown-option-active-font-weight: 600;
 }
 
 /* ---------- top bar ---------- */

--- a/public/landing.css
+++ b/public/landing.css
@@ -101,13 +101,41 @@ header.bar nav a:hover {
 }
 r-select.lang-select {
   display: inline-block;
-  min-width: 84px;
+  min-width: 76px;
   font-size: 14px;
-  height: 44px;
+  /* Matches the nav links beside it (14px on space-2/space-3 padding); the
+     44px default stood a head taller than everything else in the bar. */
+  height: 34px;
 }
 /* hide the raw option list pre-upgrade; the reserved width avoids layout shift */
 r-select.lang-select:not(:defined) {
   visibility: hidden;
+}
+
+/* ---------- language menu (ranui r-select) ----------
+   The site's own palette applied to the component's variables. The panel is
+   portalled to <body>, so these have to be declared at the root: scoped to the
+   trigger they would style the trigger and never reach the menu.
+
+   Kept byte-identical in home.css and landing.css (the homepage does not load
+   landing.css); test/unit/design-contract.test.ts compares the two blocks. */
+:root {
+  --ran-dropdown-padding: 4px;
+  /* 10px, not the component's 12: the panel is 76px wide and two rows tall,
+     and at radius-md its corners eat into the rows inside it. */
+  --ran-dropdown-border-radius: 10px;
+  --ran-dropdown-box-shadow:
+    0 0 0 1px var(--ran-color-border), 0 8px 24px -6px color-mix(in srgb, var(--ran-color-text) 18%, transparent);
+  --ran-dropdown-option-item-padding: 6px 10px;
+  --ran-dropdown-option-item-border-radius: var(--ran-radius-sm);
+  --ran-dropdown-option-item-font-size: 14px;
+  --ran-dropdown-option-item-content-font-size: 14px;
+  --ran-dropdown-option-item-hover-background-color: var(--ran-color-bg-hover);
+  /* Selection is weight plus a neutral ground, not a blue fill: on this site
+     blue means a link, and every row of this menu is one. */
+  --ran-dropdown-option-active-background-color: var(--ran-color-bg-active);
+  --ran-dropdown-option-active-hover-background-color: var(--ran-color-bg-active);
+  --ran-dropdown-option-active-font-weight: 600;
 }
 
 /* ---------- article column ---------- */

--- a/test/unit/design-contract.test.ts
+++ b/test/unit/design-contract.test.ts
@@ -73,6 +73,17 @@ describe('page width scale', () => {
     expect(column, 'reading column').toBeGreaterThanOrEqual(600);
   });
 
+  it('themes the language menu identically in both stylesheets', () => {
+    // The menu panel is portalled to <body>, so its variables live at :root --
+    // and the homepage does not load landing.css, so the block exists twice.
+    // Two copies of a palette drift the moment someone tunes one of them.
+    const block = (css: string) => /:root \{([^}]*--ran-dropdown[^}]*)\}/.exec(css)?.[1]?.trim();
+    const inHome = block(home);
+    const inLanding = block(landing);
+    expect(inHome, 'home.css declares the menu palette').toBeTruthy();
+    expect(inLanding).toBe(inHome);
+  });
+
   it('bounds prose by characters, not by whatever the container happens to be', () => {
     const intro = declaration(history, '.history-intro', 'max-width');
     expect(intro).toMatch(/^\d{2}ch$/);


### PR DESCRIPTION
The open menu was ranui's default: a blue-filled selected row, a 12px
panel radius and a 44px trigger standing a head taller than the nav links
beside it. On this site blue means a link -- and every row in that menu is
one -- so selection now reads as weight plus a neutral ground.

The panel is portalled to <body>, so the variables have to sit at :root;
scoped to the trigger they would style the trigger and never reach the
menu. That also means the block exists twice (the homepage does not load
landing.css), so design-contract compares the two copies.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
