### PR TITLE
fix(safari): repair the landing-page file handoff, and make the cross-browser nightly mean something

### DIFF
--- a/.github/workflows/nightly-corpus.yml
+++ b/.github/workflows/nightly-corpus.yml
@@ -1,7 +1,19 @@
-# Nightly real-document regression matrix (docs/superpowers/plans/2026-08-15-v9-test-coverage-strategy.md,
-# section 2 tier 2 / section 6). Pulls a public corpus of real Office files
-# (never committed here), drives the real editor through open -> edit -> save
-# for each, and publishes the findings table. Red is a signal, not a gate.
+# What the pull-request gate does not cover, run on a clock instead of on a
+# diff: the PR-time specs on the two engines the gate never launches
+# (playwright.browsers.config.ts), the interaction sweeps and throttled-network
+# budgets, and the real-document matrix over a public corpus of real Office
+# files (docs/superpowers/plans/2026-08-15-v9-test-coverage-strategy.md, section
+# 2 tier 2 / section 6). Red here is a signal, not a gate.
+#
+# Two cadences, one nightly trigger (see the `gate` job):
+#   - cross-browser + sweeps run nightly. They are this repository's ONLY
+#     WebKit/Firefox coverage, and on 2026-08-25 that is what surfaced a
+#     shipped Safari defect the Chromium gate cannot see.
+#   - the corpus matrix runs on Sundays. It is 80 minutes against a corpus that
+#     never changes; what varies is this repository, and a week of it at a time
+#     is enough to keep the findings table current.
+# Neither runs when nothing has been committed since the last time it did --
+# `schedule` fires whether or not there is anything new to say.
 name: Nightly corpus
 
 on:
@@ -20,10 +32,63 @@ on:
         default: "1"
 
 jobs:
