### PR TITLE
fix(i18n): /history tells a Chinese reader they are on the English site

### DIFF
--- a/docs/explorations/2026-08-27-history-page-chrome-stuck-in-english.md
+++ b/docs/explorations/2026-08-27-history-page-chrome-stuck-in-english.md
@@ -1,0 +1,38 @@
+# /history 的顶栏与标签页标题卡在英文（2026-08-27）
+
+## 现象
+
+`/history?locale=zh-CN`：正文全中文（标题"本机保存的文档"、按钮、保留规则），
+而**语言切换器写着 English**、**浏览器标签写着 Local history**。
+`<html lang>` 已经是 `zh-CN`。等于一边用中文读，一边被告知自己在英文站上。
+七种语言都一样，只是英文看不出来。
+
+## 根因
+
+`/history` 是手写页（`history.html`，应用页，不进 sitemap、不由 `bin/build-pages.mjs`
+生成），它的 `<title>` 与 `<span class="lang-current">English</span>` 是写死的英文字面量；
+`lib/history-page.ts` 在运行时把**正文**换成当前语言，但从来没管这两处。
+落地页没有这个问题——它们的当前语言是生成时写进 HTML 的。
+
+CLAUDE.md 里已经记着同一类事故：`/history` 与 `/404` 的语言菜单曾经长期只列 en 和 zh，
+因为它们是手写的。这次是同一个成因的另一面。
+
+## 修法
+
+`syncPageChrome()`（`lib/history-page.ts`，紧跟 `applyDocumentLanguage()`）：
+
+- `document.title = t('historyTitle')`，与页面 h1 用同一个词条；
+- 按 `<html lang>` 找到对应的 `<a class="lang-option" lang>`，把它的文字复制到
+  `.lang-current`，并把 `is-current` / `aria-current="page"` 移到它身上。
+
+**自称标签不另建一张表**：七种语言的自称已经在 DOM 里（每个 lang-option 一个），
+再写一份就又多了一处要跟 `bin/pages/locales.mjs` 对齐的地方。
+
+## 用例
+
+`test/e2e/history-page.spec.ts` 加一条 `the chrome follows the language, not just the body`：
+`?locale=zh-CN` 下断言 `<html lang>`、`.lang-current`、`aria-current` 的那一项都是"中文"，
+且 `document.title` 等于页面 h1 的文字。
+
+反向验证：撤掉 `syncPageChrome()`，该用例报 `Expected "中文" / Received "English"`；
+恢复后 16 条全绿。

--- a/lib/history-page.ts
+++ b/lib/history-page.ts
@@ -463,6 +463,33 @@ async function render(): Promise<void> {
   root().replaceChildren(pageEl);
 }
 
+/**
+ * The chrome around this page is hand-written (history.html), so its <title>
+ * and the language switch's current entry ship as English literals while the
+ * body is translated at runtime -- a Chinese reader got a Chinese page whose
+ * switch still read "English" and whose tab still read "Local history".
+ *
+ * The endonyms are already in the DOM, one per <a class="lang-option" lang>,
+ * so the current entry is copied from the link that matches <html lang>
+ * rather than from a second table that would have to be kept in step with
+ * bin/pages/locales.mjs.
+ */
+function syncPageChrome(): void {
+  document.title = t('historyTitle');
+  const lang = document.documentElement.getAttribute('lang');
+  const options = [...document.querySelectorAll<HTMLAnchorElement>('a.lang-option')];
+  const current = options.find((option) => option.getAttribute('lang') === lang);
+  if (!current) return;
+  for (const option of options) {
+    option.classList.toggle('is-current', option === current);
+    if (option === current) option.setAttribute('aria-current', 'page');
+    else option.removeAttribute('aria-current');
+  }
+  const label = document.querySelector('.lang-current');
+  if (label) label.textContent = current.textContent?.trim() ?? '';
+}
+
 applyDocumentLanguage();
+syncPageChrome();
 readUrl();
 void render();

--- a/test/e2e/history-page.spec.ts
+++ b/test/e2e/history-page.spec.ts
@@ -317,6 +317,31 @@ test.describe('local history page', () => {
     expect((await chooser).isMultiple()).toBe(false);
   });
 
+  /**
+   * The page's own chrome is hand-written in history.html, so the tab title and
+   * the language switch's current entry are English literals that the runtime
+   * has to correct. It did not: /history?locale=zh-CN rendered a Chinese page
+   * whose switch still read "English" and whose tab still read "Local history"
+   * -- the reader is told they are on the English site while reading Chinese.
+   */
+  test('the chrome follows the language, not just the body', async ({ page }) => {
+    await page.goto('/history?locale=zh-CN');
+    await expect(page.locator('#history-empty')).toBeVisible();
+
+    const chrome = await page.evaluate(() => ({
+      title: document.title,
+      lang: document.documentElement.getAttribute('lang'),
+      current: document.querySelector('.lang-current')?.textContent?.trim(),
+      marked: [...document.querySelectorAll('a.lang-option[aria-current="page"]')].map((a) => a.textContent?.trim()),
+    }));
+
+    expect(chrome.lang).toBe('zh-CN');
+    expect(chrome.current).toBe('\u4e2d\u6587');
+    expect(chrome.marked).toEqual(['\u4e2d\u6587']);
+    // The heading is translated already; the tab has to say the same thing.
+    expect(chrome.title).toBe(await page.locator('.history-title').first().innerText());
+  });
+
   test('opens a stored document back in the editor', async ({ page }) => {
     await seed(page, [{ id: 'reopen-me', title: 'Reopen.docx' }]);
     await page.reload();


### PR DESCRIPTION
The page's chrome is hand-written in history.html -- a <title> and a
<span class="lang-current"> that ship as English literals -- while
history-page.ts translates only the body at runtime. So /history?locale=zh-CN
rendered Chinese copy under a switch that read "English", in a tab that read
"Local history", with <html lang="zh-CN">. Every non-English locale had it.

syncPageChrome() sets the title from the same historyTitle entry the h1 uses,
and moves is-current/aria-current onto the option matching <html lang>,
copying that link's endonym into .lang-current. The endonyms are already in
the DOM, so this adds no second table to keep in step with
bin/pages/locales.mjs.

Reverse-verified: without syncPageChrome the new test reports
Expected "中文" / Received "English".

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
