### PR TITLE
fix(i18n): the zh-CN hero CTAs render as four blank pills

### DIFF
--- a/content/zh-CN/home.json
+++ b/content/zh-CN/home.json
@@ -9,10 +9,10 @@
   },
   "sub": "没装 Office？任何 DOCX、XLSX、PPTX 文件即开即看，需要时随手编辑——全部在你的设备本地运行，免注册、可离线。",
   "cta": {
-    "open": "",
-    "docx": "",
-    "xlsx": "",
-    "pptx": ""
+    "open": "打开文件",
+    "docx": "新建 Word",
+    "xlsx": "新建 Excel",
+    "pptx": "新建 PPT"
   },
   "recent": {
     "label": "继续编辑",

--- a/docs/explorations/2026-08-27-zh-home-cta-blank-buttons.md
+++ b/docs/explorations/2026-08-27-zh-home-cta-blank-buttons.md
@@ -1,0 +1,39 @@
+# 中文首页四个 CTA 按钮是空白药丸（2026-08-27）
+
+## 现象
+
+`/zh-CN/` 的 hero 区，"打开文件 / 新建 Word / 新建 Excel / 新建 PPT" 四个按钮渲染成
+四个没有文字的圆角块——按钮本身、布局、点击行为都在，只是没有标签。英文首页正常。
+
+## 根因
+
+`73b460b`（refactor(landing): generate the homepages from data too）把两张手写首页
+改成由 `content/<locale>/home.json` 驱动，迁移 zh-CN 时 `cta` 四个键留成了空串：
+
+```json
+"cta": { "open": "", "docx": "", "xlsx": "", "pptx": "" }
+```
+
+而 `render-home.mjs` 忠实地把空串写进 `<r-button>`，于是按钮有壳无字。
+迁移前那版 `public/zh-CN/index.html` 里写的是"打开文件 / 新建 Word / 新建 Excel /
+新建 PPT"，现已按原文填回。
+
+七种语言里只有 zh-CN 有空串（脚本全量扫过），所以这是一次性的迁移遗漏，不是机制问题。
+
+## 为什么没有测试拦住
+
+`test/unit/landing-pages.test.ts` 钉的是 canonical / hreflang / JSON-LD / sitemap /
+双语互指这些**结构**契约。空串在这些维度上完全合法：键在、页面在、链接在，只是没有
+文字。渲染出的 HTML 也仍然是合法的 `<r-button></r-button>`。
+
+## 补的用例
+
+同一个文件末尾加 `homepage content data` 两条：
+
+1. **每个 locale 的 home.json 不得有空串**（递归到每个叶子，报出路径如 `cta.docx`）。
+   反向验证：把四个 cta 值改回空串，这条立刻红；改回来即绿。
+2. **每个 locale 的槽位集合必须与 en 相同**（数组下标折叠成 `[]`）——键少了就是少一
+   个位置。下标必须折叠：`foot.links` 是按"该语言真正存在哪些页面"列的，ONLYOFFICE
+   那页只有 en 和 zh-CN 有，ja/de/es/ko/pt 就少一条，那是对的。
+
+第 1 条管"有键没内容"，第 2 条管"没有键"，两种都会在页面上表现为缺一块东西。

--- a/test/unit/landing-pages.test.ts
+++ b/test/unit/landing-pages.test.ts
@@ -469,3 +469,45 @@ describe('r-button radius overrides', () => {
     }
   });
 });
+
+/**
+ * The homepages are rendered from content/<locale>/home.json. A key that is
+ * present but empty renders as an element with no text -- the zh-CN hero
+ * shipped four blank pills where its CTA buttons should have been, because
+ * the move to data-driven homepages left content/zh-CN/home.json's `cta`
+ * strings empty and nothing read them back. Both halves matter: the shape
+ * has to match en (a missing key is a missing slot) and every string has to
+ * carry text (a present key is not a translated one).
+ */
+describe('homepage content data', () => {
+  const home = (locale: string) =>
+    JSON.parse(readFileSync(resolve(ROOT, 'content', locale, 'home.json'), 'utf8')) as unknown;
+
+  /** Every leaf string's path, e.g. 'cta.docx' or 'trust[3]'. */
+  const leaves = (value: unknown, path = ''): Array<{ path: string; text: string }> => {
+    if (typeof value === 'string') return [{ path, text: value }];
+    if (Array.isArray(value)) return value.flatMap((v, i) => leaves(v, `${path}[${i}]`));
+    if (value && typeof value === 'object')
+      return Object.entries(value).flatMap(([k, v]) => leaves(v, path ? `${path}.${k}` : k));
+    return [];
+  };
+
+  const locales = Object.keys(LOCALES);
+
+  it.each(locales)('%s/home.json has no blank strings', (locale) => {
+    const blank = leaves(home(locale))
+      .filter(({ text }) => !text.trim())
+      .map(({ path }) => path);
+    expect(blank, `${locale}/home.json`).toEqual([]);
+  });
+
+  /**
+   * Array indices are collapsed, because the lists are genuinely per-locale:
+   * the footer links to the pages that exist in that language, so ja has one
+   * fewer than en. What may not differ is the set of named slots.
+   */
+  it.each(locales.filter((l) => l !== 'en'))('%s/home.json has the same slots as en', (locale) => {
+    const slots = (value: unknown) => [...new Set(leaves(value).map((l) => l.path.replace(/\[\d+\]/g, '[]')))];
+    expect(slots(home(locale))).toEqual(slots(home('en')));
+  });
+});


### PR DESCRIPTION
The move to data-driven homepages (73b460b) left content/zh-CN/home.json's
cta strings empty, and render-home.mjs faithfully wrote empty strings into
the four <r-button> elements: shells with no label. Restore the labels the
hand-written page carried before the migration.

Nothing caught it because the landing-page contract checks structure
(canonical, hreflang, JSON-LD, sitemap, bilingual pairing) and an empty
string is structurally valid. Add two data checks: no home.json string may
be blank in any locale, and every locale must carry the same named slots as
en (array indices collapsed -- the footer genuinely links to the pages that
exist in that language). Reverse-verified: re-emptying the cta values turns
the first one red.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