+  # Which of tonight's jobs have anything to say. Cheap (one checkout, no
+  # toolchain) and it runs every night, so the run itself is the record of why
+  # a quiet night was quiet -- a workflow that simply stops appearing is
+  # indistinguishable from one that broke.
+  gate:
+    name: What to run tonight
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      browsers: ${{ steps.decide.outputs.browsers }}
+      corpus: ${{ steps.decide.outputs.corpus }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Decide
+        id: decide
+        env:
+          MANUAL: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          age_hours=$(( ( $(date -u +%s) - $(git log -1 --format=%ct) ) / 3600 ))
+          # 1..7 with 7 = Sunday. The cron fires at 19:17 UTC, so this is the
+          # UTC weekday of the trigger, not of the Asia/Shanghai morning it
+          # lands in -- which is what the comment above the crons means.
+          weekday=$(date -u +%u)
+
+          browsers=false
+          corpus=false
+          # A cycle plus an hour of slack on each window: a commit landing just
+          # before the run it belongs to would otherwise wait a whole cycle.
+          # Written as `if` blocks rather than `a || b && c` -- that list
+          # evaluates to non-zero when both tests fail, and the step runs under
+          # `bash -e`, so a quiet night would end as a failed gate.
+          if [ "$MANUAL" = "true" ] || [ "$age_hours" -lt 25 ]; then
+            browsers=true
+          fi
+          if [ "$MANUAL" = "true" ] || { [ "$weekday" -eq 7 ] && [ "$age_hours" -lt 193 ]; }; then
+            corpus=true
+          fi
+
+          {
+            echo "HEAD is ${age_hours}h old, UTC weekday ${weekday}, manual=${MANUAL}"
+            echo ""
+            echo "- cross-browser + sweeps: ${browsers}"
+            echo "- corpus matrix: ${corpus}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "browsers=${browsers}" >> "$GITHUB_OUTPUT"
+          echo "corpus=${corpus}" >> "$GITHUB_OUTPUT"
+
   corpus:
     name: Real-document matrix (Apache POI test-data)
     runs-on: ubuntu-latest
     timeout-minutes: 300
+    needs: gate
+    if: needs.gate.outputs.corpus == 'true'
 
     steps:
       - name: Checkout code
@@ -83,6 +148,8 @@ jobs:
     name: Cross-browser (WebKit + Firefox)
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    needs: gate
+    if: needs.gate.outputs.browsers == 'true'
 
     steps:
       - name: Checkout code
@@ -96,7 +163,17 @@ jobs:
       # The same PR-time suites (minus the opt-in sweeps) on the two engines
       # the gate does not cover. Same-realm/L0 rules apply unchanged.
       - name: Run E2E on WebKit and Firefox
-        run: pnpm exec playwright test -c playwright.browsers.config.ts --grep-invert "api surface|corpus" --reporter=list
+        run: pnpm exec playwright test -c playwright.browsers.config.ts --grep-invert "api surface|corpus|@serial" --reporter=list
+
+      # The other half of that `--grep-invert`, exactly as ci.yml's e2e job
+      # pairs them: an @serial case is one that cannot share the run. Without
+      # this split sw-silent-update.spec.ts rewrites the served sw.js while
+      # other specs are being served from it, replacing THEIR worker mid-test
+      # -- which is where sw-warm's "runtime-e2e-next" and cache-first's
+      # missing sentinel came from on 2026-08-25. Without the second pass
+      # nothing runs them at all and the job stays green regardless.
+      - name: Run the cases that cannot share the run
+        run: pnpm exec playwright test -c playwright.browsers.config.ts --grep @serial --workers=1 --reporter=list
 
       - name: Upload report
         if: always()
@@ -110,6 +187,8 @@ jobs:
     name: Slow-network budgets
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: gate
+    if: needs.gate.outputs.browsers == 'true'
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,17 @@ notes. Entries describe what users experience, not internal refactors.
 
 ### Fixed
 
+- **Safari: opening a file from the homepage landed on an empty editor.** The
+  homepage hands the file you pick to the editor through this browser's own
+  storage, and Safari refuses to store a file that way -- so the editor opened
+  with nothing in it and you had to pick the same document a second time. The
+  handoff now checks that the file really arrived, and passes the contents
+  across when it did not.
+- **Safari: leaving the homepage logged errors.** The homepage quietly loads
+  the editor while you read, and whatever was still downloading when you
+  clicked was reported as a failure. The download now stops when you leave --
+  which also stops spending your connection on a page you are no longer on --
+  and picks up again if you turn out to have stayed.
 - **A new version now reaches you by itself.** An update used to wait until no
   document was open anywhere, which for anyone who goes straight to the editor
   meant never -- reloading served the same old build back, and when that build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,9 +224,10 @@ test/setup/vitest.ts          # 全局 mock：matchMedia、URL.createObjectURL�
   `CORPUS_LIMIT=<上限，截断会打印>` / `CORPUS_VISUAL=1`（L3：原始 vs 存回再
   打开的渲染逐像素比对）；每条用例结束即追加一行到
   `test-results/corpus-rows-<worker>.jsonl`，`node bin/corpus-report.mjs [dir]`
-  合并出 JSON + markdown 表（含 L2 内容、L3 视觉、open/save p50/p95）；**夜间 CI** `.github/workflows/nightly-corpus.yml`
+  合并出 JSON + markdown 表（含 L2 内容、L3 视觉、open/save p50/p95）；**CI 每周日**
+  由 `.github/workflows/nightly-corpus.yml`
   拉 Apache POI test-data 公开语料跑同一套（红=信号非门禁，可
-  workflow_dispatch 指定 limit/filter）；对目录下每个 docx/doc/xlsx/xls/pptx/ppt/csv 走
+  workflow_dispatch 随时手动触发并指定 limit/filter）；对目录下每个 docx/doc/xlsx/xls/pptx/ppt/csv 走
   打开 → 监听致命弹窗/asc_onError → 编辑 → 保存 → 产物 sanity，输出汇总
   报告。语料留在测试机上不入库；未设 `CORPUS_DIR` 整套 skip，CI 保持绿。
   第一天就抓出 P0（非 ASCII 文件名导致 -82 打开失败 + 永久转圈），见
@@ -250,6 +251,19 @@ test/setup/vitest.ts          # 全局 mock：matchMedia、URL.createObjectURL�
 复现 CF Pages 托管语义，CI job `e2e-pages`）、`playwright.browsers.config.ts`
 （WebKit + Firefox，夜间）、`playwright.prod.config.ts`（打线上/preview，
 `prod-smoke.yml` 与 PR 门禁 `preview-smoke.yml` 用）。
+
+**夜间那个 workflow 有两档节奏，且没有新提交就整晚不跑**（`nightly-corpus.yml`
+的 `gate` job，2026-08-25 起）：cross-browser + sweeps **每天**（它是本仓库唯一
+的 WebKit/Firefox 覆盖，PR 门禁全是 Chromium），corpus 矩阵**每周日**（80 分钟，
+而语料是静态的，变的是本仓库）；`workflow_dispatch` 无视这两个判断。判据是
+HEAD 的提交时间，窗口各留一个周期加一小时的余量。**gate 本身每晚都跑**——安静
+的夜晚也要留下一条 run 说明为什么安静，否则"没有 run"和"workflow 坏了"长得一样。
+**cross-browser 那个 job 必须和 ci.yml 一样把 `@serial` 分成两趟**
+（`--grep-invert "api surface|corpus|@serial"` + `--grep @serial --workers=1`）：
+`sw-silent-update.spec.ts` 靠改写被服务的 `dist/sw.js` 来模拟一次部署，那是**整个
+源站可见**的，跟别的 spec 并排跑会把它们的 worker 也换掉——2026-08-25 之前
+`sw-warm` 读到 `runtime-e2e-next`、`sw-vendor-cache-first` 找不到自己刚种下的
+哨兵，都是这个。两半必须成对，`workflow-contract.test.ts` 钉住。
 
 **L0 全局 fixture（`test/e2e/lib/l0.ts`，2026-08-15 起所有 spec 从它
 导入 `test`/`expect`）**：自动把 `asc_onError`、厂商致命弹窗、编辑器 iframe

--- a/docs/explorations/2026-08-25-cross-browser-nightly-red.md
+++ b/docs/explorations/2026-08-25-cross-browser-nightly-red.md
@@ -1,0 +1,197 @@
+# 2026-08-25 — 夜间 cross-browser 那 11 条红，是两个真 bug 加三处跑道问题
+
+`Nightly corpus` 的 `Cross-browser (WebKit + Firefox)` job 从建起来就没绿过，
+每晚 11～12 条失败、名单几乎完全一致（不是 flake，是稳定复现的欠账）。
+这次把它们全部定位、修完、验完。起点：run 32770230528。
+
+跑道：`playwright.browsers.config.ts`（webkit + firefox，workers=2，retries=1），
+本地全部用 `E2E_PORT=4176` 复现。
+
+## 一、结论先行
+
+| 类别                               | 条数 | 根因                                                                        | 归属         |
+| ---------------------------------- | ---- | --------------------------------------------------------------------------- | ------------ |
+| WebKit 落地页交接全灭              | 5    | Safari 不能把 `File`/`Blob` 结构化克隆进 IndexedDB                          | **产品缺陷** |
+| WebKit 离开落地页报 uncaught error | 1    | 预热 fetch 在 unload 时被浏览器取消，任何 `.catch` 都来不及跑               | **产品缺陷** |
+| Firefox `sw.js:336` console.error  | 3～4 | 同一件事的 Firefox 说法：被取消的请求，怪到正在应答它的 service worker 头上 | 浏览器噪声   |
+| Firefox open-retry "Error"         | 1    | Firefox 把 `console.error(err)` 交给 driver 时只剩一个 "Error"              | L0 盲点      |
+| Firefox landing-prefetch 7/8       | 1    | 断言自己把被测的东西饿死了（默认 100ms 轮询 Cache API）                     | 用例缺陷     |
+| WebKit save-to-file                | 2    | 这个引擎的 OPFS 没有 writable stream，用例的 picker stub 根本立不起来       | 引擎缺能力   |
+
+## 二、Safari 不能把 File 存进 IndexedDB（P1，线上真坏）
+
+静态落地页没有 app bundle，所以"打开文件"是：`public/open-local.js` 把选中的
+`File` 塞进 IndexedDB，跳到 `/editor?open=local`，`lib/pending-open.ts` 取出来。
+
+WebKit 实测（`put(File)` / `put(Blob)` / `put({bytes: Uint8Array})`）：
+
+```
+RESULT file  tx error: null
+RESULT blob  tx error: null
+RESULT plain ok
+```
+
+put 被接受，**事务随后以 `error === null` 失败**。于是 `stashFile` 的 reject 分支
+走 fallback，把 `open=local` 从 URL 里删掉——用户刚选完文件，落到一个空编辑器。
+`entry-paths.spec.ts` 里那条 `page.evaluate: null` 就是这个 null error 的原样。
+
+WebKit 上因此连挂 5 条：`entry-paths ?open=local`、`main-site` 两条、
+`save-to-file` 两条、`autosave-recovery`（它们都走 hero → 落地页交接）。
+
+**修法**：先按引用存 `File`，**写完读回来确认**，确认不到才读字节存
+`{ name, type, lastModified, bytes: Uint8Array }`；读侧两种形状都接受。
+
+三处都是 review 逼出来的，不是第一版：
+
+- **不能无条件读字节**。app 打开文件走的是 `createObjectURL(file)`，从不把文档读进
+  内存；无条件 `arrayBuffer()` 等于在"选完文件"和"跳转"之间插一段没有任何反馈的
+  停顿，而文件够大时它直接 reject——落到的正是这次要修的那个空编辑器。
+- **不能只信"put 没抛"**。fake-indexeddb 会把 File 静默存成 `{}` 而不是报错；真
+  Safari 是响亮地失败（`tx error: null`），但一个安静失败的引擎会绕过任何只检查写
+  入的判断，症状一模一样。读回一个引用不花什么，所以读回来确认。
+- **判型用 `ArrayBuffer.isView`** 而不是 `instanceof Uint8Array`——跨 realm 的类型化
+  数组 `instanceof` 恒 false。
+
+写侧与读侧是两个文件、靠注释维系，所以补了
+`test/unit/pending-open-handoff.test.ts`：eval 真的 `public/open-local.js`，
+用 fake-indexeddb 写进去，再用真的 `takePendingFile()` 读出来，并断言
+**存的值不是 Blob**。反向验证：把 `put(record)` 改回 `put(file)`，4 条里红 3 条。
+E2E 那条也改成调页面自己的 `__openLocal.stashFile`，不再手抄第三份形状。
+
+## 三、离开落地页时的 uncaught error（P2，Safari 控制台每次都脏）
+
+`landing-prefetch.js` 在访客读页面的整段时间里串行预热 ~34 MB。所以点 CTA 的
+那一刻几乎总有一个几 MB 的 fetch 挂着，而**浏览器**在 unload 时取消它的方式，
+两个引擎都报成错误：
+
+- WebKit：uncaught `Fetch API cannot load <url> due to access control checks.`
+- Firefox：`Failed to load '<url>'. A ServiceWorker intercepted the request and
+encountered an unexpected error.`（指着 `sw.js:336`，也就是 vendor cache-first 分支）
+
+**先证伪了两个顺手的解释**：
+
+1. "WebKit 是同步抛，所以 `.catch` 没挂上"——不是。在 `pagehide` 里探针式地调
+   `fetch()` 并立刻挂 rejection handler，三次全部 `returned-promise`，而三条
+   uncaught error 照样出现。文档先死了，微任务没机会跑，谁都接不住。
+2. "让 sw.js 的 `respondWith` 不 reject 就行"——不行。分别让它回缓存副本、回
+   合成 504、回 `Response.error()`，Firefox 那行**一字不差地照出**。它报的是
+   请求被取消，不是 worker 出错。
+
+**能修的只有一件事：别让浏览器来取消，我们自己先取消。** `beforeunload` /
+`pagehide` 时 abort（`AbortController`），rejection 在文档还活着的时候被 `.catch`
+接住。WebKit 实测由 5 条 pageerror 变 0 条；Firefox 大幅减少但仍有残留（abort 和
+unload 抢时序），所以那条消息进 L0 白名单。
+
+**`beforeunload` 是必需的，`pagehide` 太晚。** review 提出 `beforeunload` 对**没有
+发生的导航**也会触发（外部 scheme、下载链接、被取消的 unload），而 `stopWarming`
+是一扇单向门——访客继续读着这一页，预热已经悄悄永久关掉了。改成只挂 `pagehide`
+之后实测：WebKit 那 5 条 uncaught error 全回来了。所以正确的答案不是换事件，是
+**把这扇门做成双向**：`pointerdown` / `keydown` / `scroll` / bfcache 恢复，任何一个
+"文档还在被用"的信号都重新开始预热（真的走掉了它们就再也不会触发）。
+刻意不用定时器：慢导航会让它恰好在 unload 前触发，把刚取消的请求又发一遍。
+
+顺带这也是对的行为：不再为一个正在离开的页面烧带宽。
+
+`test/unit/landing-prefetch.test.ts` 钉住：每个请求都带 signal、`beforeunload`
+之后在飞的被 abort 且不再排新的、bfcache 回来恢复。反向验证：去掉那两行
+listener，该条立刻红。
+
+## 四、L0 的两个盲点
+
+1. **Firefox 把 `console.error(new Error(...))` 交出来只剩 "Error"**——消息在参数
+   对象里，而那个 frame 通常正在被拆（open-retry 就是编辑器 iframe 报完就重建），
+   `jsHandle.evaluate` 拿不到（实测 `Execution context was destroyed`）。于是
+   `open-retry.spec.ts` 明明写了 `l0.allowConsole(/Document conversion failed/)`，
+   却匹配不到自己注入的那个故障。修法：init script 里包一层 `console.error`，
+   把 Error 参数在**调用点**转成 `name: message`，所有引擎一致。
+2. **被取消的请求**：Chromium 的 `net::ERR_` 早就在白名单里，Firefox 的
+   `A ServiceWorker intercepted the request` 是同一类东西，补进去，并把上面
+   三次证伪写在注释里。
+
+## 五、断言把被测的东西饿死了
+
+`landing-prefetch.spec.ts` 两处 `expect.poll(..., { timeout: 180_000 })` 用的是
+Playwright 默认的 100ms 起步节奏，而每次轮询都要 `caches.keys()` + 每个 cache
+`keys()`。Firefox 上这把 worker 自己那次 9.4 MB 的 `cache.put` 挤到永远做不完：
+整整 180 秒卡在 7/8。改成 `intervals: [1000]`，同一台机器上 3 秒就到 8/8。
+
+（同一个文件里另一条早就写了"polled, not asserted outright"的注释——这次是同
+一个坑的第二种形态：不是"问得太早"，是"问得太密"。）
+
+## 六、WebKit 没有 OPFS writable stream
+
+`save-to-file.spec.ts` 的 picker stub 发的是真的 origin-private file handle，
+所以整条用例依赖 `createWritable()`。这个引擎上它对**任何** payload 都 reject：
+
+```
+file: FAIL UnknownError   blob: FAIL UnknownError   u8: FAIL UnknownError
+ab:   FAIL UnknownError   str:  FAIL UnknownError
+```
+
+写失败 → `saveToDiskFile` 返回 `unavailable` → 回落到下载 → ranuts 的
+`saveFileToDisk` 又去开一次 picker，于是 `pickerCalls` 是 2 不是 1（两条调用栈
+一条在 `save-target`、一条在 `input-*.js`，这才看清）。
+
+真 Safari 根本没有 `showSaveFilePicker`，`canWriteToDisk()` 为 false，整个功能
+按设计回落到下载——**产品侧没有 bug**。用例改成运行时探测能力后 skip，而不是
+按浏览器名写死：WebKit 哪天补上 writable stream，它自己就开始跑。
+
+## 七、两处"导航把 evaluate 掀了"的竞态（CI 里一直标 flaky）
+
+同一份名单里还有两条常年 flaky、这次有一条两次重试都没过的：
+
+1. `embed-api.spec.ts` 的三条 postMessage 用例。`page.goto('/?embed=1')` 在
+   落地页自己 load 完就 resolve 了，而那些 embed 参数会让它**接着**跳到
+   `/editor`；`page.evaluate` 起在这条缝里就是
+   `Execution context was destroyed`。WebKit 输这场比赛的次数比 Chromium 多，
+   但竞态不是 WebKit 的。补了个 `openEmbed()`，goto 之后 `waitForURL(/\/editor/)`。
+2. `sw-vendor-cache-first.spec.ts` 挂在 `waitForEditorReady` 里。这次是
+   **产品功能正常工作被报成失败**：`lib/sw-update.ts` 的 `healStaleController()`
+   会把跑在本机没跑过的构建上的标签页悄悄 reload 一次，冷 profile 上每次首访
+   都会发生。改法是让 `waitForEditorReady` 容忍一次导航——捕获这个错误、在同一
+   个 deadline 内到新文档上重来，而不是在每条用例里绕。
+
+## 八、验证
+
+- 单测 51 files / 2709 passed，两条新用例都做了反向验证（见上）。
+- Chromium 全量 E2E：151 passed / 16 skipped，绿。
+- 之前失败的 8 个 spec 在 webkit+firefox 上：62 passed / 2 skipped，绿。
+- 夜间那条完整命令本地跑了三轮：修完前 11 failed / 4 flaky；只剩两条竞态时
+  2 failed / 1 flaky / 281 passed；竞态修完后 0 failed / 2 flaky / 282 passed，
+  那 2 条 flaky 就是第九节那个 `@serial` 并发问题；拆成两趟之后全绿。
+
+## 九、顺手把这个 workflow 的节奏改了
+
+修完之后回头看这个 job 值不值得每天跑。结论是值得，但它当时的形态确实在浪费
+注意力（仓库是公开的，runner 免费，花掉的不是钱）：
+
+- **它是本仓库唯一的非 Chromium 覆盖**。分支保护的 6 个必需检查全跑 Chromium，
+  Safari 和 Firefox 一条都不测。今天这个 Safari 缺陷已经在线上躺着了，正常 PR
+  流程永远发现不了。所以 cross-browser + sweeps 保持每天。
+- **corpus 改成每周日**。它 80 分钟，拉的是**静态**的 Apache POI 语料，产出的
+  表几乎每晚一样；变的是本仓库，一周一次足够。
+- **没有新提交就整晚不跑**。`schedule` 不管有没有改动都会触发。加了一个
+  `gate` job 按 HEAD 的提交时间决定今晚跑什么，两个窗口各留一个周期加一小时
+  的余量，`workflow_dispatch` 无视这两个判断。
+- **gate 本身每晚都跑**（一次 checkout，不装工具链）。安静的夜晚也要留下一条
+  run 说明为什么安静——否则"没有 run"和"workflow 坏了"在列表里长得一样。
+
+判据那两行刻意写成 `if` 块而不是 `a || b && c`：后者在两个判断都为假时整体
+返回非零，而 step 跑在 `bash -e` 下，于是一个安静的夜晚会以 gate 失败收场。
+真值表在本地过了一遍（fresh/stale × 周三/周日 × manual）。
+
+顺带修掉了最后两条 flaky，它们是同一个根因：**`sw-silent-update.spec.ts` 靠改写
+被服务的 `dist/sw.js` 来模拟一次部署，那是整个源站可见的**。它自己早就标了
+`@serial` 并把这个危险写在文件头，但**夜间那个 job 从来没做 `@serial` 分离**——
+`ci.yml` 的 e2e job 做了，它没做。于是它并排跑的时候把别人的 worker 也换掉：
+`sw-warm` 读到 `document-editor-runtime-e2e-next`，`sw-vendor-cache-first` 找不到
+自己刚种下的哨兵（1296 字节的真文件，不是 sentinel）。补上 `--grep-invert` +
+`--grep @serial --workers=1` 两趟，`workflow-contract.test.ts` 把这一对钉住
+（两半各自反向验证过：去掉任意一半，该条变红）。
+
+## 十、同一晚 corpus job 的 5 条红（未修，是信号不是门禁）
+
+`47950_lower.doc` / `47950_upper.doc` / `Bug51944.doc` /
+`2100a8d44da…ppt` 打不开（-82，x2t 读不了这几个老二进制格式），
+`Bugs 184 deep-table-cell.docx` 把渲染进程压崩（`Target crashed`）。
+这些是引擎能力问题，属于 v9 回归战役方向零的台账，本次不动。

--- a/lib/pending-open.ts
+++ b/lib/pending-open.ts
@@ -1,10 +1,63 @@
 // Consume a file handed off by a static landing page (public/open-local.js):
-// the page stashes the picked File in IndexedDB and navigates to the app with
-// `?open=local`; the app takes the file out (one-shot) and opens it. The DB /
-// store / key names here must stay in sync with public/open-local.js.
+// the page stashes the picked file in IndexedDB and navigates to the app with
+// `?open=local`; the app takes it out (one-shot) and opens it. The DB / store /
+// key names here must stay in sync with public/open-local.js.
 const DB_NAME = 'document-handoff';
 const STORE = 'files';
 const KEY = 'pending';
+
+/**
+ * What is actually stored: the bytes plus the File fields the app needs back.
+ *
+ * A File cannot be the stored value. Safari fails the whole transaction (with
+ * a null error) when asked to structured-clone a File or a Blob into
+ * IndexedDB, which broke the handoff outright there -- the landing page took
+ * its "IndexedDB unavailable" fallback and dropped the file the visitor had
+ * just picked. This shape clones on every engine; public/open-local.js writes
+ * it and this module rebuilds the File from it.
+ */
+type PendingRecord = {
+  name: string;
+  type: string;
+  lastModified: number;
+  bytes: Uint8Array | ArrayBuffer;
+};
+
+// Duck-typed rather than `instanceof`: the value comes back out of a
+// structured clone, and a typed array that crossed a realm boundary answers
+// `false` to `instanceof Uint8Array` while being perfectly usable.
+const isBytes = (value: unknown): value is Uint8Array | ArrayBuffer =>
+  ArrayBuffer.isView(value) || (typeof ArrayBuffer !== 'undefined' && value instanceof ArrayBuffer);
+
+const isPendingRecord = (value: unknown): value is PendingRecord =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as PendingRecord).name === 'string' &&
+  isBytes((value as PendingRecord).bytes);
+
+/**
+ * Turn a stored value back into a File.
+ *
+ * Still accepts a bare File: a landing page cached before this change writes
+ * one, and the visitor who picked a file on it deserves to have it opened
+ * rather than silently dropped.
+ */
+const toFile = (value: unknown): File | null => {
+  if (value instanceof File) return value;
+  if (!isPendingRecord(value)) return null;
+  const view = value.bytes;
+  const bytes: Uint8Array<ArrayBuffer> = ArrayBuffer.isView(view)
+    ? new Uint8Array(view.buffer as ArrayBuffer, view.byteOffset, view.byteLength)
+    : new Uint8Array(view);
+  return new File([bytes], value.name, { type: value.type, lastModified: value.lastModified });
+};
+
+const toRecord = async (file: File): Promise<PendingRecord> => ({
+  name: file.name,
+  type: file.type,
+  lastModified: file.lastModified,
+  bytes: new Uint8Array(await file.arrayBuffer()),
+});
 
 /**
  * Stash a picked file for the editor to take on boot, then the caller
@@ -13,12 +66,55 @@ const KEY = 'pending';
  * page that deliberately does not load the editor bundle, so it cannot open a
  * file itself), and the DB/store/key names belong to this module.
  */
-export const stashPendingFile = (file: File): Promise<boolean> => {
-  return new Promise((resolve) => {
-    if (typeof indexedDB === 'undefined') {
-      resolve(false);
+export const stashPendingFile = async (file: File): Promise<boolean> => {
+  if (typeof indexedDB === 'undefined') return false;
+  // By reference first, bytes only if the store will not keep a File, and the
+  // write is confirmed rather than trusted -- the same decision, spelled out,
+  // in public/open-local.js.
+  if ((await put(file)) && (await peek()) instanceof Blob) return true;
+  try {
+    return await put(await toRecord(file));
+  } catch {
+    return false;
+  }
+};
+
+/** Whatever is under the handoff key right now. Null when it cannot be read. */
+const peek = (): Promise<unknown> =>
+  new Promise((resolve) => {
+    let req: IDBOpenDBRequest;
+    try {
+      req = indexedDB.open(DB_NAME, 1);
+    } catch {
+      resolve(null);
       return;
     }
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(STORE);
+    };
+    req.onerror = () => resolve(null);
+    req.onsuccess = () => {
+      const db = req.result;
+      try {
+        const read = db.transaction(STORE, 'readonly').objectStore(STORE).get(KEY);
+        read.onsuccess = () => {
+          db.close();
+          resolve(read.result);
+        };
+        read.onerror = () => {
+          db.close();
+          resolve(null);
+        };
+      } catch {
+        db.close();
+        resolve(null);
+      }
+    };
+  });
+
+/** Put one value under the handoff key. Resolves false rather than throwing. */
+const put = (value: File | PendingRecord): Promise<boolean> =>
+  new Promise((resolve) => {
     let req: IDBOpenDBRequest;
     try {
       req = indexedDB.open(DB_NAME, 1);
@@ -34,7 +130,7 @@ export const stashPendingFile = (file: File): Promise<boolean> => {
       const db = req.result;
       try {
         const tx = db.transaction(STORE, 'readwrite');
-        tx.objectStore(STORE).put(file, KEY);
+        tx.objectStore(STORE).put(value, KEY);
         tx.oncomplete = () => {
           db.close();
           resolve(true);
@@ -49,7 +145,6 @@ export const stashPendingFile = (file: File): Promise<boolean> => {
       }
     };
   });
-};
 
 /** Read and delete the pending handoff file. Resolves null when there is none
  *  (stale `?open=local` URL, reload after consumption) or IndexedDB is unusable. */
@@ -83,7 +178,7 @@ export const takePendingFile = (): Promise<File | null> => {
           store.delete(KEY);
           tx.oncomplete = () => {
             db.close();
-            resolve(value instanceof File ? value : null);
+            resolve(toFile(value));
           };
         };
         get.onerror = () => {

--- a/public/landing-prefetch.js
+++ b/public/landing-prefetch.js
@@ -79,15 +79,80 @@
   }
 
   /**
+   * Stop warming when the visitor leaves, and cancel what is still in flight.
+   *
+   * Not an optimisation -- a correctness fix for what the browser does to a
+   * request IT cancels at unload. The warm-up runs for the whole time the page
+   * is being read, so there is nearly always a multi-MB fetch open when the
+   * call to action is finally clicked, and that fetch fails in a way no
+   * handler can catch: Safari raises an uncaught "Fetch API cannot load <url>
+   * due to access control checks" (probed 2026-08-25 -- fetch() returns a
+   * promise normally and a rejection handler IS attached; the document simply
+   * dies before the microtask can run), and Firefox blames the service worker
+   * that was answering it, logging "A ServiceWorker intercepted the request
+   * and encountered an unexpected error". One line per file still queued, in
+   * the console of a page the visitor is leaving.
+   *
+   * Cancelling first, while the document is still alive, lets the rejection
+   * reach the `.catch` below -- and stops spending a leaving visitor's
+   * bandwidth on bytes their next page will not have time to use.
+   */
+  var leaving = false;
+  var aborter = typeof AbortController === 'function' ? new AbortController() : null;
+
+  function newAborter() {
+    return typeof AbortController === 'function' ? new AbortController() : null;
+  }
+
+  function stopWarming() {
+    if (leaving) return;
+    leaving = true;
+    if (aborter) aborter.abort();
+  }
+
+  function resumeWarming() {
+    if (!leaving) return;
+    leaving = false;
+    aborter = newAborter();
+    startBackgroundWarmUp();
+  }
+
+  // `beforeunload` and not just `pagehide`: measured on WebKit, pagehide is
+  // already too late -- the uncaught errors this exists to prevent come back.
+  window.addEventListener('beforeunload', stopWarming);
+  window.addEventListener('pagehide', stopWarming);
+
+  // Stopping must not be a one-way door. `beforeunload` also fires for a
+  // navigation that never happens (an external scheme, a download link, an
+  // unload the visitor cancels), and without a way back the visitor would
+  // carry on reading a page that has quietly stopped warming -- so the editor
+  // they open next is cold for no reason. Any sign the document is still being
+  // used picks it up again; on a navigation that does go through, none of
+  // these fire again. Deliberately not a timer: a slow navigation would let it
+  // fire just before unload and restart the very requests we cancelled.
+  ['pointerdown', 'keydown', 'scroll'].forEach(function (event) {
+    window.addEventListener(event, resumeWarming, { passive: true });
+  });
+  // Restored from the back/forward cache: same situation, different signal.
+  window.addEventListener('pageshow', function (event) {
+    if (event.persisted) resumeWarming();
+  });
+
+  /**
    * Fetch through the service worker so the response is stored in ITS cache.
    * A `<link rel=prefetch>` would only populate the HTTP cache, and the worker
    * serves the vendored tree cache-first -- a miss there re-requests the file
    * even when the browser still holds a copy.
    */
   function warm(url) {
+    if (leaving) return Promise.resolve();
     if (requested[url]) return Promise.resolve();
     requested[url] = true;
-    return fetch(url, { credentials: 'same-origin', priority: 'low' })
+    return fetch(url, {
+      credentials: 'same-origin',
+      priority: 'low',
+      signal: aborter ? aborter.signal : undefined,
+    })
       .then(drain)
       .catch(function () {
         // A warm-up failure must stay invisible: the real load will just be cold.
@@ -250,6 +315,11 @@
     CORE: CORE,
     ENGINES: ENGINES,
     formatUrls: formatUrls,
+    warm: warm,
+    stopWarming: stopWarming,
+    isLeaving: function () {
+      return leaving;
+    },
     warmSerially: warmSerially,
     warmEverything: warmEverything,
   };

--- a/public/open-local.js
+++ b/public/open-local.js
@@ -11,7 +11,8 @@
   var STORE = 'files';
   var KEY = 'pending';
 
-  function stashFile(file) {
+  /** Put one value under the handoff key, resolving when the write commits. */
+  function put(value) {
     return new Promise(function (resolve, reject) {
       var req = indexedDB.open(DB_NAME, 1);
       req.onupgradeneeded = function () {
@@ -23,7 +24,13 @@
       req.onsuccess = function () {
         var db = req.result;
         var tx = db.transaction(STORE, 'readwrite');
-        tx.objectStore(STORE).put(file, KEY);
+        try {
+          tx.objectStore(STORE).put(value, KEY);
+        } catch (error) {
+          db.close();
+          reject(error);
+          return;
+        }
         tx.oncomplete = function () {
           db.close();
           resolve();
@@ -35,6 +42,94 @@
       };
     });
   }
+
+  // The bytes plus the three fields a File carries that the app needs back.
+  // Read lazily -- see stashFile.
+  function toRecord(file) {
+    return file.arrayBuffer().then(function (buffer) {
+      return {
+        name: file.name,
+        type: file.type,
+        lastModified: file.lastModified,
+        bytes: new Uint8Array(buffer),
+      };
+    });
+  }
+
+  /** Read back whatever is under the handoff key. */
+  function get() {
+    return new Promise(function (resolve, reject) {
+      var req = indexedDB.open(DB_NAME, 1);
+      req.onupgradeneeded = function () {
+        req.result.createObjectStore(STORE);
+      };
+      req.onerror = function () {
+        reject(req.error);
+      };
+      req.onsuccess = function () {
+        var db = req.result;
+        var read = db.transaction(STORE, 'readonly').objectStore(STORE).get(KEY);
+        read.onsuccess = function () {
+          db.close();
+          resolve(read.result);
+        };
+        read.onerror = function () {
+          db.close();
+          reject(read.error);
+        };
+      };
+    });
+  }
+
+  /**
+   * Hand the picked file to the app, by reference where that is possible.
+   *
+   * The File goes in first because storing it costs nothing: it is a reference
+   * to bytes already on disk, and the app opens it with createObjectURL
+   * without ever reading it into memory. Only if the store will not keep a
+   * File is the document read -- doing that unconditionally would put a stall
+   * between the file dialog and the navigation for every visitor, and on a
+   * large enough file `arrayBuffer()` rejects, landing on the exact empty
+   * editor this is here to prevent.
+   *
+   * The write is CONFIRMED rather than trusted, because "it did not throw" is
+   * not the same as "the file is in there". Safari refuses loudly -- it cannot
+   * structured-clone a File or a Blob into IndexedDB, and it says so by
+   * accepting the put and then failing the transaction with a null error,
+   * which is what left the handoff silently broken there: the landing page
+   * took its "IndexedDB unavailable" fallback and the visitor arrived at an
+   * empty editor holding nothing of what they had just picked. An engine that
+   * refuses QUIETLY, keeping an empty object where the File went, would
+   * reproduce the same symptom past any check of the write alone. Reading a
+   * reference back costs nothing.
+   *
+   * lib/pending-open.ts reads both shapes back.
+   */
+  function stashBytes(file) {
+    return toRecord(file).then(put);
+  }
+
+  function stashFile(file) {
+    // Two-argument `then`, not `.catch`: a `.catch` hung off the end would
+    // also catch the fallback failing and run it a second time, reading the
+    // document into memory twice over on the one path where memory is already
+    // the thing going wrong.
+    return put(file)
+      .then(get)
+      .then(
+        function (stored) {
+          return stored instanceof Blob ? undefined : stashBytes(file);
+        },
+        function () {
+          return stashBytes(file);
+        },
+      );
+  }
+
+  // Test hook: test/unit/pending-open-handoff.test.ts drives the stash and
+  // reads it back through lib/pending-open.ts, which is the only way the two
+  // halves of the record shape stay pinned to each other.
+  window.__openLocal = { stashFile: stashFile, DB_NAME: DB_NAME, STORE: STORE, KEY: KEY };
 
   document.addEventListener('DOMContentLoaded', function () {
     var buttons = document.querySelectorAll('[data-open-local]');

--- a/test/e2e/actions/editor.ts
+++ b/test/e2e/actions/editor.ts
@@ -33,6 +33,26 @@ export async function waitForEditorReady(
   page: Page,
   timeoutMs = 120_000,
 ): Promise<{ kind: EditorKind; loadMs: number }> {
+  const deadline = Date.now() + timeoutMs;
+  // The page under test is allowed to reload itself exactly once while this is
+  // waiting, and does: lib/sw-update.ts quietly moves a tab off a build this
+  // browser has not run before, which on a cold profile is every first visit.
+  // The evaluate below dies with "Execution context was destroyed" when that
+  // lands mid-wait -- a shipped feature working, reported as a test failure
+  // (sw-vendor-cache-first flaked on it night after night). Start over on the
+  // new document instead, within the same deadline.
+  for (;;) {
+    try {
+      return await evaluateEditorReady(page, Math.max(0, deadline - Date.now()));
+    } catch (error) {
+      const destroyed = /Execution context was destroyed/.test(String((error as Error)?.message ?? error));
+      if (!destroyed || Date.now() >= deadline) throw error;
+      await page.waitForLoadState('domcontentloaded');
+    }
+  }
+}
+
+function evaluateEditorReady(page: Page, timeoutMs: number): Promise<{ kind: EditorKind; loadMs: number }> {
   return page.evaluate(async (timeoutMs) => {
     const t0 = Date.now();
     const findSdk = (): { api: any; win: any } | null => {

--- a/test/e2e/embed-api.spec.ts
+++ b/test/e2e/embed-api.spec.ts
@@ -8,6 +8,21 @@ import { expect, test } from './lib/l0';
 // observe these messages.
 // ---------------------------------------------------------------------------
 
+/**
+ * Open the embedded editor and wait until it is the document being talked to.
+ *
+ * `/` is the static landing page; the embed query strings make it redirect to
+ * `/editor`, and `page.goto` resolves on the landing page's own load -- before
+ * that redirect. A `page.evaluate` started in the gap dies with "Execution
+ * context was destroyed, most likely because of a navigation", which is what
+ * made three of these tests flake on WebKit night after night (it loses the
+ * race more often than Chromium, but the race is not WebKit's).
+ */
+const openEmbed = async (page: import('@playwright/test').Page, query = 'embed=1'): Promise<void> => {
+  await page.goto(`/?${query}`);
+  await page.waitForURL(/\/editor/);
+};
+
 test.describe('embed mode activation', () => {
   test('adds embed-mode class to body when ?embed=1 is present', async ({ page }) => {
     await page.goto('/?embed=1');
@@ -42,7 +57,7 @@ test.describe('postMessage API', () => {
       });
     });
 
-    await page.goto('/?embed=1');
+    await openEmbed(page);
     // Give a tick for async postMessage dispatch
     await page.waitForTimeout(200);
 
@@ -51,7 +66,7 @@ test.describe('postMessage API', () => {
   });
 
   test('responds to document:get-state with readonly and hasDocument flags', async ({ page }) => {
-    await page.goto('/?embed=1');
+    await openEmbed(page);
 
     const response = await page.evaluate(
       () =>
@@ -71,7 +86,7 @@ test.describe('postMessage API', () => {
   });
 
   test('document:set-readonly changes readonly state', async ({ page }) => {
-    await page.goto('/?embed=1');
+    await openEmbed(page);
 
     // Query initial state
     const before = await page.evaluate(
@@ -105,7 +120,7 @@ test.describe('postMessage API', () => {
     // page.evaluate postMessage has origin http://127.0.0.1:4173 (same origin),
     // which does NOT match the allowed 'https://allowed.example.com',
     // so the message handler should be skipped and no response received.
-    await page.goto('/?embed=1&embedOrigin=https://allowed.example.com');
+    await openEmbed(page, 'embed=1&embedOrigin=https://allowed.example.com');
 
     const blocked = await page.evaluate(
       () =>

--- a/test/e2e/entry-paths.spec.ts
+++ b/test/e2e/entry-paths.spec.ts
@@ -106,7 +106,10 @@ test.describe('entry paths (real editor)', () => {
   });
 
   test('?open=local consumes the file a static landing page stashed in IndexedDB', async ({ page }) => {
-    // Same DB/store/key names as public/open-local.js and lib/pending-open.ts.
+    // Stashed by the landing page's own writer (public/open-local.js), not by
+    // a copy of it: the record shape is a contract between that file and
+    // lib/pending-open.ts, and a third hand-written copy here would drift and
+    // still pass. test/unit/pending-open-handoff.test.ts pins the two halves.
     await page.goto('/zh-CN/');
     await page.evaluate(async (b64) => {
       const bin = atob(b64);
@@ -115,21 +118,9 @@ test.describe('entry paths (real editor)', () => {
       const file = new File([bytes], '落地页交接.docx', {
         type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
       });
-      await new Promise<void>((resolve, reject) => {
-        const req = indexedDB.open('document-handoff', 1);
-        req.onupgradeneeded = () => req.result.createObjectStore('files');
-        req.onerror = () => reject(req.error);
-        req.onsuccess = () => {
-          const db = req.result;
-          const tx = db.transaction('files', 'readwrite');
-          tx.objectStore('files').put(file, 'pending');
-          tx.oncomplete = () => {
-            db.close();
-            resolve();
-          };
-          tx.onerror = () => reject(tx.error);
-        };
-      });
+      await (window as unknown as { __openLocal: { stashFile: (f: File) => Promise<void> } }).__openLocal.stashFile(
+        file,
+      );
     }, Buffer.from(DOC).toString('base64'));
     await page.goto('/?locale=zh-CN&open=local');
     await settleEditor(page);

--- a/test/e2e/landing-prefetch.spec.ts
+++ b/test/e2e/landing-prefetch.spec.ts
@@ -96,7 +96,15 @@ test.describe('landing page warm-up', () => {
     }
 
     // No hover, no click: this is the background layer doing its job.
-    await expect.poll(async () => (await cachedPaths(page, core)).length, { timeout: 180_000 }).toBe(core.length);
+    //
+    // Polled once a second, not at Playwright's default 100 ms. Reading the
+    // cache is not free and it contends with the writer: on Firefox a poll at
+    // the default rate kept the worker's put of the last (9.4 MB) core file
+    // from ever completing, and the assertion sat at 7 of 8 for its whole
+    // three-minute budget. Slowing the observer down makes it land in seconds.
+    await expect
+      .poll(async () => (await cachedPaths(page, core)).length, { timeout: 180_000, intervals: [1000] })
+      .toBe(core.length);
   });
 
   /**
@@ -148,7 +156,10 @@ test.describe('landing page warm-up', () => {
     await expect(page.locator('#landing-hero')).toBeVisible();
     await page.evaluate(() => navigator.serviceWorker.ready);
     const core = await page.evaluate(() => (window as any).__landingPrefetch.CORE as string[]);
-    await expect.poll(async () => (await cachedPaths(page, core)).length, { timeout: 180_000 }).toBe(core.length);
+    // Once a second, for the reason spelled out in the test above.
+    await expect
+      .poll(async () => (await cachedPaths(page, core)).length, { timeout: 180_000, intervals: [1000] })
+      .toBe(core.length);
 
     // Warm the engines too, then watch what still leaves the page.
     await page.evaluate(() => (window as any).__landingPrefetch.warmEverything());

--- a/test/e2e/lib/l0.ts
+++ b/test/e2e/lib/l0.ts
@@ -42,6 +42,14 @@ const CONSOLE_ALLOWLIST: RegExp[] = [
   // e.g. when an editor iframe is torn down while its toolbar sprite is
   // still streaming; the same file decodes fine (probed 2026-08-15).
   /Image corrupt or truncated/,
+  // Firefox's wording for a request the BROWSER cancelled while a service
+  // worker was answering it -- a navigation away while the landing page's
+  // warm-up or an editor asset is still streaming. It says nothing about the
+  // worker: probed 2026-08-25 with sw.js answering the same cancelled request
+  // from cache, with a synthetic 504 and with Response.error(), and the line
+  // appears identically in all three. Chromium's equivalent (net::ERR_ABORTED)
+  // is already allowed above.
+  /A ServiceWorker intercepted the request/,
 ];
 
 const FATAL_DIALOG_PATTERN = /error occurred during the work|与文档工作|критическ/i;
@@ -69,6 +77,16 @@ const INIT_SCRIPT = () => {
   window.addEventListener('unhandledrejection', (event) => {
     bucket.frameErrors.push({ kind: 'unhandledrejection', message: describe(event.reason), href: location.pathname });
   });
+  // Firefox hands `console.error(someError)` to the driver as the bare word
+  // "Error" -- the message lives in the argument object, and by the time it
+  // could be resolved the frame that logged it is usually gone (the editor
+  // iframe is torn down as part of the very failure being reported). An
+  // allowlist cannot match what it cannot see, so the vendor's own logging of
+  // a fault a test deliberately injected read as an unexplained "Error" and
+  // failed it. Stringify at the call site instead, on every engine.
+  const nativeConsoleError = console.error.bind(console);
+  console.error = (...args: unknown[]) =>
+    nativeConsoleError(...args.map((arg) => (arg instanceof Error ? `${arg.name}: ${arg.message}` : arg)));
   window.addEventListener('error', (event) => {
     const err = event.error as { stack?: unknown } | undefined;
     const stack =

--- a/test/e2e/save-to-file.spec.ts
+++ b/test/e2e/save-to-file.spec.ts
@@ -145,6 +145,31 @@ test.describe('saving into the document own file (real editor)', () => {
 
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(stubPicker);
+
+    // The stub hands out a real origin-private file handle, so this spec needs
+    // OPFS writable streams. WebKit has the handles but not the streams --
+    // `createWritable().write(x)` rejects with UnknownError for every payload
+    // shape (File, Blob, Uint8Array, ArrayBuffer, string; probed 2026-08-25).
+    // Nothing to fix on our side: saving to the document's own file is
+    // Chromium-only by design (Safari has no showSaveFilePicker at all,
+    // Firefox has said it will not add one) and falls back to a download
+    // everywhere else. Probed rather than keyed to the browser name so the
+    // spec starts running by itself if WebKit ships the streams.
+    await page.goto('/');
+    const writableStreams = await page.evaluate(async () => {
+      try {
+        const root = await navigator.storage.getDirectory();
+        const handle = await root.getFileHandle('probe.bin', { create: true });
+        const stream = await handle.createWritable();
+        await stream.write(new Uint8Array([1]));
+        await stream.close();
+        await root.removeEntry('probe.bin');
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    test.skip(!writableStreams, 'this engine has no origin-private writable streams to stub the picker with');
   });
 
   test('picks a file once, then writes to it on every later save', async ({ page }) => {

--- a/test/unit/landing-prefetch.test.ts
+++ b/test/unit/landing-prefetch.test.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+/**
+ * public/landing-prefetch.js -- the landing page's editor warm-up.
+ *
+ * The shipped file is evaluated here rather than reimplemented; a hand-copied
+ * version would only test the copy.
+ *
+ * What is worth pinning down here is what happens when the visitor finally
+ * clicks: the warm-up runs for the whole time the page is read, so a multi-MB
+ * fetch is nearly always open at that moment, and a request the browser
+ * cancels at unload is reported as an error nobody can catch -- an uncaught
+ * "Fetch API cannot load <url> due to access control checks" on Safari, a
+ * service worker blamed for "an unexpected error" on Firefox. Cancelling
+ * first, while the page is still alive, is what keeps that quiet.
+ */
+type Prefetch = {
+  CORE: string[];
+  ENGINES: string[];
+  warm: (url: string) => Promise<unknown>;
+  warmSerially: (urls: string[]) => Promise<unknown>;
+  stopWarming: () => void;
+  isLeaving: () => boolean;
+};
+
+let prefetch: Prefetch;
+
+const okResponse = () => ({ body: null, arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)) });
+
+/** The RequestInit `warm()` passed on call `n`. */
+const initOf = (mock: { mock: { calls: unknown[][] } }, n = 0): RequestInit => mock.mock.calls[n][1] as RequestInit;
+
+/** Come back from the back/forward cache, so later tests warm again. */
+const restore = () => {
+  const event = new Event('pageshow') as Event & { persisted: boolean };
+  Object.defineProperty(event, 'persisted', { value: true });
+  window.dispatchEvent(event);
+};
+
+beforeAll(() => {
+  const src = readFileSync(resolve(__dirname, '../../public/landing-prefetch.js'), 'utf8');
+  // The file is an IIFE over `window`; in jsdom that is this realm's global.
+  new Function(src).call(globalThis);
+  prefetch = (globalThis as unknown as { __landingPrefetch: Prefetch }).__landingPrefetch;
+  expect(typeof prefetch?.warm).toBe('function');
+});
+
+describe('landing page warm-up', () => {
+  it('survives a fetch that fails: the real load is just cold', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new Error('offline'))),
+    );
+    await expect(prefetch.warm('/rejects.js')).resolves.toBeUndefined();
+    vi.unstubAllGlobals();
+  });
+
+  it('hands every request an abort signal', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(okResponse()));
+    vi.stubGlobal('fetch', fetchMock);
+    await prefetch.warm('/signalled.js');
+    const init = initOf(fetchMock);
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    expect(init.signal!.aborted).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  /**
+   * Reverse-verified: with the unload listeners removed, the queued file below
+   * is still requested and the in-flight signal never aborts -- which is
+   * precisely the state that produces the uncaught errors.
+   */
+  it('cancels in flight requests and stops queueing new ones once the page is leaving', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(okResponse()));
+    vi.stubGlobal('fetch', fetchMock);
+    await prefetch.warm('/in-flight.js');
+    const init = initOf(fetchMock);
+
+    window.dispatchEvent(new Event('beforeunload'));
+    expect(prefetch.isLeaving()).toBe(true);
+    expect(init.signal!.aborted, 'the open request is cancelled while the page can still handle it').toBe(true);
+
+    fetchMock.mockClear();
+    await prefetch.warmSerially(['/queued-a.js', '/queued-b.js']);
+    expect(fetchMock, 'nothing new is started for a page that is going away').not.toHaveBeenCalled();
+
+    restore();
+    expect(prefetch.isLeaving()).toBe(false);
+    await prefetch.warm('/after-restore.js');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+
+  it('picks the warm-up back up after a navigation that never happened', () => {
+    // beforeunload also fires for an external scheme, a download link, an
+    // unload the visitor cancels. They are still reading the page, so any sign
+    // of life has to undo the stop -- otherwise it is a one-way door and the
+    // editor they open next is cold for no reason.
+    window.dispatchEvent(new Event('beforeunload'));
+    expect(prefetch.isLeaving()).toBe(true);
+    window.dispatchEvent(new Event('pointerdown'));
+    expect(prefetch.isLeaving()).toBe(false);
+  });
+
+  it('exposes a core list the service worker serves cache-first', () => {
+    // Everything warmed has to be under a tree sw.js treats as vendor content,
+    // or the bytes land in the HTTP cache only and the second visit is not free.
+    for (const url of prefetch.CORE) expect(url).toMatch(/^\/(?:sdkjs|web-apps|fonts)\//);
+    expect(prefetch.ENGINES).toEqual(['docx', 'xlsx', 'pptx']);
+  });
+});

--- a/test/unit/pending-open-handoff.test.ts
+++ b/test/unit/pending-open-handoff.test.ts
@@ -1,0 +1,104 @@
+import 'fake-indexeddb/auto';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { stashPendingFile, takePendingFile } from '../../lib/pending-open';
+
+/**
+ * The landing-page handoff, both halves at once.
+ *
+ * public/open-local.js writes the record and lib/pending-open.ts reads it, and
+ * they are separate files by necessity: the static landing pages do not ship
+ * the app bundle. So the shape of what is stored is a contract between two
+ * files with nothing but a comment holding them together -- this drives the
+ * shipped writer and the shipped reader against one database and pins it.
+ *
+ * The invariant with teeth is that a refusal to store the File is survived.
+ * Safari will not structured-clone a File or a Blob into IndexedDB -- the put
+ * is accepted and the transaction then fails with a null error -- so the
+ * handoff was broken outright there: the landing page took its "IndexedDB
+ * unavailable" fallback and the visitor arrived at an empty editor, having
+ * just picked a document. The writer now falls back to the bytes.
+ *
+ * fake-indexeddb refuses a File in the same way, so every test below takes
+ * that fallback. The by-reference path is the one Chromium and Firefox take,
+ * and it is covered where it is real: entry-paths.spec.ts drives this same
+ * handoff through the shipped landing page on all three engines.
+ */
+type OpenLocal = {
+  stashFile: (file: File) => Promise<void>;
+  DB_NAME: string;
+  STORE: string;
+  KEY: string;
+};
+
+let openLocal: OpenLocal;
+
+beforeAll(() => {
+  const src = readFileSync(resolve(__dirname, '../../public/open-local.js'), 'utf8');
+  // The file is an IIFE over `window`; in jsdom that is this realm's global.
+  new Function(src).call(globalThis);
+  openLocal = (globalThis as unknown as { __openLocal: OpenLocal }).__openLocal;
+  expect(typeof openLocal?.stashFile).toBe('function');
+});
+
+/** Whatever is sitting under the handoff key right now, untouched. */
+const peek = (): Promise<unknown> =>
+  new Promise((done, fail) => {
+    const req = indexedDB.open(openLocal.DB_NAME, 1);
+    req.onupgradeneeded = () => req.result.createObjectStore(openLocal.STORE);
+    req.onerror = () => fail(req.error);
+    req.onsuccess = () => {
+      const db = req.result;
+      const get = db.transaction(openLocal.STORE, 'readonly').objectStore(openLocal.STORE).get(openLocal.KEY);
+      get.onsuccess = () => {
+        db.close();
+        done(get.result);
+      };
+      get.onerror = () => {
+        db.close();
+        fail(get.error);
+      };
+    };
+  });
+
+const sample = () =>
+  new File([new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x11])], '落地页交接.docx', {
+    type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    lastModified: 1_700_000_000_000,
+  });
+
+describe('landing page -> editor file handoff', () => {
+  it('the landing page writes what the app reads back, name and bytes intact', async () => {
+    await openLocal.stashFile(sample());
+
+    const taken = await takePendingFile();
+    expect(taken).toBeInstanceOf(File);
+    expect(taken!.name).toBe('落地页交接.docx');
+    expect(taken!.type).toBe('application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+    expect(taken!.lastModified).toBe(1_700_000_000_000);
+    expect([...new Uint8Array(await taken!.arrayBuffer())]).toEqual([0x50, 0x4b, 0x03, 0x04, 0x11]);
+  });
+
+  it('falls back to plain bytes when the engine will not store a File', async () => {
+    await openLocal.stashFile(sample());
+    const stored = await peek();
+    expect(stored).not.toBeInstanceOf(Blob);
+    expect(stored).toMatchObject({ name: '落地页交接.docx' });
+    await takePendingFile();
+  });
+
+  it('the app half stores the same shape when it does the stashing (the /history route)', async () => {
+    expect(await stashPendingFile(sample())).toBe(true);
+    const stored = await peek();
+    expect(stored).not.toBeInstanceOf(Blob);
+    const taken = await takePendingFile();
+    expect(taken!.name).toBe('落地页交接.docx');
+  });
+
+  it('is one-shot: a reload of `?open=local` finds nothing left', async () => {
+    await openLocal.stashFile(sample());
+    expect(await takePendingFile()).toBeInstanceOf(File);
+    expect(await takePendingFile()).toBeNull();
+  });
+});

--- a/test/unit/workflow-contract.test.ts
+++ b/test/unit/workflow-contract.test.ts
@@ -377,6 +377,35 @@ describe('.github/workflows/nightly-corpus.yml', () => {
     expect(readFileSync(resolve(ROOT, 'test/e2e/lib/l0.ts'), 'utf8')).toMatch(/projectName: \[/);
   });
 
+  it('keeps the cases that cannot share the run out of the parallel pass, and still runs them', () => {
+    // The same pairing ci.yml's e2e job has, for the same reason and with the
+    // same failure mode when either half goes missing. Here the case that
+    // needs it is sw-silent-update.spec.ts: it rewrites the served sw.js to
+    // stand in for a deploy, which replaces the worker under every other spec
+    // on the origin -- sw-warm read a vendor stamp that belonged to it, and
+    // the cache-first probe lost the entry it had just planted.
+    expect(src).toMatch(/--grep-invert "api surface\|corpus\|@serial"/);
+    expect(src).toMatch(/-c playwright\.browsers\.config\.ts --grep @serial --workers=1/);
+  });
+
+  it('runs each half of the night only when it has something to say', () => {
+    // `schedule` fires whether or not anything was committed, and the corpus
+    // is static: what varies is this repository. Both windows are decided in
+    // one cheap gate job so a quiet night still leaves a run explaining itself.
+    const jobs = parseJobs(src);
+    expect(jobs.map(({ name }) => name)).toContain('gate');
+    for (const name of ['browsers', 'budgets']) {
+      const job = jobs.find((candidate) => candidate.name === name);
+      expect(job, name).toBeDefined();
+      expect(job!.body, name).toMatch(/^ {4}if: needs\.gate\.outputs\.browsers == 'true'$/m);
+      expect(job!.body, name).toMatch(/^ {4}needs: gate$/m);
+    }
+    const corpus = jobs.find(({ name }) => name === 'corpus');
+    expect(corpus!.body).toMatch(/^ {4}if: needs\.gate\.outputs\.corpus == 'true'$/m);
+    // Manual runs always go through, whatever the clock says.
+    expect(src).toMatch(/MANUAL: \$\{\{ github\.event_name == 'workflow_dispatch' \}\}/);
+  });
+
   it('drops the corpus fuzzer output without dropping real bug-report files', () => {
     // Byte soup minimized by a fuzzer until it broke a parser: "this editor
     // will not open it either" is not a finding, and 15 such files were red on


### PR DESCRIPTION
The nightly cross-browser job ([run 32770230528](https://github.com/ranuts/document/actions/runs/32770230528)) had been red every morning for over a month with almost the same eleven cases each time. Not flakes — a stable backlog, and a **shipped Safari defect was sitting inside it**.

## What was actually broken in production

**Opening a file from the homepage does not work in Safari.** The static landing pages carry no app bundle, so the picked file is handed to the editor through IndexedDB. Safari will not structured-clone a `File` or a `Blob` into a store — it accepts the put and then fails the transaction with a *null* error. The handoff read that as "IndexedDB unavailable", dropped `open=local` from the URL, and the visitor arrived at an **empty editor**, having just chosen a document. Five of the eleven red cases were this one bug.

**Leaving the homepage logs uncaught errors in Safari.** The warm-up runs the whole time the page is read, so a multi-MB fetch is nearly always open when the visitor clicks — and a request the *browser* cancels at unload is reported as an error nothing can catch.

## What was wrong with the tests

| | |
|---|---|
| L0 blind on Firefox | `console.error(someError)` reaches the driver as the bare word `"Error"`; a spec's own `allowConsole` could not match the fault it had injected |
| L0 missing an allowlist entry | Firefox's wording for a cancelled request — Chromium's `net::ERR_` was already there |
| landing-prefetch | polled the Cache API every 100 ms and starved the worker's own `cache.put`: 7 of 8 for a full three minutes |
| save-to-file on WebKit | needs OPFS writable streams to stub its picker; WebKit has the handles, not the streams |
| embed-api ×3 | `page.goto('/?embed=1')` resolves before the redirect to `/editor` |
| sw-vendor-cache-first | died when `healStaleController()` did its job — a shipped feature working, reported as a failure |

## The nightly itself

Corpus matrix → Sundays (80 min against a corpus that never changes; what varies is this repo). Cross-browser stays nightly — it is our only WebKit/Firefox coverage. Neither runs when nothing was committed, decided in one cheap `gate` job that *does* run every night, so a quiet night still leaves a run explaining itself.

The cross-browser job also gains the `@serial` split `ci.yml` already had: `sw-silent-update.spec.ts` rewrites the served `dist/sw.js` to stand in for a deploy — visible to the whole origin — so beside others it replaced *their* worker mid-test. That was the last two flakes.

## Notable non-fixes

Three plausible explanations were tried and disproved, and the record is in the exploration doc:

- *"WebKit throws synchronously from `fetch()` during unload"* — no. It returns a promise and a handler **is** attached; the document dies before the microtask runs.
- *"Make `sw.js` not reject `respondWith`"* — no. Firefox prints the same line whether the worker answers from cache, with a synthetic 504, or with `Response.error()`.
- *"Store the bytes unconditionally"* — no. The editor opens the File with `createObjectURL` and never reads it; an unconditional read is a stall with no feedback between the file dialog and the navigation, and on a large file `arrayBuffer()` rejects into the very empty editor being fixed. The File goes in by reference, the write is **confirmed by reading it back**, and only a refusal costs the bytes.

## Verification

- unit **2713 pass**; Chromium E2E **151 pass**
- cross-browser: **11 failed / 4 flaky → green** on both engines, both passes
- every new case reverse-verified (remove the fix, watch it go red)

Record: `docs/explorations/2026-08-25-cross-browser-nightly-red.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)